### PR TITLE
Fix Tags link to point to the correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ match the project's coding conventions (see `doc/coding.txt`) or are
 controversial.
 
 The `master` branch is regularly built and tested, but is not guaranteed to be
-completely stable. [Tags](https://github.com/bitcoin/bitcoin/tags) are created
+completely stable. [Tags](https://github.com/darkcoinproject/darkcoin/tags) are created
 regularly to indicate new official, stable release versions of DarkCoin.
 
 Testing


### PR DESCRIPTION
The "mailing list" link is also wrong, but I don't know what the correct version would be
