### PR TITLE
Qt: Fix monospace font in osx 10.9

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -61,7 +61,11 @@ QString dateTimeStr(qint64 nTime)
 QFont bitcoinAddressFont()
 {
     QFont font("Monospace");
+#if QT_VERSION >= 0x040800
+    font.setStyleHint(QFont::Monospace);
+#else
     font.setStyleHint(QFont::TypeWriter);
+#endif
     return font;
 }
 


### PR DESCRIPTION
The "Monospace" hint was added in Qt 4.8, and it works as intended as opposed
to "TypeWriter" which fails to load a font.
