### PR TITLE
fix dseg logging

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -265,6 +265,7 @@ void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream
             } else if (vin == mn.vin) {
                 LogPrintf("dseg - Sending masternode entry - %s \n", mn.addr.ToString().c_str());
                 pfrom->PushMessage("dsee", mn.vin, mn.addr, mn.sig, mn.now, mn.pubkey, mn.pubkey2, count, i, mn.lastTimeSeen);
+                return;
             }
             i++;
         }


### PR DESCRIPTION
Looks like dseg logging was actually "broken" - it was printing message for every masternode in the list even when dseg was sent for one only.
Also moved logging of "give me all" request mostly to debug level (will print only single-line overview in production now).
