### PR TITLE
On client shutdown write directly into "peers.dat"...

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -494,26 +494,18 @@ CAddrDB::CAddrDB()
 bool CAddrDB::Write(const CAddrMan& addr)
 {
     unsigned char pchMessageStart[4] = { 0xfb, 0xc0, 0xb6, 0xdb };
-
-    // Generate random temporary filename
-    unsigned short randv = 0;
-    RAND_bytes((unsigned char *)&randv, sizeof(randv));
-    std::string tmpfn = strprintf("peers.dat.%04x", randv);
-
     // serialize addresses, checksum data up to that point, then append csum
     CDataStream ssPeers(SER_DISK, CLIENT_VERSION);
     ssPeers << FLATDATA(pchMessageStart);
     ssPeers << addr;
     uint256 hash = Hash(ssPeers.begin(), ssPeers.end());
     ssPeers << hash;
-
-    // open temp output file, and associate with CAutoFile
-    boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
-    FILE *file = fopen(pathTmp.string().c_str(), "wb");
+    // open output file, and associate with CAutoFile
+    boost::filesystem::path pathAddr = GetDataDir() / "peers.dat";
+    FILE *file = fopen(pathAddr.string().c_str(), "wb");
     CAutoFile fileout = CAutoFile(file, SER_DISK, CLIENT_VERSION);
     if (!fileout)
         return error("CAddrman::Write() : open failed");
-
     // Write and commit header, data
     try {
         fileout << ssPeers;
@@ -523,11 +515,6 @@ bool CAddrDB::Write(const CAddrMan& addr)
     }
     FileCommit(fileout);
     fileout.fclose();
-
-    // replace existing peers.dat, if any, with new peers.dat.XXXX
-    if (!RenameOver(pathTmp, pathAddr))
-        return error("CAddrman::Write() : Rename-into-place failed");
-
     return true;
 }
 


### PR DESCRIPTION
...and not into a temporary file which gets renamed to "peers.dat" later.
This prevents softlinks from being replaced by a "real" file, see http://jira.darkcoin.qa/browse/DRK-122

Change was already merged (see https://github.com/darkcoin/darkcoin/pull/57), but got somehow lost because of a forced update by Evan.

Please merge again.
