### PR TITLE
Missleading progress-bar message

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -644,7 +644,7 @@ void BitcoinGUI::setNumBlocks(int count)
             break;
         case BLOCK_SOURCE_NONE:
             // Case: not Importing, not Reindexing and no network connection
-            progressBarLabel->setText(tr("No block source available..."));
+            progressBarLabel->setText(tr("No local block source available, synchronizing with network..."));
             break;
     }
 


### PR DESCRIPTION
When sync is stuck I notice more and more user asking if "No block source available..." is the reason for this and whether their network setup is broken.

The changed message should make clear that there is no LOCAL source available and that the wallet is still trying to synchronize via network.
