### PR TITLE
Fix status update (darksend mixing stuck)

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1187,6 +1187,7 @@ bool CDarkSendPool::StatusUpdate(int newState, int newEntriesCount, int newAccep
         } else if (newAccepted == 0 && sessionID == 0 && !sessionFoundMasternode) {
             LogPrintf("CDarkSendPool::StatusUpdate - entry not accepted by masternode \n");
             UnlockCoins();
+            UpdateState(POOL_STATUS_ACCEPTING_ENTRIES);
             DoAutomaticDenominating(); //try another masternode
         }
         if(sessionFoundMasternode) return true;


### PR DESCRIPTION
Fix darksend mixing stuck on newAccepted == 0 and newStatus == POOL_STATUS_ACCEPTING_ENTRIES - without UpdateState DoAuto... will never pass second if there https://github.com/darkcoin/darkcoin/blob/master/src/darksend.cpp#L1395
`if(state == POOL_STATUS_ERROR || state == POOL_STATUS_SUCCESS) return false;`
because of previously changed state here https://github.com/darkcoin/darkcoin/blob/master/src/darksend.cpp#L1169-L1172

```
        if(newAccepted == 0){
            UpdateState(POOL_STATUS_ERROR);
            lastMessage = error;
        }
```
