### PR TITLE
make masternode.conf loading more strict

### DIFF
--- a/src/darkcoind.cpp
+++ b/src/darkcoind.cpp
@@ -80,7 +80,11 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
 
-        masternodeConfig.read(GetMasternodeConfigFile());
+        std::string strErr;
+        if(!masternodeConfig.read(GetMasternodeConfigFile(), strErr)) {
+            fprintf(stderr,"Error reading masternode configuration file: %s\n", strErr.c_str());
+            return false;
+        }
 
         // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
         if (!SelectParamsFromCommandLine()) {

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -4,29 +4,31 @@
 CMasternodeConfig masternodeConfig;
 
 void CMasternodeConfig::add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex) {
-	CMasternodeEntry cme(alias, ip, privKey, txHash, outputIndex);
-	entries.push_back(cme);
+    CMasternodeEntry cme(alias, ip, privKey, txHash, outputIndex);
+    entries.push_back(cme);
 }
 
-void CMasternodeConfig::read(boost::filesystem::path path) {
-	boost::filesystem::ifstream streamConfig(GetMasternodeConfigFile());
-	if (!streamConfig.good()) {
-		return; // No masternode.conf file is OK
-	}
+bool CMasternodeConfig::read(boost::filesystem::path path, std::string& strErr) {
+    boost::filesystem::ifstream streamConfig(GetMasternodeConfigFile());
+    if (!streamConfig.good()) {
+        return true; // No masternode.conf file is OK
+    }
 
-	for(std::string line; std::getline(streamConfig, line); )
-	{
-		if(line.empty()) {
-			continue;
-		}
-		std::istringstream iss(line);
+    for(std::string line; std::getline(streamConfig, line); )
+    {
+        if(line.empty()) {
+            continue;
+        }
+        std::istringstream iss(line);
         std::string alias, ip, privKey, txHash, outputIndex;
         if (!(iss >> alias >> ip >> privKey >> txHash >> outputIndex)) {
-        	LogPrintf("CMasternodeConfig::read - Could not parse masternode.conf. Line: %s\n", line.c_str());
-        	continue;
+            strErr = "Could not parse masternode.conf line: " + line;
+            streamConfig.close();
+            return false;
         }
         add(alias, ip, privKey, txHash, outputIndex);
-	}
+    }
 
-	streamConfig.close();
+    streamConfig.close();
+    return true;
 }

--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -84,7 +84,7 @@ public:
 	}
 
 	void clear();
-	void read(boost::filesystem::path path);
+    bool read(boost::filesystem::path path, std::string& strErr);
 	void add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
 
 	std::vector<CMasternodeEntry>& getEntries() {

--- a/src/qt/darkcoin.cpp
+++ b/src/qt/darkcoin.cpp
@@ -534,7 +534,12 @@ int main(int argc, char *argv[])
         return false;
     }
 
-    masternodeConfig.read(GetMasternodeConfigFile());
+    string strErr;
+    if(!masternodeConfig.read(GetMasternodeConfigFile(), strErr)) {
+        QMessageBox::critical(0, QObject::tr("Darkcoin"),
+                              QObject::tr("Error reading masternode configuration file: %1").arg(strErr.c_str()));
+        return false;
+    }
 
     /// 7. Determine network (and switch to network specific options)
     // - Do not call Params() before this step


### PR DESCRIPTION
- do not continue wallet start if masternode.conf has incorrect format
- move error message out of debug.log to stderr/qt-dialog
- tab/spaces clean up in masternodeconfig.cpp (h needs it too maybe?)
