### PR TITLE
Disable RFC1918 local addresses again

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -59,7 +59,7 @@ void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream
             return;
         }
 
-        bool isLocal = false; // addr.IsRFC1918();
+        bool isLocal = addr.IsRFC1918();
         std::string vchPubKey(pubkey.begin(), pubkey.end());
         std::string vchPubKey2(pubkey2.begin(), pubkey2.end());
 


### PR DESCRIPTION
There are private addresses in the Masternode list which should not happen.
