### PR TITLE
"path" argument isn't used in masternode conf read function

### DIFF
--- a/src/darkcoind.cpp
+++ b/src/darkcoind.cpp
@@ -81,7 +81,7 @@ bool AppInit(int argc, char* argv[])
         }
 
         std::string strErr;
-        if(!masternodeConfig.read(GetMasternodeConfigFile(), strErr)) {
+        if(!masternodeConfig.read(strErr)) {
             fprintf(stderr,"Error reading masternode configuration file: %s\n", strErr.c_str());
             return false;
         }

--- a/src/masternodeconfig.cpp
+++ b/src/masternodeconfig.cpp
@@ -8,7 +8,7 @@ void CMasternodeConfig::add(std::string alias, std::string ip, std::string privK
     entries.push_back(cme);
 }
 
-bool CMasternodeConfig::read(boost::filesystem::path path, std::string& strErr) {
+bool CMasternodeConfig::read(std::string& strErr) {
     boost::filesystem::ifstream streamConfig(GetMasternodeConfigFile());
     if (!streamConfig.good()) {
         return true; // No masternode.conf file is OK

--- a/src/masternodeconfig.h
+++ b/src/masternodeconfig.h
@@ -84,7 +84,7 @@ public:
 	}
 
 	void clear();
-    bool read(boost::filesystem::path path, std::string& strErr);
+    bool read(std::string& strErr);
 	void add(std::string alias, std::string ip, std::string privKey, std::string txHash, std::string outputIndex);
 
 	std::vector<CMasternodeEntry>& getEntries() {

--- a/src/qt/darkcoin.cpp
+++ b/src/qt/darkcoin.cpp
@@ -535,7 +535,7 @@ int main(int argc, char *argv[])
     }
 
     string strErr;
-    if(!masternodeConfig.read(GetMasternodeConfigFile(), strErr)) {
+    if(!masternodeConfig.read(strErr)) {
         QMessageBox::critical(0, QObject::tr("Darkcoin"),
                               QObject::tr("Error reading masternode configuration file: %1").arg(strErr.c_str()));
         return false;


### PR DESCRIPTION
One of possible solutions (which is implemented in this pr) is to get read of unused argument and simplify function call. Another one is to start using "path" argument at line 12 instead of "GetMasternodeConfigFile()" https://github.com/UdjinM6/darkcoin/blob/560b06fc3896d1f291fe8022cc3d45bdac3d49ef/src/masternodeconfig.cpp#L12