### PR TITLE
fix dseg messaging / banning issues

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2228,8 +2228,8 @@ void ThreadCheckDarkSendPool()
             CleanTransactionLocksList();
         }
 
-        //try to sync the masternode list and payment list every 20 seconds
-        if(c % 5 == 0 && RequestedMasterNodeList <= 2){
+        //try to sync the masternode list and payment list every 5 seconds from at least 3 nodes
+        if(c % 5 == 0 && (RequestedMasterNodeList <= 2 || vecMasternodes.size() == 0)){
             bool fIsInitialDownload = IsInitialBlockDownload();
             if(!fIsInitialDownload) {
                 LOCK(cs_vNodes);

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -273,7 +273,7 @@ void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream
                 {
                     int64_t t = (*i).second;
                     if (GetTime() < t) {
-                        Misbehaving(pfrom->GetId(), 100);
+                        Misbehaving(pfrom->GetId(), 20);
                         LogPrintf("dseg - peer already asked me for the list\n");
                         return;
                     }
@@ -284,7 +284,7 @@ void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream
             }
         } //else, asking for a specific node which is ok
 
-        int count = vecMasternodes.size()-1;
+        int count = vecMasternodes.size();
         int i = 0;
 
         BOOST_FOREACH(CMasterNode mn, vecMasternodes) {


### PR DESCRIPTION
This should fix:
- banning issues that prevented upgrades sometimes.
- slow MN list syncing (banning was also the reason clients didn't get the full list)
- incorrect MN count in dseg replies (dsee messages)