### PR TITLE
allow masternode commands execution while client is in safemode

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -271,7 +271,7 @@ static const CRPCCommand vRPCCommands[] =
 
     /* Darkcoin features */
     { "darksend",               &darksend,               false,     false,      true },
-    { "masternode",             &masternode,             false,     false,      true },
+    { "masternode",             &masternode,             true,      false,      true },
 
 #ifdef ENABLE_WALLET
     /* Wallet */


### PR DESCRIPTION
As no funds sending operations are involved in these actions I guess it's safe enough to let users execute "masternode ..." commands even while network is unstable/forking (i.e. safemode)