### PR TITLE
fixing pre-mix process of creation denominated amounts

### DIFF
--- a/src/darksend.h
+++ b/src/darksend.h
@@ -259,8 +259,6 @@ public:
     int64_t sessionTotalValue; //used for autoDenom
     std::vector<CTransaction> vecSessionCollateral;
 
-    int lastSplitUpBlock;
-    int splitUpInARow; // how many splits we've done since a success?
     int cachedLastSuccess;
     int cachedNumBlocks; //used for the overview screen
     int minBlockSpacing; //required blocks between mixes
@@ -277,11 +275,9 @@ public:
         /* DarkSend uses collateral addresses to trust parties entering the pool
             to behave themselves. If they don't it takes their money. */
 
-        lastSplitUpBlock = 0;
         cachedLastSuccess = 0;
         cachedNumBlocks = 0;
         unitTest = false;
-        splitUpInARow = 0;
         txCollateral = CTransaction();
         minBlockSpacing = 1;
         nDsqCount = 0;
@@ -420,7 +416,7 @@ public:
     // used for liquidity providers
     bool SendRandomPaymentToSelf();
     // split up large inputs or make fee sized inputs
-    bool SplitUpMoney(bool justCollateral=false);
+    bool MakeCollateralAmounts();
     bool CreateDenominated(int64_t nTotalValue);
     // get the denominations for a list of outputs (returns a bitshifted integer)
     int GetDenominations(const std::vector<CTxOut>& vout);

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1237,12 +1237,12 @@ void CWallet::AvailableCoins(vector<COutput>& vCoins, bool fOnlyConfirmed, const
                    CTxIn vin = CTxIn(out.tx->GetHash(), out.i);
                    int rounds = GetInputDarksendRounds(vin);
                    if(rounds >= 0) found = true;
-                } else if(coin_type == ONLY_NONDENOMINATED || coin_type == ONLY_NONDENOMINATED_MN) {
+                } else if(coin_type == ONLY_NONDENOMINATED || coin_type == ONLY_NONDENOMINATED_NOTMN) {
                     found = true;
                     BOOST_FOREACH(int64_t d, darkSendDenominations)
                         if(pcoin->vout[i].nValue == d)
                             found = false;
-                    if(coin_type == ONLY_NONDENOMINATED_MN) found = found && (pcoin->vout[i].nValue != 1000*COIN);
+                    if(coin_type == ONLY_NONDENOMINATED_NOTMN) found = found && (pcoin->vout[i].nValue != 1000*COIN);
                 } else {
                     found = true;
                 }
@@ -1590,7 +1590,7 @@ bool CWallet::SelectCoinsDark(int64_t nValueMin, int64_t nValueMax, std::vector<
     nValueRet = 0;
 
     vector<COutput> vCoins;
-    AvailableCoins(vCoins, false, coinControl, nDarksendRoundsMin < 0 ? ONLY_NONDENOMINATED : ONLY_DENOMINATED);
+    AvailableCoins(vCoins, false, coinControl, nDarksendRoundsMin < 0 ? ONLY_NONDENOMINATED_NOTMN : ONLY_DENOMINATED);
 
     set<pair<const CWalletTx*,unsigned int> > setCoinsRet2;
 
@@ -1849,7 +1849,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                         strFailReason = _("Insufficient funds");
                     else if (coin_type == ONLY_NONDENOMINATED)
                         strFailReason = _("Unable to locate enough Darksend non-denominated funds for this transaction");
-                    else if (coin_type == ONLY_NONDENOMINATED_MN)
+                    else if (coin_type == ONLY_NONDENOMINATED_NOTMN)
                         strFailReason = _("Unable to locate enough Darksend non-denominated funds for this transaction that are not equal 1000 DRK");
                     else
                         strFailReason = _("Unable to locate enough Darksend denominated funds for this transaction");

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -137,7 +137,8 @@ public:
     bool SelectCoinsByDenominations(int nDenom, int64_t nValueMin, int64_t nValueMax, std::vector<CTxIn>& setCoinsRet, vector<COutput>& vCoins, int64_t& nValueRet, int nDarksendRoundsMin, int nDarksendRoundsMax);
     bool SelectCoinsDarkDenominated(int64_t nTargetValue, std::vector<CTxIn>& setCoinsRet, int64_t& nValueRet) const;
     bool SelectCoinsMasternode(CTxIn& vin, int64_t& nValueRet, CScript& pubScript) const;
-    bool HasDarksendFeeInputs() const;
+    bool HasCollateralInputs() const;
+    bool IsCollateralAmount(int64_t nInputAmount) const;
     int  CountInputsWithAmount(int64_t nInputAmount);
 
     bool SelectCoinsCollateral(std::vector<CTxIn>& setCoinsRet, int64_t& nValueRet) const ;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -56,7 +56,7 @@ enum AvailableCoinsType
     ALL_COINS = 1,
     ONLY_DENOMINATED = 2,
     ONLY_NONDENOMINATED = 3,
-    ONLY_NONDENOMINATED_MN = 4 // ONLY_NONDENOMINATED and not 1000 DRK at the same time
+    ONLY_NONDENOMINATED_NOTMN = 4 // ONLY_NONDENOMINATED and not 1000 DRK at the same time
 };
 
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -55,7 +55,8 @@ enum AvailableCoinsType
 {
     ALL_COINS = 1,
     ONLY_DENOMINATED = 2,
-    ONLY_NONDENOMINATED = 3
+    ONLY_NONDENOMINATED = 3,
+    ONLY_NONDENOMINATED_MN = 4 // ONLY_NONDENOMINATED and not 1000 DRK at the same time
 };
 
 


### PR DESCRIPTION
Fixes:
- leave at least nLowestDenom DRK non-denominated at the end (this should help to prevent "broken" DS mixing txes)
- prevent masternode-like vins (exactly 1000 DRK) to me denominated
- message when we run out of compatible inputs to keep denominating funds should be more explicit now
- demand at least 2 DS fee inputs to be available in wallet