### PR TITLE
fix updateDarksendProgress / add isDenominatedAmount and GetNormalizedAnonymizedBalance - v0.11.1.x

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -279,6 +279,7 @@ public:
     int64_t GetImmatureBalance() const;
     int64_t GetAnonymizedBalance() const;
     double GetAverageAnonymizedRounds() const;
+    int64_t GetNormalizedAnonymizedBalance() const;
     int64_t GetDenominatedBalance(bool onlyDenom=true, bool onlyUnconfirmed=false) const;
 
     bool CreateTransaction(const std::vector<std::pair<CScript, int64_t> >& vecSend,
@@ -324,6 +325,8 @@ public:
         }
         return ret;
     }
+
+    bool IsDenominatedAmount(int64_t nInputAmount) const;
 
     bool IsMine(const CTxIn& txin) const;
     int64_t GetDebit(const CTxIn& txin) const;


### PR DESCRIPTION
Calculate progress out of two parts:
- mixing progress of denominated balance
- % of fully anonymized balance

and apply some weights to them to calculate the whole progress (80/20 seems to be pretty smooth for me)

New functions: 
- IsDenominatedAmount - if an amount equal to one of the denoms
- GetNormalizedAnonymizedBalance - calculates 'normalized' anonymized balance by multiplying each amount (output nValue) by "rounds / nDarksendRounds". It's used to calculate mixing progress of denominated balance (part of whole ds progress).