### PR TITLE
prevent running DoAutomaticDenominating while IsInitialBlockDownload

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1416,6 +1416,8 @@ bool CDarkSendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
 {
     LOCK(cs_darksend);
 
+    if(IsInitialBlockDownload()) return false;
+
     if(fMasterNode) return false;
     if(state == POOL_STATUS_ERROR || state == POOL_STATUS_SUCCESS) return false;
 


### PR DESCRIPTION
client stuck during blockchain syncing when it enters DoAutomaticDenominating function, this should solve it