### PR TITLE
"Last Darksend message" text added in overview page

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -359,6 +359,8 @@ void OverviewPage::darkSendStatus()
     int accepted = darkSendPool.GetLastEntryAccepted();
 
     std::ostringstream convert;
+    
+    convert << "Last Darksend message:\n";
 
     if(state == POOL_STATUS_ACCEPTING_ENTRIES) {
         if(entries == 0) {


### PR DESCRIPTION
Gives the end-user a better understanding on the information displayed there.
![last_darksend_message](https://cloud.githubusercontent.com/assets/10080039/6029137/d23a57b6-abee-11e4-812c-d5bf2d6eda85.jpg)
