### PR TITLE
"Debug window" -> "Tools window" renaming

### DIFF
--- a/src/qt/forms/rpcconsole.ui
+++ b/src/qt/forms/rpcconsole.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Debug window</string>
+   <string>Tools window</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>


### PR DESCRIPTION
It's not a debug-only window any more
Someone (vertoe :-) ) has to add/replace this string in the locale files.

![tools_window](https://cloud.githubusercontent.com/assets/10080039/6029286/d365edde-abef-11e4-9afa-26637a4310a5.jpg)
