### PR TITLE
clear vValue in SelectCoinsMinConf - should fix an issue with conflicted txes

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1344,8 +1344,7 @@ bool CWallet::SelectCoinsMinConf(int64_t nTargetValue, int nConfMine, int nConfT
     for (unsigned int tryDenom = 0; tryDenom < 2; tryDenom++)
     {
         if (fDebug) LogPrint("selectcoins", "tryDenom: %d\n", tryDenom);
-        setCoinsRet.clear();
-        nValueRet = 0;
+        vValue.clear();
         nTotalLower = 0;
 
         BOOST_FOREACH(COutput output, vCoins)


### PR DESCRIPTION
It was a bug introduced by one of my previous commits https://github.com/UdjinM6/darkcoin/commit/f77b2d5943bc55b8e72b10c80a3a1c4759d69936#diff-d7618bdc04db23aa74d6a5a4198c58fdR1291 :(