### PR TITLE
fix checkbox mess on mac / get rid of line in sendcoinsdialog

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -173,7 +173,16 @@
            <string notr="true"/>
           </property>
           <layout class="QHBoxLayout" name="horizontalLayoutCoinControl5">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -604,12 +613,21 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>830</width>
-        <height>149</height>
+        <width>824</width>
+        <height>138</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -723,20 +741,13 @@
         <number>3</number>
        </property>
        <item>
-        <widget class="Line" name="line">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="checkUseDarksend">
+         <property name="minimumSize">
+          <size>
+           <width>95</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="text">
           <string>Darksend</string>
          </property>
@@ -749,6 +760,12 @@
         <widget class="QCheckBox" name="checkInstantX">
          <property name="enabled">
           <bool>true</bool>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>85</width>
+           <height>0</height>
+          </size>
          </property>
          <property name="text">
           <string>InstantX</string>


### PR DESCRIPTION
It was really ugly on mac
![screen shot 2015-02-05 at 18 41 51](https://cloud.githubusercontent.com/assets/1935069/6074584/d1de9e9a-add2-11e4-8656-ba05496bfbd8.png)
and now should be like this
![screen shot 2015-02-06 at 7 04 27](https://cloud.githubusercontent.com/assets/1935069/6074585/d1e2d334-add2-11e4-897f-44ddc2bc0763.png)
