### PR TITLE
V0.11.1.x tx types cleanup

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -144,10 +144,10 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     QString strFunds = "using <b>anonymous funds</b>";
     QString strFee = "";
-    recipients[0].inputType = "ONLY_DENOMINATED";
+    recipients[0].inputType = ONLY_DENOMINATED;
 
     if(ui->checkUseDarksend->isChecked()) {
-        recipients[0].inputType = "ONLY_DENOMINATED";
+        recipients[0].inputType = ONLY_DENOMINATED;
         strFunds = "using <b>anonymous funds</b>";
         QString strNearestAmount(
             BitcoinUnits::formatWithUnit(
@@ -156,7 +156,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             "(darksend requires this amount to be rounded up to the nearest %1)."
         ).arg(strNearestAmount));
     } else {
-        recipients[0].inputType = "ALL_COINS";
+        recipients[0].inputType = ALL_COINS;
         strFunds = "using <b>any available funds (not recommended)</b>";
     }
 

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -79,7 +79,8 @@ public:
         RecvWithDarksend,
         DarksendDenominate,
         DarksendCollateralPayment,
-        DarksendSplitUpLarge,
+        DarksendMakeCollaterals,
+        DarksendCreateDenominations,
         Darksent
     };
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -370,8 +370,10 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Darksend Denominate");
     case TransactionRecord::DarksendCollateralPayment:
         return tr("Darksend Collateral Payment");
-    case TransactionRecord::DarksendSplitUpLarge:
-        return tr("Darksend Split Up Large Inputs");
+    case TransactionRecord::DarksendMakeCollaterals:
+        return tr("Darksend Make Collateral Inputs");
+    case TransactionRecord::DarksendCreateDenominations:
+        return tr("Darksend Create Denominations");
     case TransactionRecord::Darksent:
         return tr("Darksent");
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -79,7 +79,10 @@ TransactionView::TransactionView(QWidget *parent) :
     typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
                                   TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
     typeWidget->addItem(tr("Darksent"), TransactionFilterProxy::TYPE(TransactionRecord::Darksent));
+    typeWidget->addItem(tr("Darksend Make Collateral Inputs"), TransactionFilterProxy::TYPE(TransactionRecord::DarksendMakeCollaterals));
+    typeWidget->addItem(tr("Darksend Create Denominations"), TransactionFilterProxy::TYPE(TransactionRecord::DarksendCreateDenominations));
     typeWidget->addItem(tr("Darksend Denominate"), TransactionFilterProxy::TYPE(TransactionRecord::DarksendDenominate));
+    typeWidget->addItem(tr("Darksend Collateral Payment"), TransactionFilterProxy::TYPE(TransactionRecord::DarksendCollateralPayment));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -266,17 +266,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         CWalletTx *newTx = transaction.getTransaction();
         CReserveKey *keyChange = transaction.getPossibleKeyChange();
 
-
-        AvailableCoinsType act = ONLY_DENOMINATED;
-        if(recipients[0].inputType == "ONLY_NONDENOMINATED"){
-            act = ONLY_NONDENOMINATED;
-        } else if(recipients[0].inputType == "ONLY_DENOMINATED"){
-            act = ONLY_DENOMINATED;
-        } else if(recipients[0].inputType == "ALL_COINS"){
-            act = ALL_COINS;
-        }
-
-        bool fCreated = wallet->CreateTransaction(vecSend, *newTx, *keyChange, nFeeRequired, strFailReason, coinControl, act, recipients[0].useInstantX);
+        bool fCreated = wallet->CreateTransaction(vecSend, *newTx, *keyChange, nFeeRequired, strFailReason, coinControl, recipients[0].inputType, recipients[0].useInstantX);
         transaction.setTransactionFee(nFeeRequired);
 
         if(!fCreated)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -10,6 +10,7 @@
 
 #include "allocators.h" /* for SecureString */
 #include "instantx.h"
+#include "wallet.h"
 
 #include <map>
 #include <vector>
@@ -49,7 +50,7 @@ public:
     QString address;
     QString label;
     qint64 amount;
-    std::string inputType;
+    AvailableCoinsType inputType;
     bool useInstantX;
     // If from a payment request, this is used for storing the memo
     QString message;

--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -1116,7 +1116,8 @@ void ListTransactions(const CWalletTx& wtx, const string& strAccount, int nMinDe
             Object entry;
             entry.push_back(Pair("account", strSentAccount));
             MaybePushAddress(entry, s.first);
-            entry.push_back(Pair("category", wtx.IsDenominated() ? "darksent" : "send"));
+            std::map<std::string, std::string>::const_iterator it = wtx.mapValue.find("DS");
+            entry.push_back(Pair("category", (it != wtx.mapValue.end() && it->second == "1") ? "darksent" : "send"));
             entry.push_back(Pair("amount", ValueFromAmount(-s.second)));
             entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
             if (fLong)

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1918,6 +1918,7 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend,
                 if(coin_type == ONLY_DENOMINATED) {
                     nFeeRet = nChange;
                     nChange = 0;
+                    wtxNew.mapValue["DS"] = "1";
                 } else if(useIX && nFeeRet < COIN*0.01 && nChange > ((COIN*0.01)-nFeeRet)) {
                     // IX has a minimum fee of 0.01 DRK
                     nChange -= (COIN*0.01)-nFeeRet;

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -382,11 +382,13 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             pwallet->AddToWallet(wtx, true);
             //// debug print
             //LogPrintf("LoadWallet  %s\n", wtx.GetHash().ToString());
-            //LogPrintf(" %12d  %s  %s  %s\n",
-            //    wtx.vout[0].nValue,
-            //    DateTimeStrFormat("%Y-%m-%d %H:%M:%S", wtx.GetBlockTime()),
-            //    wtx.hashBlock.ToString(),
-            //    wtx.mapValue["message"]);
+            if(fDebug) LogPrintf("LoadWallet %12d %2s %20s %s %s\n",
+                    wtx.vout[0].nValue,
+                    wtx.mapValue["DS"] == "1" ? "DS" : "",
+                    DateTimeStrFormat("%Y-%m-%d %H:%M:%S", wtx.GetTxTime()),
+                    wtx.GetHash().ToString(),
+                    wtx.hashBlock.ToString()
+            );
         }
         else if (strType == "acentry")
         {


### PR DESCRIPTION
The original idea behind that PR was that there is no real way to say if some tx was really "Darksent" or not when you try to rely on current settings. To say so you would have to make sure inputs have >=N rounds that was set at that time of tx in settings but you don't have this info. Otherwise with more rounds in settings tx type will change from "Darksent" to "Sent" or even worse from "Sent" to "Darksent" when you lowering number of rounds and for example tx just used denominated amounts because there were no non-denom funds left.
Alternative approach is basically to save tx flag in wallet db with all other info about txes stored there. 
Pro: If tx was originally Darksent we can just save this info and read it later to display accurate type no matter what current settings are now. This also helps to get rid of heavy rounds calculations in tx list. 
Con: If wallet is cleaned with zappwallettxes than all info will be wiped out and txes will appear as "Sent". This operation is rare and issued in emergency situations only but such behavior might be confusing. To solve this: rounds calculations / IsDenominated logic with current settings could be applied after zapwallettxes or on wallet rescan. This is not yet implemented though.
Also:
- new tx types DarksendMakeCollaterals and DarksendCreateDenominations instead of DarksendSplitUpLarge
- decomposeTransaction logic rewritten