### PR TITLE
Added link to Transifex translation site for missing languages

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -507,6 +507,41 @@
         </layout>
        </item>
        <item>
+        <widget class="QLabel" name="label_3">
+         <property name="toolTip">
+          <string notr="true"/>
+         </property>
+         <property name="statusTip">
+          <string notr="true"/>
+         </property>
+         <property name="whatsThis">
+          <string notr="true"/>
+         </property>
+         <property name="accessibleName">
+          <string notr="true"/>
+         </property>
+         <property name="text">
+          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(Help for missing or incomplete translations appreciated, register here and request your language for translation: &lt;a  href=&quot;https://www.transifex.com/projects/p/darkcoin/&quot;&gt;https://www.transifex.com/projects/p/darkcoin/&lt;/a&gt; )&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_Display">
          <item>
           <widget class="QLabel" name="unitLabel">

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -521,7 +521,7 @@
           <string notr="true"/>
          </property>
          <property name="text">
-          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;(Help for missing or incomplete translations appreciated, register here and request your language for translation: &lt;a  href=&quot;https://www.transifex.com/projects/p/darkcoin/&quot;&gt;https://www.transifex.com/projects/p/darkcoin/&lt;/a&gt; )&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Language missing or translation incomplete? Help contributing translations here: &lt;a  href=&quot;https://www.transifex.com/projects/p/darkcoin/&quot;&gt;https://www.transifex.com/projects/p/darkcoin/&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="wordWrap">
           <bool>true</bool>


### PR DESCRIPTION
I guess it doesn't make sense to translate this one :-)

![optionsdialog](https://cloud.githubusercontent.com/assets/10080039/6135285/a9a1b7bc-b167-11e4-8d08-c22dd8cd3f70.jpg)
