### PR TITLE
Minor UI changes for Overview Page

### DIFF
--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -282,7 +282,7 @@
            <rect>
             <x>10</x>
             <y>40</y>
-            <width>431</width>
+            <width>451</width>
             <height>161</height>
            </rect>
           </property>
@@ -876,7 +876,7 @@
            <rect>
             <x>10</x>
             <y>220</y>
-            <width>288</width>
+            <width>451</width>
             <height>61</height>
            </rect>
           </property>


### PR DESCRIPTION
1: Darksend layout widened by 2 characters (4 digit amounts + 2 digit rounds didn't fit in some languages)
2: "Last Darksend Status" messages use now the increased width from 1:

(request was originally for the v0.11.1.x branch, I moved it here)