### PR TITLE
Edit darkcoin.conf from within the wallet

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -310,8 +310,8 @@ void BitcoinGUI::createActions(bool fIsTestnet)
     openRPCConsoleAction->setStatusTip(tr("Open debugging console"));
     openNetworkAction = new QAction(QIcon(":/icons/connect_4"), tr("&Network Monitor"), this);
     openNetworkAction->setStatusTip(tr("Show network monitor"));
-	openConfEditorAction = new QAction(QIcon(":/icons/edit"), tr("Edit &Configuration File"), this);
-    openConfEditorAction->setStatusTip(tr("Edit configuration file"));
+	openConfEditorAction = new QAction(QIcon(":/icons/edit"), tr("Open &Configuration File"), this);
+    openConfEditorAction->setStatusTip(tr("Open configuration file"));
 
     usedSendingAddressesAction = new QAction(QIcon(":/icons/address-book"), tr("&Sending addresses..."), this);
     usedSendingAddressesAction->setStatusTip(tr("Show the list of used sending addresses and labels"));

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -190,6 +190,7 @@ BitcoinGUI::BitcoinGUI(bool fIsTestnet, QWidget *parent) :
     connect(openInfoAction, SIGNAL(triggered()), rpcConsole, SLOT(showInfo()));
     connect(openRPCConsoleAction, SIGNAL(triggered()), rpcConsole, SLOT(showConsole()));
     connect(openNetworkAction, SIGNAL(triggered()), rpcConsole, SLOT(showNetwork()));
+    connect(openConfEditorAction, SIGNAL(triggered()), rpcConsole, SLOT(showConfEditor()));
 
 
     // prevents an oben debug window from becoming stuck/unusable on client shutdown
@@ -309,6 +310,8 @@ void BitcoinGUI::createActions(bool fIsTestnet)
     openRPCConsoleAction->setStatusTip(tr("Open debugging console"));
     openNetworkAction = new QAction(QIcon(":/icons/connect_4"), tr("&Network Monitor"), this);
     openNetworkAction->setStatusTip(tr("Show network monitor"));
+	openConfEditorAction = new QAction(QIcon(":/icons/edit"), tr("Edit &Configuration File"), this);
+    openConfEditorAction->setStatusTip(tr("Edit configuration file"));
 
     usedSendingAddressesAction = new QAction(QIcon(":/icons/address-book"), tr("&Sending addresses..."), this);
     usedSendingAddressesAction->setStatusTip(tr("Show the list of used sending addresses and labels"));
@@ -386,6 +389,7 @@ void BitcoinGUI::createMenuBar()
         tools->addAction(openInfoAction);
         tools->addAction(openRPCConsoleAction);
         tools->addAction(openNetworkAction);
+        tools->addAction(openConfEditorAction);
     }
 
     QMenu *help = appMenuBar->addMenu(tr("&Help"));
@@ -534,6 +538,7 @@ void BitcoinGUI::createTrayIconMenu()
     trayIconMenu->addAction(openInfoAction);
     trayIconMenu->addAction(openRPCConsoleAction);
     trayIconMenu->addAction(openNetworkAction);
+    trayIconMenu->addAction(openConfEditorAction);
 #ifndef Q_OS_MAC // This is built-in on Mac
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(quitAction);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -96,6 +96,7 @@ private:
     QAction *openInfoAction;
     QAction *openRPCConsoleAction;
     QAction *openNetworkAction;
+    QAction *openConfEditorAction;
     QAction *openAction;
     QAction *showHelpMessageAction;
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -374,6 +374,15 @@ void openDebugLogfile()
         QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathDebug)));
 }
 
+void openConfigfile()
+{
+    boost::filesystem::path pathConfig = GetConfigFile();
+
+    /* Open darkcoin.conf with the associated application */
+    if (boost::filesystem::exists(pathConfig))
+        QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
+}
+
 ToolTipToRichTextFilter::ToolTipToRichTextFilter(int size_threshold, QObject *parent) :
     QObject(parent), size_threshold(size_threshold)
 {

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -103,6 +103,9 @@ namespace GUIUtil
 
     // Open debug.log
     void openDebugLogfile();
+	
+    // Open darkcoin.conf
+    void openConfigfile();	
 
     /** Qt event filter that intercepts ToolTipChange events, and replaces the tooltip with a rich text
       representation if needed. This assures that Qt can word-wrap long tooltip messages.

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -517,3 +517,8 @@ void RPCConsole::showNetwork()
     ui->tabWidget->setCurrentIndex(2);
     show();
 }
+
+void RPCConsole::showConfEditor()
+{
+    GUIUtil::openConfigfile();
+}

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -63,6 +63,8 @@ public slots:
     void showConsole();
     /** Switch to network tab and show */
     void showNetwork();
+    /** Open external (default) editor with darkcoin.conf */
+    void showConfEditor();	
 
 signals:
     // For RPC command executor


### PR DESCRIPTION
Users of the lesser operating systems (IOW, Windows and OSX) often have a hard time to figure out how to change darkcoin.conf because they simply can't find it, so I figured it would be a good idea to be able to open it from the wallet, because the wallet should know where it is located.
When the user selects this menu item the system-default editor for *.conf files is opened with the current darkcoin.conf.

This is how it looks (wallet in the foreground, default editor of my test-box in the background):

![confedit](https://cloud.githubusercontent.com/assets/10080039/6203402/bb6b0a86-b520-11e4-900c-c9c8e152ee85.jpg)
