### PR TITLE
Added automake to build requirements

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -52,7 +52,7 @@ Dependency Build Instructions: Ubuntu & Debian
 Build requirements:
 
 	sudo apt-get install build-essential
-	sudo apt-get install libtool autotools-dev autoconf
+	sudo apt-get install libtool autotools-dev autoconf automake
 	sudo apt-get install libssl-dev
 
 for Ubuntu 12.04 and later:


### PR DESCRIPTION
At least Ubuntu >= 14.04 based distributions don't have automake installed by default.