### PR TITLE
V0.11.2.x fix has collateral inputs

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1721,7 +1721,7 @@ bool CWallet::HasCollateralInputs() const
     BOOST_FOREACH(const COutput& out, vCoins)
         if(IsCollateralAmount(out.tx->vout[out.i].nValue)) nFound++;
 
-    return nFound > 1; // should have more than one just in case
+    return nFound > 0;
 }
 
 bool CWallet::IsCollateralAmount(int64_t nInputAmount) const


### PR DESCRIPTION
HasCollateralInputs should check only for at least 1 collateral (not 2, otherwise we can hit endless loop)