### PR TITLE
V0.11.2.x Few fixes for processing extra messages:

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -51,6 +51,7 @@ int RequestedMasterNodeList = 0;
 void ProcessMessageDarksend(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
     if(fLiteMode) return; //disable all darksend/masternode related functionality
+    if(IsInitialBlockDownload()) return;
 
     if (strCommand == "dsf") { //DarkSend Final tx
         if (pfrom->nVersion < darkSendPool.MIN_PEER_PROTO_VERSION) {

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -37,6 +37,7 @@ void ProcessMessageInstantX(CNode* pfrom, std::string& strCommand, CDataStream& 
 {
     if(fLiteMode) return; //disable all darksend/masternode related functionality
     if(!IsSporkActive(SPORK_2_INSTANTX)) return;
+    if(IsInitialBlockDownload()) return;
 
     if (strCommand == "txlreq")
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4826,6 +4826,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv)
         //probably one the extensions
         ProcessMessageDarksend(pfrom, strCommand, vRecv);
         mnodeman.ProcessMessage(pfrom, strCommand, vRecv);
+        ProcessMessageMasternodePayments(pfrom, strCommand, vRecv);
         ProcessMessageInstantX(pfrom, strCommand, vRecv);
         ProcessSpork(pfrom, strCommand, vRecv);
     }

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -21,6 +21,8 @@ std::map<int64_t, uint256> mapCacheBlockHashes;
 
 void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
+    if(IsInitialBlockDownload()) return;
+
     if (strCommand == "mnget") { //Masternode Payments Request Sync
         if(fLiteMode) return; //disable all darksend/masternode related functionality
 


### PR DESCRIPTION
- call ProcessMessageMasternodePayments on ProcessMessage (lost after moving mnodeman functionality)
- do not process extra functionality messages (DS, IX, payments) during initial download / reindex