### PR TITLE
V0.11.2.x fix crash on client shutdown

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -160,6 +160,7 @@ void OverviewPage::handleTransactionClicked(const QModelIndex &index)
 
 OverviewPage::~OverviewPage()
 {
+    disconnect(timer, SIGNAL(timeout()), this, SLOT(darkSendStatus()));
     delete ui;
 }
 


### PR DESCRIPTION
Disconnecting timer on overview page destruction should prevent crash on client shutdown.