### PR TITLE
V0.11.2.x check expired MNs right on client start

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1160,10 +1160,12 @@ bool AppInit2(boost::thread_group& threadGroup)
         CMasternodeDB mndb;
         if (!mndb.Read(mnodeman))
             LogPrintf("Invalid or missing masternodes.dat; recreating\n");
+        else
+            mnodeman.CheckAndRemove(); // clean out expired
     }
 
-    LogPrintf("Loaded %i masternodes from masternodes.dat  %dms\n",
-           mnodeman.size(), GetTimeMillis() - nStart);
+    LogPrintf("Loaded info from masternodes.dat  %dms\n", GetTimeMillis() - nStart);
+    LogPrintf("  %s\n", mnodeman.ToString());
 
 
     fMasterNode = GetBoolArg("-masternode", false);

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -140,7 +140,7 @@ bool CMasternodeMan::Add(CMasternode &mn)
 
     if (pmn == NULL)
     {
-        LogPrintf("CMasternodeMan: Adding new masternode %s\n", mn.addr.ToString().c_str());
+        if(fDebug) LogPrintf("CMasternodeMan: Adding new masternode %s - %i now\n", mn.addr.ToString().c_str(), size() + 1);
         vMasternodes.push_back(mn);
         return true;
     }
@@ -166,7 +166,7 @@ void CMasternodeMan::CheckAndRemove()
     vector<CMasternode>::iterator it = vMasternodes.begin();
     while(it != vMasternodes.end()){
         if((*it).activeState == 4 || (*it).activeState == 3){
-            LogPrintf("CMasternodeMan: Removing inactive masternode %s\n", (*it).addr.ToString().c_str());
+            if(fDebug) LogPrintf("CMasternodeMan: Removing inactive masternode %s - %i now\n", (*it).addr.ToString().c_str(), size() - 1);
             it = vMasternodes.erase(it);
         } else {
             ++it;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -123,7 +123,8 @@ void DumpMasternodes()
     CMasternodeDB mndb;
     mndb.Write(mnodeman);
 
-    LogPrintf("Flushed %d masternodes to masternodes.dat  %dms\n", mnodeman.size(), GetTimeMillis() - nStart);
+    LogPrintf("Flushed info to masternodes.dat  %dms\n", GetTimeMillis() - nStart);
+    LogPrintf("  %s\n", mnodeman.ToString());
 }
 
 CMasternodeMan::CMasternodeMan() {}
@@ -627,4 +628,16 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         LogPrintf("dseg - Sent %d masternode entries to %s\n", i, pfrom->addr.ToString().c_str());
     }
 
+}
+
+std::string CMasternodeMan::ToString()
+{
+    std::ostringstream info;
+
+    info << "masternodes: " << (int)vMasternodes.size() <<
+            ", peers who asked us for masternode list: " << (int)mAskedUsForMasternodeList.size() <<
+            ", peers we asked for masternode list: " << (int)mWeAskedForMasternodeList.size() <<
+            ", entries in masternode list we asked for: " << (int)mWeAskedForMasternodeListEntry.size();
+
+    return info.str();
 }

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -113,6 +113,8 @@ public:
     // Return the number of (unique) masternodes
     int size() { return vMasternodes.size(); }
 
+    std::string ToString();
+
 };
 
 #endif


### PR DESCRIPTION
- Execute CheckAndRemove on load as it will executed after one minute anyway and can cause confusions why # dropped so fast.
- Give more info in log, move log spamming "Adding.." and "Removing.." to debug level.