### PR TITLE
v0.11.2.x better old mn filtering

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -707,7 +707,7 @@ bool AppInit2(boost::thread_group& threadGroup)
     }
 
     //ignore masternodes below protocol version
-    nMasternodeMinProtocol = GetArg("-masternodeminprotocol", 70051);
+    nMasternodeMinProtocol = GetArg("-masternodeminprotocol", MIN_PEER_PROTO_VERSION);
 
     int64_t nStart;
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -626,7 +626,7 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         // see if we have this masternode
         CMasternode* pmn = this->Find(vin);
-        if(pmn != NULL)
+        if(pmn != NULL && pmn->protocolVersion >= nMasternodeMinProtocol)
         {
             // LogPrintf("dseep - Found corresponding mn for vin: %s\n", vin.ToString().c_str());
             // take this only if it's newer


### PR DESCRIPTION
Prevent masternodes with protocol less then nMasternodeMinProtocol (set to MIN_PEER_PROTO_VERSION by default now) to be able to stay in masternode list. Scenario: MIN_PEER_PROTO_VERSION was bumped but because we remember masternode we will never ask it for dsee again.