### PR TITLE
v0.11.2.x Parse masternode.conf only after network is recognized

### DIFF
--- a/src/darkcoind.cpp
+++ b/src/darkcoind.cpp
@@ -80,15 +80,16 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
 
-        std::string strErr;
-        if(!masternodeConfig.read(strErr)) {
-            fprintf(stderr,"Error reading masternode configuration file: %s\n", strErr.c_str());
-            return false;
-        }
-
         // Check for -testnet or -regtest parameter (TestNet() calls are only valid after this clause)
         if (!SelectParamsFromCommandLine()) {
             fprintf(stderr, "Error: Invalid combination of -regtest and -testnet.\n");
+            return false;
+        }
+
+        // parse masternode.conf
+        std::string strErr;
+        if(!masternodeConfig.read(strErr)) {
+            fprintf(stderr,"Error reading masternode configuration file: %s\n", strErr.c_str());
             return false;
         }
 

--- a/src/qt/darkcoin.cpp
+++ b/src/qt/darkcoin.cpp
@@ -534,13 +534,6 @@ int main(int argc, char *argv[])
         return false;
     }
 
-    string strErr;
-    if(!masternodeConfig.read(strErr)) {
-        QMessageBox::critical(0, QObject::tr("Darkcoin"),
-                              QObject::tr("Error reading masternode configuration file: %1").arg(strErr.c_str()));
-        return false;
-    }
-
     /// 7. Determine network (and switch to network specific options)
     // - Do not call Params() before this step
     // - Do this after parsing the configuration file, as the network can be switched there
@@ -567,6 +560,14 @@ int main(int argc, char *argv[])
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
 
 #ifdef ENABLE_WALLET
+    /// 7a. parse masternode.conf
+    string strErr;
+    if(!masternodeConfig.read(strErr)) {
+        QMessageBox::critical(0, QObject::tr("Darkcoin"),
+                              QObject::tr("Error reading masternode configuration file: %1").arg(strErr.c_str()));
+        return false;
+    }
+
     /// 8. URI IPC sending
     // - Do this early as we don't want to bother initializing if we are just calling IPC
     // - Do this *after* setting up the data directory, as the data directory hash is used in the name


### PR DESCRIPTION
New checks for 9999 in https://github.com/darkcoin/darkcoin/pull/237 highlighted that masternode.conf was parsed too early. This should fix it.