### PR TITLE
V0.11.2.x fix toolbar styling

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -121,9 +121,8 @@ BitcoinGUI::BitcoinGUI(bool fIsTestnet, QWidget *parent) :
 #ifdef ENABLE_WALLET
     if(enableWallet)
     {
-        /** Create wallet frame and make it the central widget */
+        /** Create wallet frame*/
         walletFrame = new WalletFrame(this);
-        setCentralWidget(walletFrame);
     } else
 #endif
     {
@@ -406,7 +405,7 @@ void BitcoinGUI::createToolBars()
 {
     if(walletFrame)
     {
-        QToolBar *toolbar = addToolBar(tr("Tabs toolbar"));
+        QToolBar *toolbar = new QToolBar(tr("Tabs toolbar"));
         toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
         toolbar->addAction(overviewAction);
         toolbar->addAction(sendCoinsAction);
@@ -414,6 +413,18 @@ void BitcoinGUI::createToolBars()
         toolbar->addAction(historyAction);
         toolbar->setMovable(false); // remove unused icon in upper left corner
         overviewAction->setChecked(true);
+
+        /** Create additional container for toolbar and walletFrame and make it the central widget.
+            This is a workaround mostly for toolbar styling on Mac OS but should work fine for every other OSes too.
+        */
+        QVBoxLayout *layout = new QVBoxLayout;
+        layout->addWidget(toolbar);
+        layout->addWidget(walletFrame);
+        layout->setSpacing(0);
+        layout->setContentsMargins(QMargins());
+        QWidget *containerWidget = new QWidget();
+        containerWidget->setLayout(layout);
+        setCentralWidget(containerWidget);
     }
 }
 


### PR DESCRIPTION
QT has a bug for toolbar styling so after https://github.com/darkcoin/darkcoin/pull/234 wallet looks strange on Mac OS. To solve this you need to create additional container for toolbar and walletFrame and make it the central widget. This is a workaround mostly for toolbar styling on Mac OS but should work fine for every other OSes too. Tested on Mac OS and Ubutntu. Would be nice if someone can test it on Windows too.
Before:
![screen shot 2015-03-13 at 18 13 18](https://cloud.githubusercontent.com/assets/1935069/6641442/cc08d0ce-c9ae-11e4-9de6-edeadfea635a.png)
After:
![screen shot 2015-03-13 at 18 00 18](https://cloud.githubusercontent.com/assets/1935069/6641443/cdef8b08-c9ae-11e4-88b7-afa28fae9920.png)
