### PR TITLE
V0.11.2.x  network specific masternode.conf 

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1098,7 +1098,7 @@ boost::filesystem::path GetConfigFile()
 boost::filesystem::path GetMasternodeConfigFile()
 {
     boost::filesystem::path pathConfigFile(GetArg("-mnconf", "masternode.conf"));
-    if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir(false) / pathConfigFile;
+    if (!pathConfigFile.is_complete()) pathConfigFile = GetDataDir() / pathConfigFile;
     return pathConfigFile;
 }
 


### PR DESCRIPTION
Use network specific masternode.conf otherwise after https://github.com/darkcoin/darkcoin/pull/238 and with masternode.conf for mainnet wallet will complain that config is wrong if you start on testnet.