### PR TITLE
V0.11.2.x fix litemode consistency for anon balance quering

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -73,7 +73,6 @@ qint64 WalletModel::getBalance(const CCoinControl *coinControl) const
 
 qint64 WalletModel::getAnonymizedBalance() const
 {
-    if(fLiteMode) return 0;
     return wallet->GetAnonymizedBalance();
 }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1090,6 +1090,8 @@ int64_t CWallet::GetBalance() const
 
 int64_t CWallet::GetAnonymizedBalance() const
 {
+    if(fLiteMode) return 0;
+
     int64_t nTotal = 0;
     {
         LOCK2(cs_main, cs_wallet);


### PR DESCRIPTION
Although this doesn't really fix anything now because of some additional checks that were implemented already but to keep things consistent I think it's better to check fLiteMode on GetAnonymizedBalance in CWallet itself instead of WalletModel.