### PR TITLE
mn inputage/sigtime checks (regtest support)

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -404,8 +404,8 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
     // pay to the oldest MN that still had no payment but its input is old enough and it was active long enough
     CMasternode *pmn = mnodeman.FindOldestNotInVec(vecLastPayments);
-
-    if(pmn != NULL)
+    if(pmn != NULL &&
+    (RegTest() || (!RegTest() && pmn->GetMasternodeInputAge() > nMinimumAge && pmn->lastTimeSeen - pmn->sigTime > nMinimumAge * 2.5 * 60)))
     {
         newWinner.score = 0;
         newWinner.nBlockHeight = nBlockHeight;


### PR DESCRIPTION
This was dropped during mn donations debugging https://github.com/darkcoin/darkcoin/commit/c65adeb7d1cab9952c641e275266869aba1fe276?diff=split#diff-031d4f9d201291e57fa6adbede2755a1R408. Returning it in place with "softer" regtest condition now.