### PR TITLE
Wrong default theme name on initialization fixed

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -776,7 +776,7 @@ QString loadStyleSheet()
     }
     else {
         cssName = QString(":/css/drkblue");  
-        settings.setValue("theme", ":/css/drkblue");
+        settings.setValue("theme", "drkblue");
     }
     
     QFile qFile(cssName);      


### PR DESCRIPTION
When the re-designed wallet is started for the very first time the QSetting for "theme" is set to the wrong value.