### PR TITLE
V0.11.2.x fix scorecalculation hash

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -214,7 +214,7 @@ uint256 CMasternode::CalculateScore(int mod, int64_t nBlockHeight)
     if(!GetBlockHash(hash, nBlockHeight)) return 0;
 
     uint256 hash2 = Hash(BEGIN(hash), END(hash));
-    uint256 hash3 = Hash(BEGIN(hash), END(aux));
+    uint256 hash3 = Hash(BEGIN(hash), END(hash), BEGIN(aux), END(aux));
 
     uint256 r = (hash3 > hash2 ? hash3 - hash2 : hash2 - hash3);
 


### PR DESCRIPTION
explicitly grab each piece of data from memory for hashing in CMasternode::CalculateScore