### PR TITLE
V0.11.2.x few small mn related fixes & cleanups

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -144,9 +144,10 @@ CMasternode::CMasternode()
     nLastDsq = 0;
     donationAddress = CScript();
     donationPercentage = 0;
-    nScanningErrorCount = 0;
     nVote = 0;
     lastVote = 0;
+    nScanningErrorCount = 0;
+    nLastScanningErrorBlockHeight = 0;
 }
 
 CMasternode::CMasternode(const CMasternode& other)
@@ -169,9 +170,10 @@ CMasternode::CMasternode(const CMasternode& other)
     nLastDsq = other.nLastDsq;
     donationAddress = other.donationAddress;
     donationPercentage = other.donationPercentage;
-    nScanningErrorCount = other.nScanningErrorCount;
     nVote = other.nVote;
     lastVote = other.lastVote;
+    nScanningErrorCount = other.nScanningErrorCount;
+    nLastScanningErrorBlockHeight = other.nLastScanningErrorBlockHeight;
 }
 
 CMasternode::CMasternode(CService newAddr, CTxIn newVin, CPubKey newPubkey, std::vector<unsigned char> newSig, int64_t newSigTime, CPubKey newPubkey2, int protocolVersionIn, CScript newDonationAddress, int newDonationPercentage)
@@ -192,11 +194,12 @@ CMasternode::CMasternode(CService newAddr, CTxIn newVin, CPubKey newPubkey, std:
     allowFreeTx = true;
     protocolVersion = protocolVersionIn;
     nLastDsq = 0;
-    nScanningErrorCount = 0;
     donationAddress = newDonationAddress;
     donationPercentage = newDonationPercentage;
     nVote = 0;
     lastVote = 0;
+    nScanningErrorCount = 0;
+    nLastScanningErrorBlockHeight = 0;
 }
 
 //

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -43,14 +43,6 @@ extern CMasternodePayments masternodePayments;
 extern map<uint256, CMasternodePaymentWinner> mapSeenMasternodeVotes;
 extern map<int64_t, uint256> mapCacheBlockHashes;
 
-enum masternodeState {
-    MASTERNODE_ENABLED = 1,
-    MASTERNODE_EXPIRED = 2,
-    MASTERNODE_VIN_SPENT = 3,
-    MASTERNODE_REMOVE = 4,
-    MASTERNODE_POS_ERROR = 5
-};
-
 void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 bool GetBlockHash(uint256& hash, int nBlockHeight);
 
@@ -65,6 +57,14 @@ private:
     mutable CCriticalSection cs;
 
 public:
+    enum state {
+        MASTERNODE_ENABLED = 1,
+        MASTERNODE_EXPIRED = 2,
+        MASTERNODE_VIN_SPENT = 3,
+        MASTERNODE_REMOVE = 4,
+        MASTERNODE_POS_ERROR = 5
+    };
+
     CTxIn vin;
     CService addr;
     CPubKey pubkey;

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -79,13 +79,13 @@ public:
     bool unitTest;
     bool allowFreeTx;
     int protocolVersion;
+    int64_t nLastDsq; //the dsq count from the last dsq broadcast of this node
     CScript donationAddress;
     int donationPercentage;
-    int64_t nLastDsq; //the dsq count from the last dsq broadcast of this node
-    int nScanningErrorCount;
-    int nLastScanningErrorBlockHeight;
     int nVote;
     int64_t lastVote;
+    int nScanningErrorCount;
+    int nLastScanningErrorBlockHeight;
 
     CMasternode();
     CMasternode(const CMasternode& other);
@@ -109,14 +109,16 @@ public:
         swap(first.lastTimeSeen, second.lastTimeSeen);
         swap(first.cacheInputAge, second.cacheInputAge);
         swap(first.cacheInputAgeBlock, second.cacheInputAgeBlock);
+        swap(first.unitTest, second.unitTest);
         swap(first.allowFreeTx, second.allowFreeTx);
         swap(first.protocolVersion, second.protocolVersion);
-        swap(first.unitTest, second.unitTest);
         swap(first.nLastDsq, second.nLastDsq);
         swap(first.donationAddress, second.donationAddress);
         swap(first.donationPercentage, second.donationPercentage);
         swap(first.nVote, second.nVote);
         swap(first.lastVote, second.lastVote);
+        swap(first.nScanningErrorCount, second.nScanningErrorCount);
+        swap(first.nLastScanningErrorBlockHeight, second.nLastScanningErrorBlockHeight);
     }
 
     CMasternode& operator=(CMasternode from)
@@ -163,6 +165,8 @@ public:
                 READWRITE(donationPercentage);
                 READWRITE(nVote);
                 READWRITE(lastVote);
+                READWRITE(nScanningErrorCount);
+                READWRITE(nLastScanningErrorBlockHeight);
         }
     )
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -489,8 +489,8 @@ CMasternode* CMasternodeMan::GetMasternodeByRank(int nRank, int64_t nBlockHeight
 
 void CMasternodeMan::ProcessMasternodeConnections()
 {
-    //we don't care about this for testing
-    if(TestNet() || RegTest()) return;
+    //we don't care about this for regtest
+    if(RegTest()) return;
 
     LOCK(cs_vNodes);
 

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -209,7 +209,7 @@ void CMasternodeMan::CheckAndRemove()
     //remove inactive
     vector<CMasternode>::iterator it = vMasternodes.begin();
     while(it != vMasternodes.end()){
-        if((*it).activeState == 4 || (*it).activeState == 3){
+        if((*it).activeState == CMasternode::MASTERNODE_REMOVE || (*it).activeState == CMasternode::MASTERNODE_VIN_SPENT){
             if(fDebug) LogPrintf("CMasternodeMan: Removing inactive Masternode %s - %i now\n", (*it).addr.ToString().c_str(), size() - 1);
             it = vMasternodes.erase(it);
         } else {

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -391,11 +391,10 @@ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, in
     // scan for winner
     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
 
-        mn.Check();
-
         if(mn.protocolVersion < minProtocol) continue;
-        if(fOnlyActive && !mn.IsEnabled()) {
-            continue;
+        if(fOnlyActive) {
+            mn.Check();
+            if(!mn.IsEnabled()) continue;
         }
 
         uint256 n = mn.CalculateScore(1, nBlockHeight);
@@ -462,11 +461,10 @@ CMasternode* CMasternodeMan::GetMasternodeByRank(int nRank, int64_t nBlockHeight
     // scan for winner
     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
 
-        mn.Check();
-
         if(mn.protocolVersion < minProtocol) continue;
-        if(fOnlyActive && !mn.IsEnabled()) {
-            continue;
+        if(fOnlyActive) {
+            mn.Check();
+            if(!mn.IsEnabled()) continue;
         }
 
         uint256 n = mn.CalculateScore(1, nBlockHeight);

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -763,11 +763,11 @@ Value masternodelist(const Array& params, bool fHelp)
 
                 std::string strStatus = "ACTIVE";
 
-                if(mn.activeState == MASTERNODE_ENABLED) strStatus = "ENABLED";
-                if(mn.activeState == MASTERNODE_EXPIRED) strStatus = "EXPIRED";
-                if(mn.activeState == MASTERNODE_VIN_SPENT) strStatus = "VIN_SPENT";
-                if(mn.activeState == MASTERNODE_REMOVE) strStatus = "REMOVE";
-                if(mn.activeState == MASTERNODE_POS_ERROR) strStatus = "POS_ERROR";
+                if(mn.activeState == CMasternode::MASTERNODE_ENABLED) strStatus = "ENABLED";
+                if(mn.activeState == CMasternode::MASTERNODE_EXPIRED) strStatus = "EXPIRED";
+                if(mn.activeState == CMasternode::MASTERNODE_VIN_SPENT) strStatus = "VIN_SPENT";
+                if(mn.activeState == CMasternode::MASTERNODE_REMOVE) strStatus = "REMOVE";
+                if(mn.activeState == CMasternode::MASTERNODE_POS_ERROR) strStatus = "POS_ERROR";
 
                 obj.push_back(Pair(strAddr,       strStatus.c_str()));
             } else if(strMode == "votes"){


### PR DESCRIPTION
- make sure nScanningErrorCount and nLastScanningErrorBlockHeight handled correctly (and save them to mncache.dat)
- move mn state enum inside class
- do not check mn unless only active requested
- ProcessMasternodeConnections should work on testnet too
- moving lines to preserve the same order of variables in different functions for better readability