### PR TITLE
Create empty dash.conf during startup if it doesn't exist

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1106,8 +1106,13 @@ void ReadConfigFile(map<string, string>& mapSettingsRet,
                     map<string, vector<string> >& mapMultiSettingsRet)
 {
     boost::filesystem::ifstream streamConfig(GetConfigFile());
-    if (!streamConfig.good())
-        return; // No dash.conf file is OK
+    if (!streamConfig.good()){
+        // Create empty dash.conf if it does not excist
+        FILE* configFile = fopen(GetConfigFile().string().c_str(), "a");
+        if (configFile != NULL)
+            fclose(configFile);
+        return; // Nothing to read, so just return
+    }
 
     set<string> setOptions;
     setOptions.insert("*");


### PR DESCRIPTION
Some text-editors don't even start when "Open Configuration File" is used and dash.conf does NOT exist, which is confusing for first time users. They also won't find it when searching "by hand", which confuses them even more and is probably the reason why some users create a dash.conf in the folder of the wallet-executable itself and wonder why it doesn't work.

In this case, my change just creates an empty dash.conf during startup.
