### PR TITLE
Transaction type column width adjusted

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -68,9 +68,9 @@ TransactionView::TransactionView(QWidget *parent) :
 
     typeWidget = new QComboBox(this);
 #ifdef Q_OS_MAC
-    typeWidget->setFixedWidth(121);
+    typeWidget->setFixedWidth(TYPE_COLUMN_WIDTH+1);
 #else
-    typeWidget->setFixedWidth(120);
+    typeWidget->setFixedWidth(TYPE_COLUMN_WIDTH);
 #endif
 
     typeWidget->addItem(tr("All"), TransactionFilterProxy::ALL_TYPES);

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -50,7 +50,7 @@ public:
     enum ColumnWidths {
         STATUS_COLUMN_WIDTH = 23,
         DATE_COLUMN_WIDTH = 120,
-        TYPE_COLUMN_WIDTH = 120,
+        TYPE_COLUMN_WIDTH = 240,
         AMOUNT_MINIMUM_COLUMN_WIDTH = 120,
         MINIMUM_COLUMN_WIDTH = 23
     };


### PR DESCRIPTION
With all those new and fancy (not to mention, LONG) transaction types like "Darksend Collateral Payments" the old Bitcoin-wallet needed some improvements to display everything.
The address-column was to wide for Dash-addresses anyway, so I increased the width of the type-column and the types are not truncated any more.
![trx](https://cloud.githubusercontent.com/assets/10080039/6987017/5f01df16-da43-11e4-9636-492b2d8d9461.png)


