### PR TITLE
Fix progress

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -300,7 +300,7 @@ void OverviewPage::updateDarksendProgress()
     {
         denomPart = (float)pwalletMain->GetNormalizedAnonymizedBalance() / denominatedBalance;
         denomPart = denomPart > 1 ? 1 : denomPart;
-        if(denomPart == 1) nMaxToAnonymize = denominatedBalance;
+        if(denomPart == 1 && nMaxToAnonymize > denominatedBalance) nMaxToAnonymize = denominatedBalance;
     }
 
     // % of fully anonymized balance


### PR DESCRIPTION
should set nMaxToAnonymize equal to denominatedBalance only if it's greater then it was possible to denominate