### PR TITLE
Fix protx/bls rpc help

### DIFF
--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -847,7 +847,10 @@ UniValue protx(const JSONRPCRequest& request)
         protx_help();
     }
 
-    std::string command = request.params[0].get_str();
+    std::string command;
+    if (request.params.size() >= 1) {
+        command = request.params[0].get_str();
+    }
 
     if (command == "register" || command == "register_fund" || command == "register_prepare") {
         return protx_register(request);
@@ -916,11 +919,14 @@ UniValue bls_generate(const JSONRPCRequest& request)
 
 UniValue _bls(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.empty()) {
+    if (request.fHelp && request.params.empty()) {
         bls_help();
     }
 
-    std::string command = request.params[0].get_str();
+    std::string command;
+    if (request.params.size() >= 1) {
+        command = request.params[0].get_str();
+    }
 
     if (command == "generate") {
         return bls_generate(request);


### PR DESCRIPTION
Yet another fix for "complex" rpc commands.
Fixes 2 issues:
1. protx
```
> dash-cli protx
JSON value is not a string as expected (code -1)
```
(should display `protx_help()` output)

2. bls
```
> dash-cli help bls generate
bls "command" ...
Set of commands to execute BLS related actions.
To get help on individual commands, use "help bls command".

Arguments:
1. "command"        (string, required) The command to execute

Available commands:
  generate          - Create a BLS secret/public key pair
```
(this is `bls_help()` output, should display `bls_generate_help()` output instead)

Kudos to @thephez for finding the issue.