### PR TITLE
Backporting Merge #18584: test: Check that the version message does n…

### DIFF
--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -16,7 +16,11 @@ import time
 from test_framework.messages import msg_getaddr, msg_ping, msg_verack
 from test_framework.mininode import mininode_lock, P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import wait_until
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than_or_equal,
+    wait_until,
+)
 
 banscore = 10
 
@@ -88,6 +92,15 @@ class CNodeNoVerackIdle(CLazyNode):
         self.send_message(msg_ping())
         self.send_message(msg_getaddr())
 
+
+class P2PVersionStore(P2PInterface):
+    version_received = None
+
+    def on_version(self, msg):
+        super().on_version(msg)
+        self.version_received = msg
+
+
 class P2PLeakTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -120,6 +133,18 @@ class P2PLeakTest(BitcoinTestFramework):
         assert(no_version_bannode.unexpected_msg == False)
         assert(no_version_idlenode.unexpected_msg == False)
         assert(no_verack_idlenode.unexpected_msg == False)
+
+        self.log.info('Check that the version message does not leak the local address of the node')
+        time_begin = int(time.time())
+        p2p_version_store = self.nodes[0].add_p2p_connection(P2PVersionStore())
+        time_end = time.time()
+        ver = p2p_version_store.version_received
+        assert_greater_than_or_equal(ver.nTime, time_begin)
+        assert_greater_than_or_equal(time_end, ver.nTime)
+        assert_equal(ver.addrFrom.port, 0)
+        assert_equal(ver.addrFrom.ip, '0.0.0.0')
+        assert_equal(ver.nStartingHeight, 201)
+        assert_equal(ver.nRelay, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…ot leak the local address

fa404f1e4718e8155581f23826480086dfbcfaa6 test: Check that the version message does not leak the local address of the node (MarcoFalke)

Pull request description:

  Add test for #8740

ACKs for top commit:
  theStack:
    ACK https://github.com/bitcoin/bitcoin/pull/18584/commits/fa404f1e4718e8155581f23826480086dfbcfaa6

Tree-SHA512: 4d1c10d1c02fba4b51bd8b9eb3a0d9a682b6aac8c3f6924e295fdca3faefa5ecc3eaa87d347cfec5d2b2bc49963c10fe0a37c463f36088ed0304a2e3716b963b