### PR TITLE
build: remove change-directory-and-build-depends behavior for immer

### DIFF
--- a/depends/packages/immer.mk
+++ b/depends/packages/immer.mk
@@ -28,16 +28,13 @@ define $(package)_config_cmds
   export CFLAGS="$($(package)_cflags) $($(package)_cppflags)" && \
   export CXXFLAGS="$($(package)_cxxflags) $($(package)_cppflags)" && \
   export LDFLAGS="$($(package)_ldflags)" && \
-  mkdir -p "$($(package)_dependencies)" && cd "$($(package)_dependencies)" && \
-  $(host_prefix)/bin/cmake ../ $($(package)_config_opts)
+  $(host_prefix)/bin/cmake . $($(package)_config_opts)
 endef
 
 define $(package)_build_cmds
-  cd "$($(package)_dependencies)" && \
   $(MAKE) $($(package)_build_opts)
 endef
 
 define $(package)_stage_cmds
-  cd "$($(package)_dependencies)" && \
   $(MAKE) install
 endef


### PR DESCRIPTION
Discovered when testing Gitian for #4255. 

Special thanks to @UdjinM6