### PR TITLE
sync: stop test_dash from reporting expected deadlocks

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -124,7 +124,6 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
         strOutput += strprintf(" %s\n", i.second.ToString().c_str());
     }
 
-    printf("%s\n", strOutput.c_str());
     LogPrintf("%s\n", strOutput.c_str());
 
     if (g_debug_lockorder_abort) {


### PR DESCRIPTION
I think this makes sense, but not in https://github.com/dashpay/dash/pull/4513
