### PR TITLE
cleanup: 4492 followup

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -900,7 +900,7 @@ static UniValue getblockheaders(const JSONRPCRequest& request)
                 "\nIf verbose is false, each item is a string that is serialized, hex-encoded data for a single blockheader.\n"
                 "If verbose is true, each item is an Object with information about a single blockheader.\n",
                 {
-                    {"hash", RPCArg::Type::STR, false},
+                    {"hash", RPCArg::Type::STR_HEX, false},
                     {"count", RPCArg::Type::NUM, true},
                     {"verbose", RPCArg::Type::BOOL, true},
                 }}
@@ -1013,8 +1013,8 @@ static UniValue getmerkleblocks(const JSONRPCRequest& request)
             RPCHelpMan{"getmerkleblocks",
                 "\nReturns an array of hex-encoded merkleblocks for <count> blocks starting from <hash> which match <filter>.\n",
                 {
-                    {"filter", RPCArg::Type::STR, false},
-                    {"hash", RPCArg::Type::STR, false},
+                    {"filter", RPCArg::Type::STR_HEX, false},
+                    {"hash", RPCArg::Type::STR_HEX, false},
                     {"count", RPCArg::Type::NUM, true},
             }}
             .ToString() +
@@ -2291,7 +2291,7 @@ static UniValue getspecialtxes(const JSONRPCRequest& request)
                 "If verbosity is 1, returns hex-encoded data for each transaction.\n"
                 "If verbosity is 2, returns an Object with information for each transaction.\n",
                 {
-                    {"blockhash", RPCArg::Type::STR, false},
+                    {"blockhash", RPCArg::Type::STR_HEX, false},
                     {"type", RPCArg::Type::NUM, true},
                     {"count", RPCArg::Type::NUM, true},
                     {"skip", RPCArg::Type::NUM, true},

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -60,7 +60,7 @@ static void gobject_deserialize_help()
         RPCHelpMan {"gobject deserialize",
             "Deserialize governance object from hex string to JSON\n",
             {
-                {"hex_data", RPCArg::Type::STR, false},
+                {"hex_data", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -89,7 +89,7 @@ static void gobject_check_help()
         RPCHelpMan{"gobject check",
             "Validate governance object data (proposal only)\n",
             {
-                {"hex_data", RPCArg::Type::STR, false},
+                {"hex_data", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -136,12 +136,12 @@ static void gobject_prepare_help(CWallet* const pwallet)
             "Prepare governance object by signing and creating tx\n"
             + HelpRequiringPassphrase(pwallet) + "\n",
             {
-                {"parent-hash", RPCArg::Type::STR, false},
+                {"parent-hash", RPCArg::Type::STR_HEX, false},
                 {"revision", RPCArg::Type::NUM, false},
                 {"time", RPCArg::Type::NUM, false},
-                {"data-hex", RPCArg::Type::STR, false},
+                {"data-hex", RPCArg::Type::STR_HEX, false},
                 {"use-IS", RPCArg::Type::BOOL, true},
-                {"outputHash", RPCArg::Type::STR, true},
+                {"outputHash", RPCArg::Type::STR_HEX, true},
                 {"outputIndex", RPCArg::Type::NUM, true},
             }}
             .ToString() +
@@ -314,11 +314,11 @@ static void gobject_submit_help()
         RPCHelpMan{"gobject submit",
             "Submit governance object to network\n",
             {
-                {"parent-hash", RPCArg::Type::STR, false},
+                {"parent-hash", RPCArg::Type::STR_HEX, false},
                 {"revision", RPCArg::Type::NUM, false},
                 {"time", RPCArg::Type::NUM, false},
-                {"data-hex", RPCArg::Type::STR, false},
-                {"fee-txid", RPCArg::Type::STR, true},
+                {"data-hex", RPCArg::Type::STR_HEX, false},
+                {"fee-txid", RPCArg::Type::STR_HEX, true},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -433,7 +433,7 @@ static void gobject_vote_conf_help()
         RPCHelpMan{"gobject vote-conf",
             "Vote on a governance object by masternode configured in dash.conf\n",
             {
-                {"governance-hash", RPCArg::Type::STR, false},
+                {"governance-hash", RPCArg::Type::STR_HEX, false},
                 {"vote", RPCArg::Type::STR, false},
                 {"vote-outcome", RPCArg::Type::STR, false},
             }}
@@ -610,7 +610,7 @@ static void gobject_vote_many_help(CWallet* const pwallet)
             "Vote on a governance object by all masternodes for which the voting key is present in the local wallet\n"
             + HelpRequiringPassphrase(pwallet) + "\n",
             {
-                {"governance-hash", RPCArg::Type::STR, false},
+                {"governance-hash", RPCArg::Type::STR_HEX, false},
                 {"vote", RPCArg::Type::STR, false},
                 {"vote-outcome", RPCArg::Type::STR, false},
             }}
@@ -669,10 +669,10 @@ static void gobject_vote_alias_help(CWallet* const pwallet)
             "Vote on a governance object by masternode's voting key (if present in local wallet)\n"
             + HelpRequiringPassphrase(pwallet) + "\n",
             {
-                {"governance-hash", RPCArg::Type::STR, false},
+                {"governance-hash", RPCArg::Type::STR_HEX, false},
                 {"vote", RPCArg::Type::STR, false},
                 {"vote-outcome", RPCArg::Type::STR, false},
-                {"protx-hash", RPCArg::Type::STR, false},
+                {"protx-hash", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -792,8 +792,8 @@ static void gobject_list_help()
         RPCHelpMan{"gobject list",
             "List governance objects (can be filtered by signal and/or object type)\n",
             {
-                {"signal", RPCArg::Type::STR, false},
-                {"type", RPCArg::Type::STR, false},
+                {"signal", RPCArg::Type::STR, true},
+                {"type", RPCArg::Type::STR, true},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -829,8 +829,8 @@ static void gobject_diff_help()
         RPCHelpMan{"gobject diff",
             "List differences since last diff or list\n",
             {
-                {"signal", RPCArg::Type::STR, false},
-                {"type", RPCArg::Type::STR, false},
+                {"signal", RPCArg::Type::STR, true},
+                {"type", RPCArg::Type::STR, true},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -866,7 +866,7 @@ static void gobject_get_help()
         RPCHelpMan{"gobject get",
             "Get governance object by hash\n",
             {
-                {"governance-hash", RPCArg::Type::STR, false},
+                {"governance-hash", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -958,8 +958,8 @@ static void gobject_getcurrentvotes_help()
         RPCHelpMan{"gobject getcurrentvotes",
             "Get only current (tallying) votes for a governance object hash (does not include old votes)\n",
             {
-                {"governance-hash", RPCArg::Type::STR, false},
-                {"txid", RPCArg::Type::STR, true},
+                {"governance-hash", RPCArg::Type::STR_HEX, false},
+                {"txid", RPCArg::Type::STR_HEX, true},
                 {"vout", RPCArg::Type::STR, true},
             }}
             .ToString() +
@@ -1103,9 +1103,9 @@ static UniValue voteraw(const JSONRPCRequest& request)
             RPCHelpMan{"voteraw",
                 "Compile and relay a governance vote with provided external signature instead of signing vote internally\n",
                 {
-                    {"mn-collateral-tx-hash", RPCArg::Type::STR, false},
+                    {"mn-collateral-tx-hash", RPCArg::Type::STR_HEX, false},
                     {"mn-collateral-tx-index", RPCArg::Type::NUM, false},
-                    {"governance-hash", RPCArg::Type::STR, false},
+                    {"governance-hash", RPCArg::Type::STR_HEX, false},
                     {"vote-signal", RPCArg::Type::STR, false},
                     {"vote-outcome", RPCArg::Type::STR, false},
                     {"time", RPCArg::Type::NUM, false},

--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -368,7 +368,7 @@ static void masternode_payments_help()
         RPCHelpMan{"masternode payments",
             "\nReturns an array of deterministic masternodes and their payments for the specified block\n",
             {
-                {"blockhash", RPCArg::Type::STR, true},
+                {"blockhash", RPCArg::Type::STR_HEX, true},
                 {"count", RPCArg::Type::NUM, true},
             }}
             .ToString() +
@@ -515,7 +515,9 @@ static UniValue masternode_payments(const JSONRPCRequest& request)
     throw std::runtime_error(
         RPCHelpMan{"masternode",
             "Set of commands to execute masternode related actions\n",
-            {}}
+            {
+                {"command", RPCArg::Type::STR, false},
+            }}
             .ToString() +
         "\nArguments:\n"
         "1. \"command\"        (string or set of strings, required) The command to execute\n"

--- a/src/rpc/rpcevo.cpp
+++ b/src/rpc/rpcevo.cpp
@@ -350,7 +350,7 @@ static void protx_register_help(CWallet* const pwallet)
             "transaction output spendable by this wallet. It must also not be used by any other masternode.\n"
             + HelpRequiringPassphrase(pwallet) + "\n",
             {
-                {"collateralHash", RPCArg::Type::STR, false},
+                {"collateralHash", RPCArg::Type::STR_HEX, false},
                 {"collateralAddress", RPCArg::Type::STR, false},
                 {"ipAndPort", RPCArg::Type::STR, false},
                 {"ownerAddress", RPCArg::Type::STR, false},
@@ -390,7 +390,7 @@ static void protx_register_prepare_help()
             "with the private key that corresponds to collateralAddress to prove collateral ownership.\n"
             "The prepared transaction will also contain inputs and outputs to cover fees.\n",
             {
-                {"collateralHash", RPCArg::Type::STR, false},
+                {"collateralHash", RPCArg::Type::STR_HEX, false},
                 {"collateralAddress", RPCArg::Type::STR, false},
                 {"ipAndPort", RPCArg::Type::STR, false},
                 {"ownerAddress", RPCArg::Type::STR, false},
@@ -432,7 +432,7 @@ static void protx_register_submit_help(CWallet* const pwallet)
             "Note: See \"help protx register_prepare\" for more info about creating a ProTx and a message to sign.\n"
             + HelpRequiringPassphrase(pwallet) + "\n",
             {
-                {"tx", RPCArg::Type::STR, false},
+                {"tx", RPCArg::Type::STR_HEX, false},
                 {"sig", RPCArg::Type::STR, false},
             }}
             .ToString() +
@@ -652,7 +652,7 @@ static void protx_update_service_help(CWallet* const pwallet)
             "If this is done for a masternode that got PoSe-banned, the ProUpServTx will also revive this masternode.\n"
             + HelpRequiringPassphrase(pwallet) + "\n",
             {
-                {"proTxHash", RPCArg::Type::STR, false},
+                {"proTxHash", RPCArg::Type::STR_HEX, false},
                 {"ipAndPort", RPCArg::Type::STR, false},
                 {"operatorKey", RPCArg::Type::STR, false},
                 {"operatorPayoutAddress", RPCArg::Type::STR, true},
@@ -756,10 +756,10 @@ static void protx_update_registrar_help(CWallet* const pwallet)
             "The owner key of the masternode must be known to your wallet.\n"
             + HelpRequiringPassphrase(pwallet) + "\n",
             {
-                {"proTxHash", RPCArg::Type::STR, false},
+                {"proTxHash", RPCArg::Type::STR_HEX, false},
                 {"operatorPubKey_update", RPCArg::Type::STR, false},
                 {"votingAddress_update", RPCArg::Type::STR, false},
-                {"payoutAddress_update", RPCArg::Type::STR, true},
+                {"payoutAddress_update", RPCArg::Type::STR, false},
                 {"feeSourceAddress", RPCArg::Type::STR, true},
             }}
             .ToString() +
@@ -854,18 +854,12 @@ static void protx_revoke_help(CWallet* const pwallet)
             "to the masternode owner.\n"
             + HelpRequiringPassphrase(pwallet) + "\n",
             {
-                {"proTxHash", RPCArg::Type::STR, false},
+                {"proTxHash", RPCArg::Type::STR_HEX, false},
                 {"operatorKey", RPCArg::Type::STR, false},
                 {"reason", RPCArg::Type::NUM, true},
                 {"feeSourceAddress", RPCArg::Type::STR, true},
             }}
             .ToString() +
-            "protx revoke \"proTxHash\" \"operatorKey\" ( reason \"feeSourceAddress\")\n"
-            "\nCreates and sends a ProUpRevTx to the network. This will revoke the operator key of the masternode and\n"
-            "put it into the PoSe-banned state. It will also set the service field of the masternode\n"
-            "to zero. Use this in case your operator key got compromised or you want to stop providing your service\n"
-            "to the masternode owner.\n"
-            + HelpRequiringPassphrase(pwallet) + "\n"
             "\nArguments:\n"
             + GetHelpString(1, "proTxHash")
             + GetHelpString(2, "operatorKey")
@@ -950,7 +944,7 @@ static void protx_list_help()
         RPCHelpMan{"protx list",
             "\nLists all ProTxs in your wallet or on-chain, depending on the given type.\n",
             {
-                {"type", RPCArg::Type::STR, false},
+                {"type", RPCArg::Type::STR, true},
                 {"detailed", RPCArg::Type::BOOL, true},
                 {"height", RPCArg::Type::NUM, true},
             }}
@@ -1126,7 +1120,7 @@ static void protx_info_help()
         RPCHelpMan{"protx info",
             "\nReturns detailed information about a deterministic masternode.\n",
             {
-                {"proTxHash", RPCArg::Type::STR, false},
+                {"proTxHash", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -1222,7 +1216,10 @@ static UniValue protx_diff(const JSONRPCRequest& request)
         RPCHelpMan{"protx",
             "Set of commands to execute ProTx related actions.\n"
             "To get help on individual commands, use \"help protx command\".\n",
-            {}} .ToString() +
+            {
+                {"command", RPCArg::Type::STR, false},
+            }}
+            .ToString() +
         "\nArguments:\n"
         "1. \"command\"        (string, required) The command to execute\n"
         "\nAvailable commands:\n"

--- a/src/rpc/rpcquorums.cpp
+++ b/src/rpc/rpcquorums.cpp
@@ -89,7 +89,7 @@ static void quorum_info_help()
             "Return information about a quorum\n",
             {
                 {"llmqType", RPCArg::Type::NUM, false},
-                {"quorumHash", RPCArg::Type::STR, false},
+                {"quorumHash", RPCArg::Type::STR_HEX, false},
                 {"includeSkShare", RPCArg::Type::BOOL, true},
             }}
             .ToString() +
@@ -253,7 +253,7 @@ static void quorum_memberof_help()
         RPCHelpMan{"quorum memberof",
             "Checks which quorums the given masternode is a member of.\n",
             {
-                {"proTxHash", RPCArg::Type::STR, false},
+                {"proTxHash", RPCArg::Type::STR_HEX, false},
                 {"scanQuorumsCount", RPCArg::Type::NUM, true},
             }}
             .ToString() +
@@ -316,9 +316,9 @@ static void quorum_sign_help()
             "Threshold-sign a message\n",
             {
                 {"llmqType", RPCArg::Type::NUM, false},
-                {"id", RPCArg::Type::STR, false},
-                {"msgHash", RPCArg::Type::STR, false},
-                {"quorumHash", RPCArg::Type::STR, true},
+                {"id", RPCArg::Type::STR_HEX, false},
+                {"msgHash", RPCArg::Type::STR_HEX, false},
+                {"quorumHash", RPCArg::Type::STR_HEX, true},
                 {"submit", RPCArg::Type::BOOL, true},
             }}
             .ToString() +
@@ -339,10 +339,10 @@ static void quorum_verify_help()
             "Test if a quorum signature is valid for a request id and a message hash\n",
             {
                 {"llmqType", RPCArg::Type::NUM, false},
-                {"id", RPCArg::Type::STR, false},
-                {"msgHash", RPCArg::Type::STR, false},
+                {"id", RPCArg::Type::STR_HEX, false},
+                {"msgHash", RPCArg::Type::STR_HEX, false},
                 {"signature", RPCArg::Type::STR, false},
-                {"quorumHash", RPCArg::Type::STR, true},
+                {"quorumHash", RPCArg::Type::STR_HEX, true},
                 {"signHeight", RPCArg::Type::NUM, true},
             }}
             .ToString() +
@@ -365,8 +365,8 @@ static void quorum_hasrecsig_help()
             "Test if a valid recovered signature is present\n",
             {
                 {"llmqType", RPCArg::Type::NUM, false},
-                {"id", RPCArg::Type::STR, false},
-                {"msgHash", RPCArg::Type::STR, false},
+                {"id", RPCArg::Type::STR_HEX, false},
+                {"msgHash", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -383,8 +383,8 @@ static void quorum_getrecsig_help()
             "Get a recovered signature\n",
             {
                 {"llmqType", RPCArg::Type::NUM, false},
-                {"id", RPCArg::Type::STR, false},
-                {"msgHash", RPCArg::Type::STR, false},
+                {"id", RPCArg::Type::STR_HEX, false},
+                {"msgHash", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -401,8 +401,8 @@ static void quorum_isconflicting_help()
             "Test if a conflict exists\n",
             {
                 {"llmqType", RPCArg::Type::NUM, false},
-                {"id", RPCArg::Type::STR, false},
-                {"msgHash", RPCArg::Type::STR, false},
+                {"id", RPCArg::Type::STR_HEX, false},
+                {"msgHash", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -538,7 +538,7 @@ static void quorum_selectquorum_help()
             "Returns the quorum that would/should sign a request\n",
             {
                 {"llmqType", RPCArg::Type::NUM, false},
-                {"id", RPCArg::Type::STR, false},
+                {"id", RPCArg::Type::STR_HEX, false},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -621,9 +621,9 @@ static void quorum_getdata_help()
             {
                 {"nodeId", RPCArg::Type::NUM, false},
                 {"llmqType", RPCArg::Type::NUM, false},
-                {"quorumHash", RPCArg::Type::STR, false},
+                {"quorumHash", RPCArg::Type::STR_HEX, false},
                 {"dataMask", RPCArg::Type::NUM, false},
-                {"proTxHash", RPCArg::Type::STR, true},
+                {"proTxHash", RPCArg::Type::STR_HEX, true},
             }}
             .ToString() +
         "\nArguments:\n"
@@ -735,7 +735,7 @@ static void verifychainlock_help()
         RPCHelpMan{"verifychainlock",
             "Test if a quorum signature is valid for a ChainLock.\n",
             {
-                {"blockHash", RPCArg::Type::STR, false},
+                {"blockHash", RPCArg::Type::STR_HEX, false},
                 {"signature", RPCArg::Type::STR, false},
                 {"blockHeight", RPCArg::Type::NUM, true},
             }}
@@ -782,8 +782,8 @@ static void verifyislock_help()
         RPCHelpMan{"verifyislock",
             "Test if a quorum signature is valid for an InstantSend Lock\n",
             {
-                {"id", RPCArg::Type::STR, false},
-                {"txid", RPCArg::Type::STR, false},
+                {"id", RPCArg::Type::STR_HEX, false},
+                {"txid", RPCArg::Type::STR_HEX, false},
                 {"signature", RPCArg::Type::STR, false},
                 {"maxHeight", RPCArg::Type::NUM, true},
             }}

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2029,7 +2029,7 @@ static UniValue walletpassphrase(const JSONRPCRequest& request)
                 {
                     {"passphrase", RPCArg::Type::STR, false},
                     {"timeout", RPCArg::Type::NUM, false},
-                    {"mixingonly", RPCArg::Type::BOOL, false},
+                    {"mixingonly", RPCArg::Type::BOOL, true},
                 }}
                 .ToString() +
             "\nArguments:\n"


### PR DESCRIPTION
tl;dr:
- block hashes and request ids are hex strings,
- some optional params were not marked as such and vice versa,
- missed few `command`s which should be args,
- duplicated help text.