### PR TITLE
fix: hpmn registration after revocation caused mining failure

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -514,7 +514,7 @@ void CDeterministicMNList::AddMN(const CDeterministicMNCPtr& dmn, bool fBumpTota
     }
 
     if (dmn->nType == MnType::HighPerformance) {
-        if (!AddUniqueProperty(*dmn, dmn->pdmnState->platformNodeID)) {
+        if (dmn->pdmnState->platformNodeID != uint160() && !AddUniqueProperty(*dmn, dmn->pdmnState->platformNodeID)) {
             mnUniquePropertyMap = mnUniquePropertyMapSaved;
             throw(std::runtime_error(strprintf("%s: Can't add a masternode %s with a duplicate platformNodeID=%s", __func__,
                                                dmn->proTxHash.ToString(), dmn->pdmnState->platformNodeID.ToString())));


### PR DESCRIPTION
## Issue being fixed or feature implemented
We reset operator info on revocation; but then on replacement via new register we try to "RemoveMN", which tries to remove platformNodeID but that's already been cleared

## What was done?
Only try to delete platformNodeID if it's non-null

## How Has This Been Tested?
Mined with it on testnet; mining works

## Breaking Changes
This will fork off other testnet nodes, as this fixes the logic

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
