### PR TITLE
chore: update defaultAssumeValid, nMinimumChainWork, checkpointData and chainTxData for testnet (again)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -393,10 +393,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V20].nFalloffCoeff = 5;            // this corresponds to 10 periods
 
         // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000002d68c89409f9383"); // 850000
+        consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000000002d68c6dc9ca04f3"); // 840000
 
         // By default assume that the signatures in ancestors of this block are valid.
-        consensus.defaultAssumeValid = uint256S("0x0000003eddb94218e7a3f41b2ac6e26143f8a748b50cd26e86bdbbab9ebe50aa"); // 850000
+        consensus.defaultAssumeValid = uint256S("0x000000cd7c3084499912ae893125c13e8c3c656abb6e511dcec6619c3d65a510"); // 840000
 
         pchMessageStart[0] = 0xce;
         pchMessageStart[1] = 0xe2;
@@ -476,7 +476,7 @@ public:
                 {470000, uint256S("0x0000009303aeadf8cf3812f5c869691dbd4cb118ad20e9bf553be434bafe6a52")},
                 {794950, uint256S("0x000001860e4c7248a9c5cc3bc7106041750560dc5cd9b3a2641b49494bcff5f2")},
                 {808000, uint256S("0x00000104cb60a2b5e00a8a4259582756e5bf0dca201c0993c63f0e54971ea91a")},
-                {850000, uint256S("0x0000003eddb94218e7a3f41b2ac6e26143f8a748b50cd26e86bdbbab9ebe50aa")},
+                {840000, uint256S("0x000000cd7c3084499912ae893125c13e8c3c656abb6e511dcec6619c3d65a510")},
             }
         };
 
@@ -484,12 +484,12 @@ public:
             // TODO to be specified in a future patch.
         };
 
-        // getchaintxstats 17280 0000003eddb94218e7a3f41b2ac6e26143f8a748b50cd26e86bdbbab9ebe50aa
+        // getchaintxstats 17280 000000cd7c3084499912ae893125c13e8c3c656abb6e511dcec6619c3d65a510
         chainTxData = ChainTxData{
-                1678858966, // * UNIX timestamp of last known number of transactions (Block 850000)
-                5796306,    // * total number of transactions between genesis and that timestamp
+                1676885923, // * UNIX timestamp of last known number of transactions (Block 840000)
+                5776047,    // * total number of transactions between genesis and that timestamp
                             //   (the tx=... number in the ChainStateFlushed debug.log lines)
-                0.01077368401768078,       // * estimated number of transactions per second after that timestamp
+                0.01120953982471268,       // * estimated number of transactions per second after that timestamp
         };
     }
 };


### PR DESCRIPTION
## Issue being fixed or feature implemented
Same as #5428 but with a lower block number this time. This should let us simply reorg testnet with 18.2.2 at deeper blocks instead of bumping v19 testnet activation params for 19.2.

## What was done?

## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

