### PR TITLE
fix: Count all MNs when calculating voting threshold

### DIFF
--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -259,6 +259,13 @@ public:
                                                             });
     }
 
+    [[nodiscard]] size_t GetWeightedMNsCount() const
+    {
+        return std::accumulate(mnMap.begin(), mnMap.end(), 0, [this](auto res, const auto& p) {
+                                                                return res + GetMnType(p.second->nType).voting_weight;
+                                                            });
+    }
+
     /**
      * Execute a callback on all masternodes in the mnList. This will pass a reference
      * of each masternode to the callback function. This should be preferred over ForEachMNShared.

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -561,7 +561,7 @@ std::optional<CSuperblock> CGovernanceManager::CreateSuperblockCandidate(int nHe
     if (HasAlreadyVotedFundingTrigger()) return std::nullopt;
 
     // A proposal is considered passing if (YES votes) >= (Total Weight of Masternodes / 10),
-    // count total valid (ENABLED) masternodes to determine passing threshold.
+    // count total registered masternodes to determine passing threshold.
     const auto mnList = deterministicMNManager->GetListAtChainTip();
     const int nWeightedMnCount = mnList.GetWeightedMNsCount();
     const int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nWeightedMnCount / 10);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -563,7 +563,7 @@ std::optional<CSuperblock> CGovernanceManager::CreateSuperblockCandidate(int nHe
     // A proposal is considered passing if (YES votes) >= (Total Weight of Masternodes / 10),
     // count total valid (ENABLED) masternodes to determine passing threshold.
     const auto mnList = deterministicMNManager->GetListAtChainTip();
-    const int nWeightedMnCount = mnList.GetValidWeightedMNsCount();
+    const int nWeightedMnCount = mnList.GetWeightedMNsCount();
     const int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nWeightedMnCount / 10);
 
     // Use std::vector of std::shared_ptr<const CGovernanceObject> because CGovernanceObject doesn't support move operations (needed for sorting the vector later)

--- a/src/qt/governancelist.cpp
+++ b/src/qt/governancelist.cpp
@@ -345,7 +345,7 @@ void GovernanceList::updateProposalList()
 {
     if (this->clientModel) {
         // A proposal is considered passing if (YES votes - NO votes) >= (Total Weight of Masternodes / 10),
-        // count total valid (ENABLED) masternodes to determine passing threshold.
+        // count total registered masternodes to determine passing threshold.
         // Need to query number of masternodes here with access to clientModel.
         const int nWeightedMnCount = clientModel->getMasternodeList().GetWeightedMNsCount();
         const int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nWeightedMnCount / 10);

--- a/src/qt/governancelist.cpp
+++ b/src/qt/governancelist.cpp
@@ -347,7 +347,7 @@ void GovernanceList::updateProposalList()
         // A proposal is considered passing if (YES votes - NO votes) >= (Total Weight of Masternodes / 10),
         // count total valid (ENABLED) masternodes to determine passing threshold.
         // Need to query number of masternodes here with access to clientModel.
-        const int nWeightedMnCount = clientModel->getMasternodeList().GetValidWeightedMNsCount();
+        const int nWeightedMnCount = clientModel->getMasternodeList().GetWeightedMNsCount();
         const int nAbsVoteReq = std::max(Params().GetConsensus().nGovernanceMinQuorum, nWeightedMnCount / 10);
         proposalModel->setVotingParams(nAbsVoteReq);
 

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -1046,7 +1046,7 @@ static UniValue getgovernanceinfo(const JSONRPCRequest& request)
     obj.pushKV("superblockmaturitywindow", Params().GetConsensus().nSuperblockMaturityWindow);
     obj.pushKV("lastsuperblock", nLastSuperblock);
     obj.pushKV("nextsuperblock", nNextSuperblock);
-    obj.pushKV("fundingthreshold", int(deterministicMNManager->GetListAtChainTip().GetValidWeightedMNsCount() / 10));
+    obj.pushKV("fundingthreshold", int(deterministicMNManager->GetListAtChainTip().GetWeightedMNsCount() / 10));
 
     return obj;
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
This is an alternative to https://github.com/dashpay/dash/pull/5583

## What was done?
Adjust threshold calculations (instead of ignoring votes form invalid MNs)

## How Has This Been Tested?


## Breaking Changes
Proposals will need 441 absolute YES votes (vs 374 now). A couple of currently passing proposals won't pass in this version (unless they get more YES votes).

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

