### PR TITLE
fix: Redefine `keepOldKeys` and align quorum and dkgsession key storage depths

### DIFF
--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -467,7 +467,8 @@ void CDKGSessionManager::CleanupOldContributions() const
 
     for (const auto& params : Params().GetConsensus().llmqs) {
         // For how many blocks recent DKG info should be kept
-        const int MAX_STORE_DEPTH = 2 * params.signingActiveQuorumCount * params.dkgInterval;
+        const int MAX_CYCLES = params.useRotation ? params.keepOldKeys / params.signingActiveQuorumCount : params.keepOldKeys;
+        const int MAX_STORE_DEPTH = MAX_CYCLES * params.dkgInterval;
 
         LogPrint(BCLog::LLMQ, "CDKGSessionManager::%s -- looking for old entries for llmq type %d\n", __func__, ToUnderlying(params.type));
 

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -104,7 +104,7 @@ struct LLMQParams {
     // For rotated quorums it should be equal to 2 x active quorums set.
     int keepOldConnections;
 
-    // The number of quorums for which we should keep keys. Usually it's equal to keepOldConnections.
+    // The number of quorums for which we should keep keys. Usually it's equal to signingActiveQuorumCount * 2.
     // Unlike for other quorum types we want to keep data (secret key shares and vvec)
     // for Platform quorums for much longer because Platform can be restarted and
     // it must be able to re-sign stuff.
@@ -145,7 +145,7 @@ static constexpr std::array<LLMQParams, 14> available_llmqs = {
         .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
 
         .keepOldConnections = 3,
-        .keepOldKeys = 3,
+        .keepOldKeys = 4,
         .recoveryMembers = 3,
     },
 
@@ -171,7 +171,7 @@ static constexpr std::array<LLMQParams, 14> available_llmqs = {
         .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
 
         .keepOldConnections = 3,
-        .keepOldKeys = 3,
+        .keepOldKeys = 4,
         .recoveryMembers = 3,
     },
 
@@ -197,7 +197,7 @@ static constexpr std::array<LLMQParams, 14> available_llmqs = {
         .signingActiveQuorumCount = 2, // just a few ones to allow easier testing
 
         .keepOldConnections = 3,
-        .keepOldKeys = 3,
+        .keepOldKeys = 4,
         .recoveryMembers = 3,
     },
 
@@ -275,7 +275,7 @@ static constexpr std::array<LLMQParams, 14> available_llmqs = {
         .signingActiveQuorumCount = 4, // just a few ones to allow easier testing
 
         .keepOldConnections = 5,
-        .keepOldKeys = 5,
+        .keepOldKeys = 8,
         .recoveryMembers = 6,
     },
 
@@ -353,7 +353,7 @@ static constexpr std::array<LLMQParams, 14> available_llmqs = {
 
         .signingActiveQuorumCount = 24, // a full day worth of LLMQs
         .keepOldConnections = 25,
-        .keepOldKeys = 25,
+        .keepOldKeys = 48,
         .recoveryMembers = 25,
     },
 
@@ -406,7 +406,7 @@ static constexpr std::array<LLMQParams, 14> available_llmqs = {
         .signingActiveQuorumCount = 4, // two days worth of LLMQs
 
         .keepOldConnections = 5,
-        .keepOldKeys = 5,
+        .keepOldKeys = 8,
         .recoveryMembers = 100,
     },
 
@@ -434,7 +434,7 @@ static constexpr std::array<LLMQParams, 14> available_llmqs = {
         .signingActiveQuorumCount = 4, // four days worth of LLMQs
 
         .keepOldConnections = 5,
-        .keepOldKeys = 5,
+        .keepOldKeys = 8,
         .recoveryMembers = 100,
     },
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
When DKG data recovery is triggered by `qgetdata` the data we use to construct `qdata` reply is actually the one handled by `CDKGSessionManager`, not by `CQuorumManager`. Not storing the data long enough in `CDKGSessionManager` will result in this data simply not being recoverable.

Also, the formula in `CDKGSessionManager::CleanupOldContributions()` is broken for quorums which use rotation (the depth is way too large).

## What was done?
Fix both issues by redefining `keepOldKeys` and aligning key storage depths in both modules.

## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

