### PR TITLE
perf: cache x11 block header hash, reduce reindex hashes from 4->2 per block

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -95,7 +95,7 @@ static CBlock FindDevNetGenesisBlock(const CBlock &prevBlock, const CAmount& rew
     for (uint32_t nNonce = 0; nNonce < UINT32_MAX; nNonce++) {
         block.nNonce = nNonce;
 
-        uint256 hash = block.GetHash();
+        uint256 hash = block.GetHash(/*use_cache=*/false);
         if (UintToArith256(hash) <= bnTarget)
             return block;
     }

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -12,10 +12,13 @@
 
 uint256 CBlockHeader::GetHash() const
 {
-    std::vector<unsigned char> vch(80);
-    CVectorWriter ss(SER_GETHASH, PROTOCOL_VERSION, vch, 0);
-    ss << *this;
-    return HashX11((const char *)vch.data(), (const char *)vch.data() + vch.size());
+    if (cached_hash.IsNull()) {
+        std::vector<unsigned char> vch(80);
+        CVectorWriter ss(SER_GETHASH, PROTOCOL_VERSION, vch, 0);
+        ss << *this;
+        cached_hash = HashX11((const char *)vch.data(), (const char *)vch.data() + vch.size());
+    }
+    return cached_hash;
 }
 
 std::string CBlock::ToString() const

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -10,9 +10,9 @@
 #include <streams.h>
 #include <tinyformat.h>
 
-uint256 CBlockHeader::GetHash() const
+uint256 CBlockHeader::GetHash(bool use_cache) const
 {
-    if (cached_hash.IsNull()) {
+    if (!use_cache || cached_hash.IsNull()) {
         std::vector<unsigned char> vch(80);
         CVectorWriter ss(SER_GETHASH, PROTOCOL_VERSION, vch, 0);
         ss << *this;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -60,7 +60,7 @@ public:
         return (nBits == 0);
     }
 
-    uint256 GetHash() const;
+    uint256 GetHash(bool use_cache = true) const;
 
     int64_t GetBlockTime() const
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -31,12 +31,18 @@ public:
     uint32_t nBits;
     uint32_t nNonce;
 
+    // Memory only cached hash as x11 is more expensive than sha256
+    mutable uint256 cached_hash;
+
     CBlockHeader()
     {
         SetNull();
     }
 
-    SERIALIZE_METHODS(CBlockHeader, obj) { READWRITE(obj.nVersion, obj.hashPrevBlock, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce); }
+    SERIALIZE_METHODS(CBlockHeader, obj) {
+        READWRITE(obj.nVersion, obj.hashPrevBlock, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce);
+        obj.cached_hash.SetNull();
+    }
 
     void SetNull()
     {
@@ -46,6 +52,7 @@ public:
         nTime = 0;
         nBits = 0;
         nNonce = 0;
+        cached_hash.SetNull();
     }
 
     bool IsNull() const
@@ -225,6 +232,7 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+        block.cached_hash    = cached_hash;
         return block;
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -131,7 +131,7 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
 
     const CChainParams& chainparams(Params());
 
-    while (max_tries > 0 && block.nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus()) && !ShutdownRequested()) {
+    while (max_tries > 0 && block.nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(block.GetHash(/*use_cache=*/false), block.nBits, chainparams.GetConsensus()) && !ShutdownRequested()) {
         ++block.nNonce;
         --max_tries;
     }

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -45,7 +45,7 @@ static CBlock BuildBlockTestCase() {
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHash(/*use_cache=*/false), block.nBits, Params().GetConsensus())) ++block.nNonce;
     return block;
 }
 
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHash(/*use_cache=*/false), block.nBits, Params().GetConsensus())) ++block.nNonce;
 
     // Test simple header round-trip with only coinbase
     {

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -83,7 +83,7 @@ CBlock BuildChainTestingSetup::CreateBlock(const CBlockIndex* prev,
         block.hashMerkleRoot = BlockMerkleRoot(block);
     }
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHash(/*use_cache=*/false), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     return block;
 }

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -594,7 +594,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
             // This will usually succeed in the first round as we take the nonce from BLOCKINFO
             // It's however useful when adding new blocks with unknown nonces (you should add the found block to BLOCKINFO)
-            while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, chainparams.GetConsensus())) {
+            while (!CheckProofOfWork(pblock->GetHash(/*use_cache=*/false), pblock->nBits, chainparams.GetConsensus())) {
                 pblock->nNonce++;
             }
         }

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -52,7 +52,7 @@ std::vector<std::shared_ptr<CBlock>> CreateBlockChain(size_t total_height, const
         block.nBits = params.GenesisBlock().nBits;
         block.nNonce = 0;
 
-        while (!CheckProofOfWork(block.GetHash(), block.nBits, params.GetConsensus())) {
+        while (!CheckProofOfWork(block.GetHash(/*use_cache=*/false), block.nBits, params.GetConsensus())) {
             ++block.nNonce;
             assert(block.nNonce);
         }
@@ -64,7 +64,7 @@ CTxIn MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
 {
     auto block = PrepareBlock(node, coinbase_scriptPubKey);
 
-    while (!CheckProofOfWork(block->GetHash(), block->nBits, Params().GetConsensus())) {
+    while (!CheckProofOfWork(block->GetHash(/*use_cache=*/false), block->nBits, Params().GetConsensus())) {
         ++block->nNonce;
         assert(block->nNonce);
     }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -560,7 +560,7 @@ CBlock TestChainSetup::CreateBlock(
         block.hashMerkleRoot = BlockMerkleRoot(block);
     }
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetHash(/*use_cache=*/false), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     CBlock result = block;
     return result;

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -92,7 +92,7 @@ std::shared_ptr<CBlock> MinerTestingSetup::FinalizeBlock(std::shared_ptr<CBlock>
 {
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
 
-    while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
+    while (!CheckProofOfWork(pblock->GetHash(/*use_cache=*/false), pblock->nBits, Params().GetConsensus())) {
         ++(pblock->nNonce);
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5143,6 +5143,8 @@ void CChainState::LoadExternalBlockFile(
                         blkdat.SetPos(nBlockPos);
                         std::shared_ptr<CBlock> pblock{std::make_shared<CBlock>()};
                         blkdat >> *pblock;
+                        // We calculated the hash of the header earlier, no need to recalculate it.
+                        pblock->cached_hash = hash;
                         nRewind = blkdat.GetPos();
 
                         BlockValidationState state;


### PR DESCRIPTION
## Issue being fixed or feature implemented
We currently hash the header up to 4 times per block we are loading from disk; drop this down to 2 times

before:
./src/dashd --printtoconsole --testnet --nowallet --reindex --stopatheight=1   76.34s user 6.15s system 95% cpu 1:25.98 total
![image](https://github.com/user-attachments/assets/5368e0f8-0a61-416a-936a-fa3744807f4c)

after:

./src/dashd --printtoconsole --testnet --nowallet --reindex --stopatheight=1   62.87s user 5.70s system 95% cpu 1:11.52 total
![image](https://github.com/user-attachments/assets/e1e6438d-50b9-4320-b51d-4224898806d4)

Shaves ~20-25% off of header reindex times.
Calculated as ((76.34-62.87)/76.34)=17.6%, but this includes the overhead of startup / shutdown, so it's likely higher.

## What was done?


## How Has This Been Tested?
Reindex headers; should probably do a full reindex

## Breaking Changes

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

