### PR TITLE
fix: intermittent error in p2p_invalid_block.py

### DIFF
--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -13,7 +13,6 @@ re-requested.
 becomes valid.
 """
 import copy
-import time
 
 from test_framework.blocktools import MAX_FUTURE_BLOCK_TIME, create_block, create_coinbase, create_tx_with_script
 from test_framework.messages import COIN
@@ -132,15 +131,14 @@ class InvalidBlockRequestTest(BitcoinTestFramework):
         peer.send_blocks_and_test([block4], node, success=False,  reject_reason='bad-txns-inputs-duplicate')
 
         self.log.info("Test accepting identical block after rejecting it due to a future timestamp.")
-        t = int(time.time())
-        node.setmocktime(t)
+        t = self.mocktime
         # Set block time +1 second past max future validity
         block = create_block(tip, create_coinbase(height), t + MAX_FUTURE_BLOCK_TIME + 1)
         block.hashMerkleRoot = block.calc_merkle_root()
         block.solve()
         # Need force_send because the block will get rejected without a getdata otherwise
         peer.send_blocks_and_test([block], node, force_send=True, success=False, reject_reason='time-too-new')
-        node.setmocktime(t + 1)
+        self.bump_mocktime(1)
         peer.send_blocks_and_test([block], node, success=True)
 
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash/issues/6694

    2025-06-03T12:14:23.400000Z TestFramework (ERROR): Assertion failed
    Traceback (most recent call last):
      File "DASH/test/functional/test_framework/test_framework.py", line 162, in main
        self.run_test()
      File "DASH/test/functional/p2p_invalid_block.py", line 142, in run_test
        peer.send_blocks_and_test([block], node, force_send=True, success=False, reject_reason='time-too-new')
      File "DASH/test/functional/test_framework/p2p.py", line 936, in send_blocks_and_test
        self.sync_with_ping()
      File "DASH/test/functional/test_framework/p2p.py", line 744, in sync_with_ping
        self.wait_until(test_function, timeout=timeout)
      File "DASH/test/functional/test_framework/p2p.py", line 625, in wait_until
        wait_until_helper(test_function, timeout=timeout, lock=p2p_lock, timeout_factor=self.timeout_factor)
      File "DASH/test/functional/test_framework/util.py", line 269, in wait_until_helper
        if predicate():
           ^^^^^^^^^^^
      File "DASH/test/functional/test_framework/p2p.py", line 622, in test_function
        assert self.is_connected
               ^^^^^^^^^^^^^^^^^
    AssertionError
    2025-06-03T12:14:23.902000Z TestFramework (INFO): Stopping nodes

## What was done?
Mocktime here is misused here `t = int(time.time())`
Use instead helper `bump_mocktime` and current mocktime as `self.mocktime`



## How Has This Been Tested?
Run multiple times locally

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone