### PR TITLE
fix: resolve compile error due to change in function arguments

### DIFF
--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -925,7 +925,7 @@ BOOST_AUTO_TEST_CASE(minimum_inputs_test)
     wallet->LoadWallet();
     LOCK(wallet->cs_wallet);
     wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
-    wallet->SetupDescriptorScriptPubKeyMans();
+    wallet->SetupDescriptorScriptPubKeyMans("", "");
 
     // Create coins (denominations) for a target that can be met without consuming all the coins
     std::vector<COutput> coins{};


### PR DESCRIPTION
## Additional Information

[dash#6570](https://github.com/dashpay/dash/pull/6570) and [dash#6755](https://github.com/dashpay/dash/pull/6755) were merged into `develop` in that order, neither conflicting with the other. Unfortunately, as [dash#6570](https://github.com/dashpay/dash/pull/6570) updated the arguments list for `SetupDescriptorScriptPubKeyMans()`, [dash#6755](https://github.com/dashpay/dash/pull/6755) introduced new usage based on the older argument list and as it was new code, it was not registered as a conflict but has caused `develop` to fail ([build](https://github.com/dashpay/dash/actions/runs/16336328705)).

This pull request remedies that issue.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
