### PR TITLE
refactor: follow-up for bitcoin#27902 and #23201 to remove segwit related code

### DIFF
--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -129,23 +129,6 @@ public:
         vOutpoints.assign(setSelected.begin(), setSelected.end());
     }
 
-    void SetInputWeight(const COutPoint& outpoint, int64_t weight)
-    {
-        m_input_weights[outpoint] = weight;
-    }
-
-    bool HasInputWeight(const COutPoint& outpoint) const
-    {
-        return m_input_weights.count(outpoint) > 0;
-    }
-
-    int64_t GetInputWeight(const COutPoint& outpoint) const
-    {
-        auto it = m_input_weights.find(outpoint);
-        assert(it != m_input_weights.end());
-        return it->second;
-    }
-
     // Dash-specific helpers
     void UseCoinJoin(bool fUseCoinJoin)
     {
@@ -160,8 +143,6 @@ public:
 private:
     std::set<COutPoint> setSelected;
     std::map<COutPoint, CTxOut> m_external_txouts;
-    //! Map of COutPoints to the maximum weight for that input
-    std::map<COutPoint, int64_t> m_input_weights;
 };
 } // namespace wallet
 

--- a/src/wallet/test/fuzz/coincontrol.cpp
+++ b/src/wallet/test/fuzz/coincontrol.cpp
@@ -72,16 +72,6 @@ FUZZ_TARGET(coincontrol, .init = initialize_coincontrol)
             [&] {
                 std::vector<COutPoint> selected;
                 coin_control.ListSelected(selected);
-            },
-            [&] {
-                int64_t weight{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
-                (void)coin_control.SetInputWeight(out_point, weight);
-            },
-            [&] {
-                // Condition to avoid the assertion in GetInputWeight
-                if (coin_control.HasInputWeight(out_point)) {
-                    (void)coin_control.GetInputWeight(out_point);
-                }
             });
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
We use size of transaction instead weight.

Having leftover helpers `HasInputWeight` and `GetInputWeight` could provoke an error in the future, if some new (especially backported) code will use it.

If these helpers doesn't exist, freshly backported code will just get a compilation error -> a developer have a clear signal to replace "weight" to "size". Otherwise it maybe skipped and some "mock" interface used instead.

## What was done?
Removed map `m_input_weights` and related setter, getter and fuzz test.

## How Has This Been Tested?
Dash Core built successfully.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone