### PR TITLE
test: reduce delays in p2p_quorum_data.py

### DIFF
--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -65,7 +65,7 @@ def wait_for_banscore(node, peer_id, expected_score):
                     # The score matches the one we expected.
                     # Wait a bit to make sure it won't change
                     # to avoid false positives.
-                    time.sleep(1)
+                    time.sleep(0.1)
                 return peer["banscore"]
         return None
     wait_until_helper(lambda: get_score() == expected_score, timeout=6)


### PR DESCRIPTION
## Issue being fixed or feature implemented
There's a lot of waiting by calls `sleep(1)`

## What was done?
1. removed useless calls of sleep(1) between steps of testing.
2. extra delay to catch false-positive is reduced from 1 second to just 0.1

Motivation for (2):

Firstly, current p2p implementation for `qdata` message is sync, there's no any async workers, it's just directly called:

        ProcessPeerMsgRet(m_llmq_ctx->qman->ProcessMessage(pfrom, m_connman, msg_type, vRecv), pfrom);

So, p2p bans for `qdata` does not really requires to wait 1 second to be processed once message is received and responded.

Secondly, there are chains of calls `wait_for_banscore` for the same connection between nodes and in the rare (probably impossible) cases when 1st call will be false-positive, the node will get extra ban score for 2nd consequent call of `wait_for_banscore`.

            wait_for_banscore(mn2.get_node(self), id_p2p_mn2, 0)
            wait_for_banscore(mn2.get_node(self), id_p2p_mn2, 10)
            <reconnecting...>
            wait_for_banscore(mn2.get_node(self), id_p2p_mn2, 0)
            wait_for_banscore(mn2.get_node(self), id_p2p_mn2, 25)
            wait_for_banscore(mn2.get_node(self), id_p2p_mn2, 50)



## How Has This Been Tested?
Median runtime on 20 runs is reduced from 141seconds to just 59seconds.

## Breaking Changes
 N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
