### PR TITLE
llmq/signing_shares: guard quorumMember indexing with Assume() to avoid OOB writes; improve ToInvString() safety

### DIFF
--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -17,8 +17,8 @@
 #include <net_processing.h>
 #include <netmessagemaker.h>
 #include <spork.h>
-#include <util/irange.h>
 #include <util/check.h>
+#include <util/irange.h>
 #include <util/thread.h>
 #include <util/time.h>
 #include <util/underlying.h>


### PR DESCRIPTION
## Issue being fixed or feature implemented
Avoid potentially undefined behavior in llmq logic by using Assume to crash in debug, and skip in release

## What was done?
  _Describe your changes in detail_


## How Has This Been Tested?
  _Please describe in detail how you tested your changes._

  _Include details of your testing environment, and the tests you ran
to see how your change affects other areas of the code, etc._


## Breaking Changes
  _Please describe any breaking changes your code introduces_


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

