### PR TITLE
fix: compilation error with newer clang-20

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -453,6 +453,15 @@ if test "$enable_werror" = "yes"; then
   fi
   ERROR_CXXFLAGS=$CXXFLAG_WERROR
 
+  dnl -Wdeprecated-literal-operator cause problems with clang 20. Do not treat these warnings as errors.
+  dnl TODO: remove it once we update hana
+  AX_CHECK_COMPILE_FLAG([-Wdeprecated-literal-operator], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-error=deprecated-literal-operator"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
+    #if !defined(__clang__) || defined(__INTEL_COMPILER)
+      #error Non-clang compiler detected, not setting flag
+    #endif
+    int main(void) { return 0; }
+  ])])
+
   dnl -Wattributes cause problems with some versions of GCC. Do not treat these warnings as errors.
   AX_CHECK_COMPILE_FLAG([-Wattributes], [NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-error=attributes"], [], [$CXXFLAG_WERROR], [AC_LANG_SOURCE([
     #if defined(__clang__) || defined(__INTEL_COMPILER) || !defined(__GNUC__)


### PR DESCRIPTION
## Issue being fixed or feature implemented

`hana` still uses spaces before literal operator, while newer clang enforces C++23 requirement

    In file included from ./evo/dmnstate.h:19:
    In file included from DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/for_each.hpp:15:
    In file included from DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/concept/foldable.hpp:19:
    In file included from DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/fold_left.hpp:20:
    In file included from DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/unpack.hpp:16:
    In file included from DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/at.hpp:16:
    In file included from DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/concept/iterable.hpp:20:
    In file included from DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/drop_front.hpp:20:
    In file included from DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/integral_constant.hpp:13:
    DASH/depends/x86_64-pc-linux-gnu/include/boost/hana/bool.hpp:198:35: error: identifier '_c' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
      198 |         constexpr auto operator"" _c() {
          |                        ~~~~~~~~~~~^~
          |                        operator""_c


## What was done?
Adds `-Wno-error=deprecated-literal-operator` for clang

## How Has This Been Tested?
Build locally successfully

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
