### PR TITLE
revert: Revert "merge bitcoin-core/gui#835: Fix crash when closing wallet"

### DIFF
--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -79,9 +79,6 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_load_wallet;
 
     friend class WalletControllerActivity;
-
-    //! Starts the wallet closure procedure
-    void removeWallet(WalletModel* wallet_model);
 };
 
 class WalletControllerActivity : public QObject


### PR DESCRIPTION
## Issue being fixed or feature implemented
This reverts commit 20763f1101484fa1bbaa46c6aa9b3aa7766c11b2 from #6829.

The issue that was meant to be fixed by that backport does not exist in our codebase yet, see https://github.com/bitcoin-core/gui/pull/835#pullrequestreview-2302703900. Even worse, backporting it too early created an issue where wallets would not be removed from gui while being removed in background.

## What was done?
revert it

## How Has This Been Tested?
open multiple wallets, try closing one of them.

develop: no visual changes, feels like "Close wallet" menu is not working but wallet is actually removed which can be confirmed by restarting qt
this PR/previous behaviour: wallet is actually gone from ui asap

## Breaking Changes
n/a


## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

