### PR TITLE
feat: do not send any governance objects to old (pre-GOVSCRIPT_PROTO_VERSION) p2p clients

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -984,6 +984,12 @@ MessageProcessingResult CGovernanceManager::SyncObjects(CNode& peer, CConnman& c
     }
     m_netfulfilledman.AddFulfilledRequest(peer.addr, NetMsgType::MNGOVERNANCESYNC);
 
+    if (peer.nVersion < GOVSCRIPT_PROTO_VERSION) {
+        LogPrintf("CGovernanceManager::%s -- peer=%d does not support p2sh govobj, skipping sync\n", __func__,
+                  peer.GetId());
+        return {};
+    }
+
     // SYNC GOVERNANCE OBJECTS WITH OTHER CLIENT
 
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s -- syncing all objects to peer=%d\n", __func__, peer.GetId());
@@ -1003,19 +1009,6 @@ MessageProcessingResult CGovernanceManager::SyncObjects(CNode& peer, CConnman& c
             LogPrint(BCLog::GOBJECT, "CGovernanceManager::%s -- not syncing deleted/expired govobj: %s, peer=%d\n", __func__,
                 strHash, peer.GetId());
             continue;
-        }
-
-        if (peer.nVersion < GOVSCRIPT_PROTO_VERSION && govobj.GetObjectType() == GovernanceObject::PROPOSAL) {
-            // We know this proposal is valid locally, otherwise we would not store it.
-            // But we don't want to relay it to pre-GOVSCRIPT_PROTO_VERSION peers if payment_address is p2sh
-            // because they won't accept it anyway and will simply ban us eventually.
-            CProposalValidator validator(govobj.GetDataAsHexString(), false /* no script */);
-            if (!validator.Validate(false /* ignore expiration */)) {
-                // The only way we could get here is when proposal is valid but payment_address is actually p2sh.
-                LogPrintf("CGovernanceManager::%s -- not syncing p2sh govobj to older node: %s, peer=%d\n", __func__,
-                    strHash, peer.GetId());
-                continue;
-            }
         }
 
         // Push the inventory budget proposal message over to the other client

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -602,21 +602,11 @@ void CGovernanceObject::Relay(PeerManager& peerman, const CMasternodeSync& mn_sy
         return;
     }
 
-    int minProtoVersion = MIN_PEER_PROTO_VERSION;
-    if (m_obj.type == GovernanceObject::PROPOSAL) {
-        // We know this proposal is valid locally, otherwise we would not get to the point we should relay it.
-        // But we don't want to relay it to pre-GOVSCRIPT_PROTO_VERSION peers if payment_address is p2sh
-        // because they won't accept it anyway and will simply ban us eventually.
-        CProposalValidator validator(GetDataAsHexString(), false /* no script */);
-        if (!validator.Validate(false /* ignore expiration */)) {
-            // The only way we could get here is when proposal is valid but payment_address is actually p2sh.
-            LogPrint(BCLog::GOBJECT, "CGovernanceObject::Relay -- won't relay %s to older peers\n", GetHash().ToString());
-            minProtoVersion = GOVSCRIPT_PROTO_VERSION;
-        }
-    }
-
     CInv inv(MSG_GOVERNANCE_OBJECT, GetHash());
-    peerman.RelayInv(inv, minProtoVersion);
+
+    // We don't want to relay it to pre-GOVSCRIPT_PROTO_VERSION peers to avoid inconsistency
+    // because they won't accept p2sh payment_address anyway and will simply ban us eventually.
+    peerman.RelayInv(inv, GOVSCRIPT_PROTO_VERSION);
 }
 
 void CGovernanceObject::UpdateSentinelVariables(const CDeterministicMNList& tip_mn_list)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Alternate solution to https://github.com/dashpay/dash/pull/6877 and unblock https://github.com/dashpay/dash/pull/6838

## What was done?
Old pre-GOVSCRIPT_PROTO_VERSION p2p clients can not accept governance objects with p2sh payment_addresses anyway.
To avoid inconsistency, do not send _any_ governance object to them.


## How Has This Been Tested?
Run unit & functional tests.


## Breaking Changes
P2p clients with version below GOVSCRIPT_PROTO_VERSION won't receive *any* governance object, not only governance objects with p2sh payment_address.
They are broken now anyway because receive only _some_ governance proposals and it helps to avoid data inconsistency.



## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone