### PR TITLE
guix: avoid downloading macOS SDK for non-darwin target HOSTs

### DIFF
--- a/contrib/containers/guix/scripts/guix-start
+++ b/contrib/containers/guix/scripts/guix-start
@@ -9,10 +9,12 @@ if [[ ! -d "${WORKSPACE_PATH}" || ! "${WORKSPACE_PATH}" = /* || ! -f "${WORKSPAC
     exit 1
 fi
 
-export SDK_PATH="${SDK_PATH:-${WORKSPACE_PATH}/depends/SDKs}"
-export SDK_SRCS="${SDK_PATH:-${WORKSPACE_PATH}/depends/sdk-sources}"
+if [[ -z "${HOSTS}" || "${HOSTS}" == *"darwin"* ]]; then
+    export SDK_PATH="${SDK_PATH:-${WORKSPACE_PATH}/depends/SDKs}"
+    export SDK_SRCS="${SDK_PATH:-${WORKSPACE_PATH}/depends/sdk-sources}"
 
-./contrib/containers/guix/scripts/setup-sdk
+    ./contrib/containers/guix/scripts/setup-sdk
+fi
 
 # Add safe.directory option only when WORKSPACE_PATH was specified via cmd-line arguments (happens in CI)
 if [[ -n "${1}" ]]; then


### PR DESCRIPTION
## Issue being fixed or feature implemented
Save some time/bandwidth for non-darwin HOSTs.

See windows build as an example:
develop: https://github.com/UdjinM6/dash/actions/runs/18493165708/job/52692931975#step:7:78
this PR: https://github.com/UdjinM6/dash/actions/runs/18494088428/job/52720349586#step:7:76

## What was done?


## How Has This Been Tested?
https://github.com/UdjinM6/dash/actions/runs/18494088428


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

