### PR TITLE
refactor: drop dependency of spork on net_processing

### DIFF
--- a/src/spork.h
+++ b/src/spork.h
@@ -25,7 +25,6 @@ template<typename T>
 class CFlatDB;
 class CNode;
 class CDataStream;
-class PeerManager;
 
 class CSporkMessage;
 class CSporkManager;
@@ -151,11 +150,6 @@ public:
      * in order to identify which spork key signed this message.
      */
     std::optional<CKeyID> GetSignerKeyID() const;
-
-    /**
-     * Relay is used to send this spork message to other peers.
-     */
-    void Relay(PeerManager& peerman) const;
 };
 
 class SporkStore
@@ -278,9 +272,10 @@ public:
 
     /**
      * UpdateSpork is used by the spork RPC command to set a new spork value, sign
-     * and broadcast the spork message.
+     * and return the spork message, ready for network relay.
+     * It returns nullopt if nothing to relay
      */
-    bool UpdateSpork(PeerManager& peerman, SporkId nSporkID, SporkValue nValue) EXCLUSIVE_LOCKS_REQUIRED(!cs, !cs_cache);
+    std::optional<CInv> UpdateSpork(SporkId nSporkID, SporkValue nValue) EXCLUSIVE_LOCKS_REQUIRED(!cs, !cs_cache);
 
     /**
      * IsSporkActive returns a bool for time-based sporks, and should be used

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -67,7 +67,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "llmq/signing_shares -> net_processing -> llmq/signing_shares",
     "masternode/payments -> validation -> masternode/payments",
     "net -> netmessagemaker -> net",
-    "net_processing -> spork -> net_processing",
     "netaddress -> netbase -> netaddress",
     "qt/appearancewidget -> qt/guiutil -> qt/appearancewidget",
     "qt/bitcoinaddressvalidator -> qt/guiutil -> qt/bitcoinaddressvalidator",


### PR DESCRIPTION
## Issue being fixed or feature implemented
Dependency of Spork on PeerManager (net_processing) is a blocker for kernel / chainstate project.

## What was done?
Removed dependency of Spork on PeerManager by moving network code to rpc/node

## How Has This Been Tested?
Run test/lint/lint-circular-dependencies.py

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

