### PR TITLE
perf: improve islock / llmq signing latency

### DIFF
--- a/src/bls/bls_batchverifier.h
+++ b/src/bls/bls_batchverifier.h
@@ -82,27 +82,27 @@ public:
         }
 
         // revert to per-source verification
-        for (const auto& p : messagesBySource) {
+        for (const auto& [from, message_map] : messagesBySource) {
             bool batchValid = false;
 
             // no need to verify it again if there was just one source
             if (messagesBySource.size() != 1) {
                 byMessageHash.clear();
-                for (auto it = p.second.begin(); it != p.second.end(); ++it) {
+                for (auto it = message_map.begin(); it != message_map.end(); ++it) {
                     byMessageHash[(*it)->second.msgHash].emplace_back(*it);
                 }
                 batchValid = VerifyBatch(byMessageHash);
             }
             if (!batchValid) {
-                badSources.emplace(p.first);
+                badSources.emplace(from);
 
                 if (perMessageFallback) {
                     // revert to per-message verification
-                    if (p.second.size() == 1) {
+                    if (message_map.size() == 1) {
                         // no need to re-verify a single message
-                        badMessages.emplace(p.second[0]->second.msgId);
+                        badMessages.emplace(message_map[0]->second.msgId);
                     } else {
-                        for (const auto& msgIt : p.second) {
+                        for (const auto& msgIt : message_map) {
                             if (badMessages.count(msgIt->first)) {
                                 // same message might be invalid from different source, so no need to re-verify it
                                 continue;

--- a/src/chainlock/chainlock.cpp
+++ b/src/chainlock/chainlock.cpp
@@ -217,6 +217,12 @@ void CChainLocksHandler::AcceptedBlockHeader(gsl::not_null<const CBlockIndex*> p
 
 void CChainLocksHandler::UpdatedBlockTip(const llmq::CInstantSendManager& isman)
 {
+    // Update the cached tip in the signer before scheduling
+    const CBlockIndex* pindexNew = WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
+    if (auto signer = m_signer.load(std::memory_order_acquire); signer && pindexNew) {
+        signer->UpdatedBlockTip(pindexNew);
+    }
+
     // don't call TrySignChainTip directly but instead let the scheduler call it. This way we ensure that cs_main is
     // never locked and TrySignChainTip is not called twice in parallel. Also avoids recursive calls due to
     // EnforceBestChainLock switching chains.

--- a/src/chainlock/signing.cpp
+++ b/src/chainlock/signing.cpp
@@ -26,6 +26,9 @@ ChainLockSigner::ChainLockSigner(CChainState& chainstate, ChainLockSignerParent&
     m_sporkman{sporkman},
     m_mn_sync{mn_sync}
 {
+    // Initialize cached tip pointer
+    LOCK(::cs_main);
+    m_cached_tip.store(m_chainstate.m_chain.Tip(), std::memory_order_release);
 }
 
 ChainLockSigner::~ChainLockSigner() = default;
@@ -38,6 +41,11 @@ void ChainLockSigner::Start()
 void ChainLockSigner::Stop()
 {
     m_sigman.UnregisterRecoveredSigsListener(this);
+}
+
+void ChainLockSigner::UpdatedBlockTip(const CBlockIndex* pindexNew)
+{
+    m_cached_tip.store(pindexNew, std::memory_order_release);
 }
 
 void ChainLockSigner::TrySignChainTip(const llmq::CInstantSendManager& isman)
@@ -55,7 +63,7 @@ void ChainLockSigner::TrySignChainTip(const llmq::CInstantSendManager& isman)
         return;
     }
 
-    const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
+    const CBlockIndex* pindex = m_cached_tip.load(std::memory_order_acquire);
 
     if (!pindex || !pindex->pprev) {
         return;

--- a/src/chainlock/signing.h
+++ b/src/chainlock/signing.h
@@ -8,6 +8,7 @@
 #include <chainlock/clsig.h>
 #include <llmq/signing.h>
 
+class CBlockIndex;
 class CMasternodeSync;
 class CSporkManager;
 struct MessageProcessingResult;
@@ -62,6 +63,9 @@ private:
     uint256 lastSignedRequestId GUARDED_BY(cs_signer);
     uint256 lastSignedMsgHash GUARDED_BY(cs_signer);
 
+    // Cached tip pointer to avoid cs_main acquisition in TrySignChainTip
+    std::atomic<const CBlockIndex*> m_cached_tip{nullptr};
+
 public:
     ChainLockSigner() = delete;
     ChainLockSigner(const ChainLockSigner&) = delete;
@@ -72,6 +76,8 @@ public:
 
     void Start();
     void Stop();
+
+    void UpdatedBlockTip(const CBlockIndex* pindexNew);
 
     void EraseFromBlockHashTxidMap(const uint256& hash)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -168,7 +168,7 @@ MessageProcessingResult CInstantSendManager::ProcessMessage(NodeId from, std::st
     }
 
     LOCK(cs_pendingLocks);
-    pendingInstantSendLocks.emplace(hash, std::make_pair(from, islock));
+    pendingInstantSendLocks.emplace(hash, instantsend::PendingISLockFromPeer{from, islock});
     NotifyWorker();
     return ret;
 }
@@ -240,7 +240,7 @@ instantsend::PendingState CInstantSendManager::ProcessPendingInstantSendLocks()
 
 Uint256HashSet CInstantSendManager::ProcessPendingInstantSendLocks(
     const Consensus::LLMQParams& llmq_params, int signOffset, bool ban,
-    const Uint256HashMap<std::pair<NodeId, instantsend::InstantSendLockPtr>>& pend,
+    const Uint256HashMap<instantsend::PendingISLockFromPeer>& pend,
     std::vector<std::pair<NodeId, MessageProcessingResult>>& peer_activity)
 {
     CBLSBatchVerifier<NodeId, uint256> batchVerifier(false, true, 8);
@@ -250,8 +250,8 @@ Uint256HashSet CInstantSendManager::ProcessPendingInstantSendLocks(
     size_t alreadyVerified = 0;
     for (const auto& p : pend) {
         const auto& hash = p.first;
-        auto nodeId = p.second.first;
-        const auto& islock = p.second.second;
+        auto nodeId = p.second.node_id;
+        const auto& islock = p.second.islock;
 
         if (batchVerifier.badSources.count(nodeId)) {
             continue;
@@ -322,8 +322,8 @@ Uint256HashSet CInstantSendManager::ProcessPendingInstantSendLocks(
     }
     for (const auto& p : pend) {
         const auto& hash = p.first;
-        auto nodeId = p.second.first;
-        const auto& islock = p.second.second;
+        auto nodeId = p.second.node_id;
+        const auto& islock = p.second.islock;
 
         if (batchVerifier.badMessages.count(hash)) {
             LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s: invalid sig in islock, peer=%d\n",
@@ -400,7 +400,7 @@ MessageProcessingResult CInstantSendManager::ProcessInstantSendLock(NodeId from,
     } else {
         // put it in a separate pending map and try again later
         LOCK(cs_pendingLocks);
-        pendingNoTxInstantSendLocks.try_emplace(hash, std::make_pair(from, islock));
+        pendingNoTxInstantSendLocks.try_emplace(hash, instantsend::PendingISLockFromPeer{from, islock});
     }
 
     // This will also add children TXs to pendingRetryTxs
@@ -443,11 +443,11 @@ void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
         LOCK(cs_pendingLocks);
         auto it = pendingNoTxInstantSendLocks.begin();
         while (it != pendingNoTxInstantSendLocks.end()) {
-            if (it->second.second->txid == tx->GetHash()) {
+            if (it->second.islock->txid == tx->GetHash()) {
                 // we received an islock earlier
                 LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
                          tx->GetHash().ToString(), it->first.ToString());
-                islock = it->second.second;
+                islock = it->second.islock;
                 pendingInstantSendLocks.try_emplace(it->first, it->second);
                 pendingNoTxInstantSendLocks.erase(it);
                 break;
@@ -544,7 +544,7 @@ void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlock
         LOCK(cs_pendingLocks);
         auto it = pendingNoTxInstantSendLocks.begin();
         while (it != pendingNoTxInstantSendLocks.end()) {
-            if (it->second.second->txid == tx->GetHash()) {
+            if (it->second.islock->txid == tx->GetHash()) {
                 // we received an islock earlier, let's put it back into pending and verify/lock
                 LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
                          tx->GetHash().ToString(), it->first.ToString());
@@ -634,7 +634,7 @@ void CInstantSendManager::TryEmplacePendingLock(const uint256& hash, const NodeI
     if (db.KnownInstantSendLock(hash)) return;
     LOCK(cs_pendingLocks);
     if (!pendingInstantSendLocks.count(hash)) {
-        pendingInstantSendLocks.emplace(hash, std::make_pair(id, islock));
+        pendingInstantSendLocks.emplace(hash, instantsend::PendingISLockFromPeer{id, islock});
     }
     NotifyWorker();
 }
@@ -859,11 +859,11 @@ bool CInstantSendManager::GetInstantSendLockByHash(const uint256& hash, instants
         LOCK(cs_pendingLocks);
         auto it = pendingInstantSendLocks.find(hash);
         if (it != pendingInstantSendLocks.end()) {
-            islock = it->second.second;
+            islock = it->second.islock;
         } else {
             auto itNoTx = pendingNoTxInstantSendLocks.find(hash);
             if (itNoTx != pendingNoTxInstantSendLocks.end()) {
-                islock = itNoTx->second.second;
+                islock = itNoTx->second.islock;
             } else {
                 return false;
             }
@@ -900,7 +900,7 @@ bool CInstantSendManager::IsWaitingForTx(const uint256& txHash) const
     LOCK(cs_pendingLocks);
     auto it = pendingNoTxInstantSendLocks.begin();
     while (it != pendingNoTxInstantSendLocks.end()) {
-        if (it->second.second->txid == txHash) {
+        if (it->second.islock->txid == txHash) {
             LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__, txHash.ToString(),
                      it->first.ToString());
             return true;

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -175,7 +175,7 @@ MessageProcessingResult CInstantSendManager::ProcessMessage(NodeId from, std::st
 
 instantsend::PendingState CInstantSendManager::ProcessPendingInstantSendLocks()
 {
-    decltype(pendingInstantSendLocks) pend;
+    std::vector<std::pair<uint256, instantsend::PendingISLockFromPeer>> pend;
     instantsend::PendingState ret;
 
     if (!IsInstantSendEnabled()) {
@@ -190,6 +190,7 @@ instantsend::PendingState CInstantSendManager::ProcessPendingInstantSendLocks()
         // The keys of the removed values are temporaily stored here to avoid invalidating an iterator
         std::vector<uint256> removed;
         removed.reserve(maxCount);
+        pend.reserve(maxCount);
 
         for (const auto& [islockHash, nodeid_islptr_pair] : pendingInstantSendLocks) {
             // Check if we've reached max count
@@ -197,7 +198,7 @@ instantsend::PendingState CInstantSendManager::ProcessPendingInstantSendLocks()
                 ret.m_pending_work = true;
                 break;
             }
-            pend.emplace(islockHash, std::move(nodeid_islptr_pair));
+            pend.emplace_back(islockHash, std::move(nodeid_islptr_pair));
             removed.emplace_back(islockHash);
         }
 
@@ -223,16 +224,17 @@ instantsend::PendingState CInstantSendManager::ProcessPendingInstantSendLocks()
     if (!badISLocks.empty()) {
         LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- doing verification on old active set\n", __func__);
 
-        // filter out valid IS locks from "pend"
-        for (auto it = pend.begin(); it != pend.end();) {
-            if (!badISLocks.count(it->first)) {
-                it = pend.erase(it);
-            } else {
-                ++it;
+        // filter out valid IS locks from "pend" - keep only bad ones
+        std::vector<std::pair<uint256, instantsend::PendingISLockFromPeer>> filteredPend;
+        filteredPend.reserve(badISLocks.size());
+        for (auto& p : pend) {
+            if (badISLocks.contains(p.first)) {
+                filteredPend.push_back(std::move(p));
             }
         }
+        
         // Now check against the previous active set and perform banning if this fails
-        ProcessPendingInstantSendLocks(llmq_params, dkgInterval, /*ban=*/true, pend, ret.m_peer_activity);
+        ProcessPendingInstantSendLocks(llmq_params, dkgInterval, /*ban=*/true, filteredPend, ret.m_peer_activity);
     }
 
     return ret;
@@ -240,7 +242,7 @@ instantsend::PendingState CInstantSendManager::ProcessPendingInstantSendLocks()
 
 Uint256HashSet CInstantSendManager::ProcessPendingInstantSendLocks(
     const Consensus::LLMQParams& llmq_params, int signOffset, bool ban,
-    const Uint256HashMap<instantsend::PendingISLockFromPeer>& pend,
+    const std::vector<std::pair<uint256, instantsend::PendingISLockFromPeer>>& pend,
     std::vector<std::pair<NodeId, MessageProcessingResult>>& peer_activity)
 {
     CBLSBatchVerifier<NodeId, uint256> batchVerifier(false, true, 8);

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -169,6 +169,7 @@ MessageProcessingResult CInstantSendManager::ProcessMessage(NodeId from, std::st
 
     LOCK(cs_pendingLocks);
     pendingInstantSendLocks.emplace(hash, std::make_pair(from, islock));
+    NotifyWorker();
     return ret;
 }
 
@@ -464,6 +465,7 @@ void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
     } else {
         RemoveMempoolConflictsForLock(::SerializeHash(*islock), *islock);
     }
+    NotifyWorker();
 }
 
 void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& tx)
@@ -481,6 +483,7 @@ void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& t
     LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- transaction %s was removed from mempool\n", __func__,
              tx->GetHash().ToString());
     RemoveConflictingLock(::SerializeHash(*islock), *islock);
+    NotifyWorker();
 }
 
 void CInstantSendManager::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
@@ -511,12 +514,14 @@ void CInstantSendManager::BlockConnected(const std::shared_ptr<const CBlock>& pb
     }
 
     db.WriteBlockInstantSendLocks(pblock, pindex);
+    NotifyWorker();
 }
 
 void CInstantSendManager::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock,
                                             const CBlockIndex* pindexDisconnected)
 {
     db.RemoveBlockInstantSendLocks(pblock, pindexDisconnected);
+    NotifyWorker();
 }
 
 void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlockIndex* pindexMined)
@@ -559,6 +564,7 @@ void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlock
 
     LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, pindexMined=%s\n", __func__,
              tx->GetHash().ToString(), pindexMined ? pindexMined->GetBlockHash().ToString() : "");
+    NotifyWorker();
 }
 
 void CInstantSendManager::RemoveNonLockedTx(const uint256& txid, bool retryChildren)
@@ -599,6 +605,7 @@ void CInstantSendManager::RemoveNonLockedTx(const uint256& txid, bool retryChild
 
     LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, retryChildren=%d, retryChildrenCount=%d\n",
              __func__, txid.ToString(), retryChildren, retryChildrenCount);
+    NotifyWorker();
 }
 
 void CInstantSendManager::RemoveConflictedTx(const CTransaction& tx)
@@ -607,6 +614,7 @@ void CInstantSendManager::RemoveConflictedTx(const CTransaction& tx)
     if (auto signer = m_signer.load(std::memory_order_acquire); signer) {
         signer->ClearInputsFromQueue(GetIdsFromLockable(tx.vin));
     }
+    NotifyWorker();
 }
 
 void CInstantSendManager::TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock)
@@ -628,11 +636,13 @@ void CInstantSendManager::TryEmplacePendingLock(const uint256& hash, const NodeI
     if (!pendingInstantSendLocks.count(hash)) {
         pendingInstantSendLocks.emplace(hash, std::make_pair(id, islock));
     }
+    NotifyWorker();
 }
 
 void CInstantSendManager::NotifyChainLock(const CBlockIndex* pindexChainLock)
 {
     HandleFullyConfirmedBlock(pindexChainLock);
+    NotifyWorker();
 }
 
 void CInstantSendManager::UpdatedBlockTip(const CBlockIndex* pindexNew)
@@ -650,6 +660,7 @@ void CInstantSendManager::UpdatedBlockTip(const CBlockIndex* pindexNew)
     if (pindex) {
         HandleFullyConfirmedBlock(pindex);
     }
+    NotifyWorker();
 }
 
 void CInstantSendManager::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
@@ -926,6 +937,7 @@ size_t CInstantSendManager::GetInstantSendLockCount() const
 void CInstantSendManager::WorkThreadMain(PeerManager& peerman)
 {
     while (!workInterrupt) {
+        uint64_t startEpoch = workEpoch.load(std::memory_order_acquire);
         bool fMoreWork = [&]() -> bool {
             if (!IsInstantSendEnabled()) return false;
             auto [more_work, peer_activity] = ProcessPendingInstantSendLocks();
@@ -953,10 +965,11 @@ void CInstantSendManager::WorkThreadMain(PeerManager& peerman)
             signer->ProcessPendingRetryLockTxs(txns);
             return more_work;
         }();
-
-        if (!fMoreWork && !workInterrupt.sleep_for(std::chrono::milliseconds(100))) {
-            return;
-        }
+        if (fMoreWork) continue;
+        std::unique_lock<Mutex> l(workMutex);
+        workCv.wait(l, [this, startEpoch]{
+            return bool(workInterrupt) || workEpoch.load(std::memory_order_acquire) != startEpoch;
+        });
     }
 }
 

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -38,6 +38,11 @@ struct DbWrapperParams;
 namespace instantsend {
 class InstantSendSigner;
 
+struct PendingISLockFromPeer {
+    NodeId node_id;
+    InstantSendLockPtr islock;
+};
+
 struct PendingState {
     bool m_pending_work{false};
     std::vector<std::pair<NodeId, MessageProcessingResult>> m_peer_activity{};
@@ -73,9 +78,9 @@ private:
 
     mutable Mutex cs_pendingLocks;
     // Incoming and not verified yet
-    Uint256HashMap<std::pair<NodeId, instantsend::InstantSendLockPtr>> pendingInstantSendLocks GUARDED_BY(cs_pendingLocks);
+    Uint256HashMap<instantsend::PendingISLockFromPeer> pendingInstantSendLocks GUARDED_BY(cs_pendingLocks);
     // Tried to verify but there is no tx yet
-    Uint256HashMap<std::pair<NodeId, instantsend::InstantSendLockPtr>> pendingNoTxInstantSendLocks GUARDED_BY(cs_pendingLocks);
+    Uint256HashMap<instantsend::PendingISLockFromPeer> pendingNoTxInstantSendLocks GUARDED_BY(cs_pendingLocks);
 
     // TXs which are neither IS locked nor ChainLocked. We use this to determine for which TXs we need to retry IS
     // locking of child TXs
@@ -121,7 +126,7 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry);
 
     Uint256HashSet ProcessPendingInstantSendLocks(const Consensus::LLMQParams& llmq_params, int signOffset, bool ban,
-                                                  const Uint256HashMap<std::pair<NodeId, instantsend::InstantSendLockPtr>>& pend,
+                                                  const Uint256HashMap<instantsend::PendingISLockFromPeer>& pend,
                                                   std::vector<std::pair<NodeId, MessageProcessingResult>>& peer_activity)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry);
     MessageProcessingResult ProcessInstantSendLock(NodeId from, const uint256& hash,

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 class CBlockIndex;
 class CChainState;
@@ -126,7 +127,7 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry);
 
     Uint256HashSet ProcessPendingInstantSendLocks(const Consensus::LLMQParams& llmq_params, int signOffset, bool ban,
-                                                  const Uint256HashMap<instantsend::PendingISLockFromPeer>& pend,
+                                                  const std::vector<std::pair<uint256, instantsend::PendingISLockFromPeer>>& pend,
                                                   std::vector<std::pair<NodeId, MessageProcessingResult>>& peer_activity)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry);
     MessageProcessingResult ProcessInstantSendLock(NodeId from, const uint256& hash,

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -66,6 +66,10 @@ private:
 
     std::thread workThread;
     CThreadInterrupt workInterrupt;
+    // Event to wake the worker thread when new work arrives
+    Mutex workMutex;
+    std::condition_variable_any workCv;
+    std::atomic<uint64_t> workEpoch{0};
 
     mutable Mutex cs_pendingLocks;
     // Incoming and not verified yet
@@ -110,7 +114,7 @@ public:
 
     void Start(PeerManager& peerman);
     void Stop();
-    void InterruptWorkerThread() { workInterrupt(); };
+    void InterruptWorkerThread() { workInterrupt(); workCv.notify_all(); };
 
 private:
     instantsend::PendingState ProcessPendingInstantSendLocks()
@@ -139,6 +143,10 @@ private:
 
     void WorkThreadMain(PeerManager& peerman)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry);
+    void NotifyWorker() { 
+        workEpoch.fetch_add(1, std::memory_order_acq_rel);
+        workCv.notify_one(); 
+    }
 
     void HandleFullyConfirmedBlock(const CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -143,9 +143,9 @@ private:
 
     void WorkThreadMain(PeerManager& peerman)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry);
-    void NotifyWorker() { 
+    void NotifyWorker() {
         workEpoch.fetch_add(1, std::memory_order_acq_rel);
-        workCv.notify_one(); 
+        workCv.notify_one();
     }
 
     void HandleFullyConfirmedBlock(const CBlockIndex* pindex)

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -432,7 +432,6 @@ MessageProcessingResult CSigningManager::ProcessMessage(NodeId from, std::string
     }
 
     pendingRecoveredSigs[from].emplace_back(recoveredSig);
-    workEpoch.fetch_add(1, std::memory_order_acq_rel);
     NotifyWorker();
     return ret;
 }
@@ -524,13 +523,9 @@ bool CSigningManager::ProcessPendingRecoveredSigs(PeerManager& peerman)
     const size_t nMaxBatchSize{32};
     CollectPendingRecoveredSigsToVerify(nMaxBatchSize, recSigsByNode, quorums);
     if (recSigsByNode.empty()) {
-        // Check if reconstructed queue has work pending so the caller can keep looping
-        {
-            LOCK(cs_pending);
-            if (!pendingReconstructedRecoveredSigs.empty() || !pendingRecoveredSigs.empty()) {
-                return true;
-            }
-        }
+        // No work in this batch. Don't proactively check queues for work that may have been
+        // added by listeners during processing, as this causes busy-wait when combined with
+        // epoch changes. External threads will call NotifyWorker() to wake us if needed.
         return false;
     }
 
@@ -583,13 +578,10 @@ bool CSigningManager::ProcessPendingRecoveredSigs(PeerManager& peerman)
         }
     }
 
-    // If we still have pending items in queues, report more work to avoid sleeping
-    bool more_in_queues = false;
-    {
-        LOCK(cs_pending);
-        more_in_queues = !pendingReconstructedRecoveredSigs.empty() || !pendingRecoveredSigs.empty();
-    }
-    return more_in_queues || recSigsByNode.size() >= nMaxBatchSize;
+    // Only report more work if we processed a full batch, indicating there's likely more
+    // work from the original collection. Don't check queues for work added by listeners
+    // during processing, as that would cause busy-wait with epoch-based wake conditions.
+    return recSigsByNode.size() >= nMaxBatchSize;
 }
 
 // signature must be verified already
@@ -637,15 +629,14 @@ void CSigningManager::ProcessRecoveredSig(const std::shared_ptr<const CRecovered
     }
 
     GetMainSignals().NotifyRecoveredSig(recoveredSig, recoveredSig->GetHash().ToString());
-    workEpoch.fetch_add(1, std::memory_order_acq_rel);
-    NotifyWorker();
+    // Note: Don't call NotifyWorker() here as this function is called by the worker thread itself
+    // NotifyWorker() is only needed when external threads add work
 }
 
 void CSigningManager::PushReconstructedRecoveredSig(const std::shared_ptr<const llmq::CRecoveredSig>& recoveredSig)
 {
     LOCK(cs_pending);
     pendingReconstructedRecoveredSigs.emplace(std::piecewise_construct, std::forward_as_tuple(recoveredSig->GetHash()), std::forward_as_tuple(recoveredSig));
-    workEpoch.fetch_add(1, std::memory_order_acq_rel);
     NotifyWorker();
 }
 
@@ -667,6 +658,7 @@ void CSigningManager::Cleanup()
     db.CleanupOldVotes(maxAge);
 
     lastCleanupTime = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+    lastCleanupTimeSteady = std::chrono::steady_clock::now();
 }
 
 void CSigningManager::RegisterRecoveredSigsListener(CRecoveredSigsListener* l)
@@ -768,11 +760,10 @@ void CSigningManager::WorkThreadMain(PeerManager& peerman)
         // new work arrives or the deadline is reached.
         auto next_deadline = std::chrono::steady_clock::time_point::max();
         {
-            int64_t now_ms = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
-            int64_t target_ms = lastCleanupTime + 5000;
-            if (target_ms > now_ms) {
-                auto delta_ms = target_ms - now_ms;
-                next_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(delta_ms);
+            auto now_steady = std::chrono::steady_clock::now();
+            auto next_cleanup = lastCleanupTimeSteady + std::chrono::milliseconds(5000);
+            if (next_cleanup > now_steady) {
+                next_deadline = next_cleanup;
             }
         }
         if (next_deadline == std::chrono::steady_clock::time_point::max()) {

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -432,6 +432,8 @@ MessageProcessingResult CSigningManager::ProcessMessage(NodeId from, std::string
     }
 
     pendingRecoveredSigs[from].emplace_back(recoveredSig);
+    workEpoch.fetch_add(1, std::memory_order_acq_rel);
+    NotifyWorker();
     return ret;
 }
 
@@ -522,6 +524,13 @@ bool CSigningManager::ProcessPendingRecoveredSigs(PeerManager& peerman)
     const size_t nMaxBatchSize{32};
     CollectPendingRecoveredSigsToVerify(nMaxBatchSize, recSigsByNode, quorums);
     if (recSigsByNode.empty()) {
+        // Check if reconstructed queue has work pending so the caller can keep looping
+        {
+            LOCK(cs_pending);
+            if (!pendingReconstructedRecoveredSigs.empty() || !pendingRecoveredSigs.empty()) {
+                return true;
+            }
+        }
         return false;
     }
 
@@ -574,7 +583,13 @@ bool CSigningManager::ProcessPendingRecoveredSigs(PeerManager& peerman)
         }
     }
 
-    return recSigsByNode.size() >= nMaxBatchSize;
+    // If we still have pending items in queues, report more work to avoid sleeping
+    bool more_in_queues = false;
+    {
+        LOCK(cs_pending);
+        more_in_queues = !pendingReconstructedRecoveredSigs.empty() || !pendingRecoveredSigs.empty();
+    }
+    return more_in_queues || recSigsByNode.size() >= nMaxBatchSize;
 }
 
 // signature must be verified already
@@ -622,12 +637,16 @@ void CSigningManager::ProcessRecoveredSig(const std::shared_ptr<const CRecovered
     }
 
     GetMainSignals().NotifyRecoveredSig(recoveredSig, recoveredSig->GetHash().ToString());
+    workEpoch.fetch_add(1, std::memory_order_acq_rel);
+    NotifyWorker();
 }
 
 void CSigningManager::PushReconstructedRecoveredSig(const std::shared_ptr<const llmq::CRecoveredSig>& recoveredSig)
 {
     LOCK(cs_pending);
     pendingReconstructedRecoveredSigs.emplace(std::piecewise_construct, std::forward_as_tuple(recoveredSig->GetHash()), std::forward_as_tuple(recoveredSig));
+    workEpoch.fetch_add(1, std::memory_order_acq_rel);
+    NotifyWorker();
 }
 
 void CSigningManager::TruncateRecoveredSig(Consensus::LLMQType llmqType, const uint256& id)
@@ -732,18 +751,38 @@ void CSigningManager::StopWorkerThread()
 void CSigningManager::InterruptWorkerThread()
 {
     workInterrupt();
+    workCv.notify_all();
 }
 
 void CSigningManager::WorkThreadMain(PeerManager& peerman)
 {
     while (!workInterrupt) {
+        uint64_t startEpoch = workEpoch.load(std::memory_order_acquire);
         bool fMoreWork = ProcessPendingRecoveredSigs(peerman);
 
         Cleanup();
 
-        // TODO Wakeup when pending signing is needed?
-        if (!fMoreWork && !workInterrupt.sleep_for(std::chrono::milliseconds(100))) {
-            return;
+        if (fMoreWork) continue;
+        std::unique_lock<Mutex> l(workMutex);
+        // Compute next cleanup deadline (~5s cadence) and wait event-driven until either
+        // new work arrives or the deadline is reached.
+        auto next_deadline = std::chrono::steady_clock::time_point::max();
+        {
+            int64_t now_ms = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+            int64_t target_ms = lastCleanupTime + 5000;
+            if (target_ms > now_ms) {
+                auto delta_ms = target_ms - now_ms;
+                next_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(delta_ms);
+            }
+        }
+        if (next_deadline == std::chrono::steady_clock::time_point::max()) {
+            workCv.wait(l, [this, startEpoch]{
+                return bool(workInterrupt) || workEpoch.load(std::memory_order_acquire) != startEpoch;
+            });
+        } else {
+            workCv.wait_until(l, next_deadline, [this, startEpoch]{
+                return bool(workInterrupt) || workEpoch.load(std::memory_order_acquire) != startEpoch;
+            });
         }
     }
 }

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -248,6 +248,7 @@ private:
     Mutex workMutex;
     std::condition_variable_any workCv;
     std::atomic<uint64_t> workEpoch{0};
+    void Cleanup(); // called from the worker thread
     void WorkThreadMain(PeerManager& peerman) EXCLUSIVE_LOCKS_REQUIRED(!cs_pending, !cs_listeners);
 
 public:

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -180,6 +180,7 @@ private:
     FastRandomContext rnd GUARDED_BY(cs_pending);
 
     int64_t lastCleanupTime{0};
+    std::chrono::steady_clock::time_point lastCleanupTimeSteady{};
 
     mutable Mutex cs_listeners;
     std::vector<CRecoveredSigsListener*> recoveredSigsListeners GUARDED_BY(cs_listeners);

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -24,6 +24,8 @@
 #include <string_view>
 #include <thread>
 #include <unordered_map>
+#include <atomic>
+#include <condition_variable>
 
 class CChainState;
 class CDataStream;
@@ -241,13 +243,17 @@ public:
 private:
     std::thread workThread;
     CThreadInterrupt workInterrupt;
-    void Cleanup(); // called from the worker thread of CSigSharesManager
-    void WorkThreadMain(PeerManager& peerman) EXCLUSIVE_LOCKS_REQUIRED(!cs_pending, !cs_listeners);
+    // Event to wake the worker thread when new work arrives
+    Mutex workMutex;
+    std::condition_variable_any workCv;
+    std::atomic<uint64_t> workEpoch{0};
+    void WorkThreadMain(PeerManager& peerman);
 
 public:
     void StartWorkerThread(PeerManager& peerman);
     void StopWorkerThread();
     void InterruptWorkerThread();
+    void NotifyWorker() { workEpoch.fetch_add(1, std::memory_order_acq_rel); workCv.notify_one(); }
 };
 
 template<typename NodesContainer, typename Continue, typename Callback>

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -247,7 +247,7 @@ private:
     Mutex workMutex;
     std::condition_variable_any workCv;
     std::atomic<uint64_t> workEpoch{0};
-    void WorkThreadMain(PeerManager& peerman);
+    void WorkThreadMain(PeerManager& peerman) EXCLUSIVE_LOCKS_REQUIRED(!cs_pending, !cs_listeners);
 
 public:
     void StartWorkerThread(PeerManager& peerman);

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -665,9 +665,12 @@ bool CSigSharesManager::ProcessPendingSigShares()
                 continue;
             }
 
+            // Materialize the signature once. Get() internally validates, so if it returns an invalid signature,
+            // we know it's malformed. This avoids calling Get() twice (once for IsValid(), once for PushMessage).
+            CBLSSignature sig = sigShare.sigShare.Get();
             // we didn't check this earlier because we use a lazy BLS signature and tried to avoid doing the expensive
             // deserialization in the message thread
-            if (!sigShare.sigShare.Get().IsValid()) {
+            if (!sig.IsValid()) {
                 BanNode(nodeId);
                 // don't process any additional shares from this node
                 break;
@@ -683,7 +686,7 @@ bool CSigSharesManager::ProcessPendingSigShares()
                 assert(false);
             }
 
-            batchVerifier.PushMessage(nodeId, sigShare.GetKey(), sigShare.GetSignHash(), sigShare.sigShare.Get(), pubKeyShare);
+            batchVerifier.PushMessage(nodeId, sigShare.GetKey(), sigShare.GetSignHash(), sig, pubKeyShare);
             verifyCount++;
         }
     }

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -792,8 +792,11 @@ void CSigSharesManager::TryRecoverSig(const CQuorum& quorum, const uint256& id, 
         return;
     }
 
-    std::vector<CBLSSignature> sigSharesForRecovery;
+    // Collect lazy signatures (cheap copy) under lock, then materialize outside lock
+    std::vector<CBLSLazySignature> lazySignatures;
     std::vector<CBLSId> idsForRecovery;
+    bool isSingleNode = false;
+
     {
         LOCK(cs);
 
@@ -812,28 +815,44 @@ void CSigSharesManager::TryRecoverSig(const CQuorum& quorum, const uint256& id, 
                 return;
             }
             const auto& sigShare = sigSharesForSignHash->begin()->second;
-            CBLSSignature recoveredSig = sigShare.sigShare.Get();
+            // Copy the lazy signature (cheap), materialize later outside lock
+            lazySignatures.emplace_back(sigShare.sigShare);
+            isSingleNode = true;
             LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- recover single-node signature. id=%s, msgHash=%s\n",
                      __func__, id.ToString(), msgHash.ToString());
+        } else {
+            // Collect lazy signatures and IDs under lock (cheap operations)
+            lazySignatures.reserve((size_t) quorum.params.threshold);
+            idsForRecovery.reserve((size_t) quorum.params.threshold);
+            for (auto it = sigSharesForSignHash->begin();
+                 it != sigSharesForSignHash->end() && lazySignatures.size() < size_t(quorum.params.threshold);
+                 ++it) {
+                const auto& sigShare = it->second;
+                lazySignatures.emplace_back(sigShare.sigShare); // Cheap copy of lazy wrapper
+                idsForRecovery.emplace_back(quorum.members[sigShare.getQuorumMember()]->proTxHash);
+            }
 
-            auto rs = std::make_shared<CRecoveredSig>(quorum.params.type, quorum.qc->quorumHash, id, msgHash,
-                                                      recoveredSig);
-            sigman.ProcessRecoveredSig(rs, m_peerman);
-            return; // end of single-quorum processing
+            // check if we can recover the final signature
+            if (lazySignatures.size() < size_t(quorum.params.threshold)) {
+                return;
+            }
         }
+    } // Release lock before expensive materialization
 
-        sigSharesForRecovery.reserve((size_t) quorum.params.threshold);
-        idsForRecovery.reserve((size_t) quorum.params.threshold);
-        for (auto it = sigSharesForSignHash->begin(); it != sigSharesForSignHash->end() && sigSharesForRecovery.size() < size_t(quorum.params.threshold); ++it) {
-            const auto& sigShare = it->second;
-            sigSharesForRecovery.emplace_back(sigShare.sigShare.Get());
-            idsForRecovery.emplace_back(quorum.members[sigShare.getQuorumMember()]->proTxHash);
-        }
+    // Materialize signatures outside the critical section (expensive BLS operations)
+    if (isSingleNode) {
+        CBLSSignature recoveredSig = lazySignatures[0].Get();
+        auto rs = std::make_shared<CRecoveredSig>(quorum.params.type, quorum.qc->quorumHash, id, msgHash,
+                                                  recoveredSig);
+        sigman.ProcessRecoveredSig(rs, m_peerman);
+        return; // end of single-quorum processing
+    }
 
-        // check if we can recover the final signature
-        if (sigSharesForRecovery.size() < size_t(quorum.params.threshold)) {
-            return;
-        }
+    // Multi-node case: materialize all signatures
+    std::vector<CBLSSignature> sigSharesForRecovery;
+    sigSharesForRecovery.reserve(lazySignatures.size());
+    for (const auto& lazySig : lazySignatures) {
+        sigSharesForRecovery.emplace_back(lazySig.Get()); // Expensive, but outside lock
     }
 
     // now recover it

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -253,6 +253,7 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const std::string& ms
         for (const auto& sigShare : receivedSigShares) {
             ProcessMessageSigShare(pfrom.GetId(), sigShare);
         }
+        NotifyWorker();
     }
 
     if (msg_type == NetMsgType::QSIGSESANN) {
@@ -268,6 +269,7 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const std::string& ms
             BanNode(pfrom.GetId());
             return;
         }
+        NotifyWorker();
     } else if (msg_type == NetMsgType::QSIGSHARESINV) {
         std::vector<CSigSharesInv> msgs;
         vRecv >> msgs;
@@ -281,6 +283,7 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const std::string& ms
             BanNode(pfrom.GetId());
             return;
         }
+        NotifyWorker();
     } else if (msg_type == NetMsgType::QGETSIGSHARES) {
         std::vector<CSigSharesInv> msgs;
         vRecv >> msgs;
@@ -294,6 +297,7 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const std::string& ms
             BanNode(pfrom.GetId());
             return;
         }
+        NotifyWorker();
     } else if (msg_type == NetMsgType::QBSIGSHARES) {
         std::vector<CBatchedSigShares> msgs;
         vRecv >> msgs;
@@ -311,10 +315,8 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const std::string& ms
             BanNode(pfrom.GetId());
             return;
         }
+        NotifyWorker();
     }
-
-    // New inbound messages can create work (requests, shares, announcements)
-    NotifyWorker();
 }
 
 bool CSigSharesManager::ProcessMessageSigSesAnn(const CNode& pfrom, const CSigSesAnn& ann)
@@ -743,7 +745,6 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CQuorum
         return;
     }
 
-    bool queued_announce = false;
     {
         LOCK(cs);
 
@@ -752,7 +753,6 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CQuorum
         }
         if (!isAllMembersConnectedEnabled) {
             sigSharesQueuedToAnnounce.Add(sigShare.GetKey(), true);
-            queued_announce = true;
         }
 
         // Update the time we've seen the last sigShare
@@ -774,9 +774,9 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CQuorum
         }
     }
 
-    if (queued_announce) {
-        NotifyWorker();
-    }
+    // Note: Don't call NotifyWorker() here even when queued_announce is true
+    // When called from worker thread: SendMessages() will handle announcements in same iteration
+    // When called from external thread: ProcessMessage() already calls NotifyWorker() (line 303)
 
     if (canTryRecovery) {
         TryRecoverSig(*quorum, sigShare.getId(), sigShare.getMsgHash());
@@ -1124,7 +1124,7 @@ void CSigSharesManager::CollectSigSharesToSendConcentrated(std::unordered_map<No
         proTxToNode.try_emplace(verifiedProRegTxHash, pnode);
     }
 
-    auto curTime = GetTime<std::chrono::milliseconds>().count();
+    auto curTime = std::chrono::steady_clock::now();
 
     for (auto& [_, signedSession] : signedSessions) {
         if (!IsAllMembersConnectedEnabled(signedSession.quorum->params.type, m_sporkman)) {
@@ -1138,7 +1138,7 @@ void CSigSharesManager::CollectSigSharesToSendConcentrated(std::unordered_map<No
         if (curTime >= signedSession.nextAttemptTime) {
             int64_t waitTime = exp2(signedSession.attempt) * EXP_SEND_FOR_RECOVERY_TIMEOUT;
             waitTime = std::min(MAX_SEND_FOR_RECOVERY_TIMEOUT, waitTime);
-            signedSession.nextAttemptTime = curTime + waitTime;
+            signedSession.nextAttemptTime = curTime + std::chrono::milliseconds(waitTime);
             auto dmn = SelectMemberForRecovery(*signedSession.quorum, signedSession.sigShare.getId(), signedSession.attempt);
             signedSession.attempt++;
 
@@ -1522,6 +1522,7 @@ void CSigSharesManager::Cleanup()
     }
 
     lastCleanupTime = GetTime<std::chrono::seconds>().count();
+    lastCleanupTimeSteady = std::chrono::steady_clock::now();
 }
 
 void CSigSharesManager::RemoveSigSharesForSession(const uint256& signHash)
@@ -1617,24 +1618,19 @@ void CSigSharesManager::WorkThreadMain()
         auto next_deadline = std::chrono::steady_clock::time_point::max();
         // Respect cleanup cadence (~5s) even when idle
         {
-            auto now_tp = std::chrono::steady_clock::now();
-            int64_t now_s = GetTime<std::chrono::seconds>().count();
-            int64_t target_s = lastCleanupTime + 5;
-            if (target_s > now_s) {
-                auto delta_ms = (target_s - now_s) * 1000;
-                auto cand = now_tp + std::chrono::milliseconds(delta_ms);
-                if (cand < next_deadline) next_deadline = cand;
+            auto now_steady = std::chrono::steady_clock::now();
+            auto next_cleanup = lastCleanupTimeSteady + std::chrono::seconds(5);
+            if (next_cleanup > now_steady) {
+                if (next_cleanup < next_deadline) next_deadline = next_cleanup;
             }
         }
         {
             // Consider next recovery attempt times for signed sessions to avoid polling
             LOCK(cs);
-            int64_t cur_ms = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+            auto now_steady = std::chrono::steady_clock::now();
             for (const auto& [_, s] : signedSessions) {
-                if (s.nextAttemptTime > cur_ms) {
-                    auto d = s.nextAttemptTime - cur_ms;
-                    auto cand = std::chrono::steady_clock::now() + std::chrono::milliseconds(d);
-                    if (cand < next_deadline) next_deadline = cand;
+                if (s.nextAttemptTime > now_steady) {
+                    if (s.nextAttemptTime < next_deadline) next_deadline = s.nextAttemptTime;
                 }
             }
         }
@@ -1679,13 +1675,13 @@ void CSigSharesManager::SignPendingSigShares()
                 auto& session = signedSessions[sigShare.GetSignHash()];
                 session.sigShare = sigShare;
                 session.quorum = pQuorum;
-                session.nextAttemptTime = 0;
+                session.nextAttemptTime = std::chrono::steady_clock::time_point{};
                 session.attempt = 0;
             }
         }
     }
-    // New sig shares or recovery attempts may be available
-    NotifyWorker();
+    // Note: Don't call NotifyWorker() here as this function is called by the worker thread itself
+    // NotifyWorker() is only needed when external threads add work
 }
 
 std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorum& quorum, const uint256& id, const uint256& msgHash) const

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -231,6 +231,8 @@ void CSigSharesManager::UnregisterAsRecoveredSigsListener()
 void CSigSharesManager::InterruptWorkerThread()
 {
     workInterrupt();
+    // Wake the worker to allow prompt shutdown
+    workCv.notify_all();
 }
 
 void CSigSharesManager::ProcessMessage(const CNode& pfrom, const std::string& msg_type, CDataStream& vRecv)
@@ -310,6 +312,9 @@ void CSigSharesManager::ProcessMessage(const CNode& pfrom, const std::string& ms
             return;
         }
     }
+
+    // New inbound messages can create work (requests, shares, announcements)
+    NotifyWorker();
 }
 
 bool CSigSharesManager::ProcessMessageSigSesAnn(const CNode& pfrom, const CSigSesAnn& ann)
@@ -738,6 +743,7 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CQuorum
         return;
     }
 
+    bool queued_announce = false;
     {
         LOCK(cs);
 
@@ -746,6 +752,7 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CQuorum
         }
         if (!isAllMembersConnectedEnabled) {
             sigSharesQueuedToAnnounce.Add(sigShare.GetKey(), true);
+            queued_announce = true;
         }
 
         // Update the time we've seen the last sigShare
@@ -765,6 +772,10 @@ void CSigSharesManager::ProcessSigShare(const CSigShare& sigShare, const CQuorum
         if (sigShareCount >= size_t(quorum->params.threshold)) {
             canTryRecovery = true;
         }
+    }
+
+    if (queued_announce) {
+        NotifyWorker();
     }
 
     if (canTryRecovery) {
@@ -1573,6 +1584,8 @@ void CSigSharesManager::BanNode(NodeId nodeId)
     });
     nodeState.requestedSigShares.Clear();
     nodeState.banned = true;
+    // Banning affects request routing and can create immediate work
+    NotifyWorker();
 }
 
 void CSigSharesManager::WorkThreadMain()
@@ -1580,22 +1593,64 @@ void CSigSharesManager::WorkThreadMain()
     int64_t lastSendTime = 0;
 
     while (!workInterrupt) {
+        // capture epoch at loop start to detect intervening notifications
+        uint64_t startEpoch = workEpoch.load(std::memory_order_acquire);
         RemoveBannedNodeStates();
 
         bool fMoreWork = ProcessPendingSigShares();
         SignPendingSigShares();
 
+        bool didSend = false;
         if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - lastSendTime > 10) {
-            SendMessages();
+            didSend = SendMessages();
             lastSendTime = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
         }
 
         Cleanup();
 
-        // TODO Wakeup when pending signing is needed?
-        if (!fMoreWork && !workInterrupt.sleep_for(std::chrono::milliseconds(10))) {
-            return;
+        // If there is more work or we just sent something, iterate again without waiting
+        if (fMoreWork || didSend) {
+            continue;
         }
+
+        // Compute next wake-up deadline for periodic tasks (recovery attempts and cleanup cadence)
+        auto next_deadline = std::chrono::steady_clock::time_point::max();
+        // Respect cleanup cadence (~5s) even when idle
+        {
+            auto now_tp = std::chrono::steady_clock::now();
+            int64_t now_s = GetTime<std::chrono::seconds>().count();
+            int64_t target_s = lastCleanupTime + 5;
+            if (target_s > now_s) {
+                auto delta_ms = (target_s - now_s) * 1000;
+                auto cand = now_tp + std::chrono::milliseconds(delta_ms);
+                if (cand < next_deadline) next_deadline = cand;
+            }
+        }
+        {
+            // Consider next recovery attempt times for signed sessions to avoid polling
+            LOCK(cs);
+            int64_t cur_ms = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+            for (const auto& [_, s] : signedSessions) {
+                if (s.nextAttemptTime > cur_ms) {
+                    auto d = s.nextAttemptTime - cur_ms;
+                    auto cand = std::chrono::steady_clock::now() + std::chrono::milliseconds(d);
+                    if (cand < next_deadline) next_deadline = cand;
+                }
+            }
+        }
+
+        // Wait event-driven until notified or deadline reached, or interrupted
+        std::unique_lock<Mutex> l(workMutex);
+        if (next_deadline == std::chrono::steady_clock::time_point::max()) {
+            workCv.wait_for(l, std::chrono::milliseconds(10), [this, startEpoch]{
+                return bool(workInterrupt) || workEpoch.load(std::memory_order_acquire) != startEpoch;
+            });
+        } else {
+            workCv.wait_until(l, next_deadline, [this, startEpoch]{
+                return bool(workInterrupt) || workEpoch.load(std::memory_order_acquire) != startEpoch;
+            });
+        }
+        // If epoch changed while we were waiting, loop will process immediately
     }
 }
 
@@ -1603,6 +1658,8 @@ void CSigSharesManager::AsyncSign(CQuorumCPtr quorum, const uint256& id, const u
 {
     LOCK(cs_pendingSigns);
     pendingSigns.emplace_back(std::move(quorum), id, msgHash);
+    // Wake worker to handle new pending sign immediately
+    NotifyWorker();
 }
 
 void CSigSharesManager::SignPendingSigShares()
@@ -1627,6 +1684,8 @@ void CSigSharesManager::SignPendingSigShares()
             }
         }
     }
+    // New sig shares or recovery attempts may be available
+    NotifyWorker();
 }
 
 std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorum& quorum, const uint256& id, const uint256& msgHash) const
@@ -1724,6 +1783,8 @@ void CSigSharesManager::ForceReAnnouncement(const CQuorum& quorum, Consensus::LL
         // we need to use a new session id as we don't know if the other node has run into a timeout already
         session->sendSessionId = UNINITIALIZED_SESSION_ID;
     }
+    // Wake worker so announcements are sent promptly
+    NotifyWorker();
 }
 
 MessageProcessingResult CSigSharesManager::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
@@ -1731,6 +1792,15 @@ MessageProcessingResult CSigSharesManager::HandleNewRecoveredSig(const llmq::CRe
     auto signHash = recoveredSig.buildSignHash().Get();
     LOCK(cs);
     RemoveSigSharesForSession(signHash);
+    // Cleaning up a session can free resources; wake worker to proceed
+    NotifyWorker();
     return {};
+}
+
+void CSigSharesManager::NotifyWorker()
+{
+    // Avoid spurious wake-ups causing contention; simple notify is fine
+    workEpoch.fetch_add(1, std::memory_order_acq_rel);
+    workCv.notify_one();
 }
 } // namespace llmq

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -1585,7 +1585,7 @@ void CSigSharesManager::WorkThreadMain()
         bool fMoreWork = ProcessPendingSigShares();
         SignPendingSigShares();
 
-        if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - lastSendTime > 100) {
+        if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - lastSendTime > 10) {
             SendMessages();
             lastSendTime = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
         }
@@ -1593,7 +1593,7 @@ void CSigSharesManager::WorkThreadMain()
         Cleanup();
 
         // TODO Wakeup when pending signing is needed?
-        if (!fMoreWork && !workInterrupt.sleep_for(std::chrono::milliseconds(100))) {
+        if (!fMoreWork && !workInterrupt.sleep_for(std::chrono::milliseconds(10))) {
             return;
         }
     }

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -356,7 +356,7 @@ public:
     CSigShare sigShare;
     CQuorumCPtr quorum;
 
-    int64_t nextAttemptTime{0};
+    std::chrono::steady_clock::time_point nextAttemptTime{};
     int attempt{0};
 };
 
@@ -418,6 +418,7 @@ private:
     const CSporkManager& m_sporkman;
 
     int64_t lastCleanupTime{0};
+    std::chrono::steady_clock::time_point lastCleanupTimeSteady{};
     std::atomic<uint32_t> recoveredSigsCounter{0};
 
 public:

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -495,7 +495,7 @@ private:
     void CollectSigSharesToAnnounce(std::unordered_map<NodeId, Uint256HashMap<CSigSharesInv>>& sigSharesToAnnounce)
         EXCLUSIVE_LOCKS_REQUIRED(cs);
     void SignPendingSigShares() EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingSigns);
-    void WorkThreadMain();
+    void WorkThreadMain() EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingSigns);
     void NotifyWorker();
 };
 } // namespace llmq

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -211,12 +211,9 @@ public:
 
     T& GetOrAdd(const SigShareKey& k)
     {
-        T* v = Get(k);
-        if (!v) {
-            Add(k, T());
-            v = Get(k);
-        }
-        return *v;
+        auto& m = internalMap[k.first]; // Get or create outer map entry
+        auto result = m.emplace(k.second, T()); // Try to insert, returns pair<iterator, bool>
+        return result.first->second; // Return reference to the value (new or existing)
     }
 
     const T* GetFirst() const

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <condition_variable>
 
 class CActiveMasternodeManager;
 class CNode;
@@ -380,6 +381,10 @@ private:
 
     std::thread workThread;
     CThreadInterrupt workInterrupt;
+    // Event to wake the worker thread when new work arrives
+    Mutex workMutex;
+    std::condition_variable_any workCv;
+    std::atomic<uint64_t> workEpoch{0};
 
     SigShareMap<CSigShare> sigShares GUARDED_BY(cs);
     Uint256HashMap<CSignedSession> signedSessions GUARDED_BY(cs);
@@ -489,8 +494,9 @@ private:
     void CollectSigSharesToSendConcentrated(std::unordered_map<NodeId, std::vector<CSigShare>>& sigSharesToSend, const std::vector<CNode*>& vNodes) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CollectSigSharesToAnnounce(std::unordered_map<NodeId, Uint256HashMap<CSigSharesInv>>& sigSharesToAnnounce)
         EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void SignPendingSigShares() EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingSigns);
-    void WorkThreadMain() EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingSigns);
+    void SignPendingSigShares();
+    void WorkThreadMain();
+    void NotifyWorker();
 };
 } // namespace llmq
 

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -494,7 +494,7 @@ private:
     void CollectSigSharesToSendConcentrated(std::unordered_map<NodeId, std::vector<CSigShare>>& sigSharesToSend, const std::vector<CNode*>& vNodes) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CollectSigSharesToAnnounce(std::unordered_map<NodeId, Uint256HashMap<CSigSharesInv>>& sigSharesToAnnounce)
         EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void SignPendingSigShares();
+    void SignPendingSigShares() EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingSigns);
     void WorkThreadMain();
     void NotifyWorker();
 };


### PR DESCRIPTION
## Issue being fixed or feature implemented
InstantSend / LLMQ signing is currently wait / loop driven. This PR converts this to notification driven. This allows us to immediately begin working on new signing or other operations instead of waiting. During very high load, this is unlikely to significantly affect throughput, however it will affect best case latency during low throughput. 

### 📊 Mempool Performance Improvement (15 nodes local functional test measuring latency via ZMQ from mempool notification to islock / recsig (should reflect input lock time) notification)

| Metric            | Before (avg of 2 runs) | After (avg of 2 runs) | Improvement (%) |
|-------------------|------------------------|------------------------|------------------|
| **lock - min**    | 307.26 ms              | 53.30 ms              | **−82.7%**       |
| **lock - p50**    | 537.28 ms              | 235.15 ms             | **−56.2%**       |
| **lock - p90**    | 718.17 ms              | 388.75 ms             | **−45.9%**       |
| **lock - p99**    | 813.85 ms              | 443.19 ms             | **−45.6%**       |
| **lock - max**    | 846.09 ms              | 561.26 ms             | **−33.6%**       |
| **recsig - min**  | 111.26 ms              | 46.55 ms              | **−58.2%**       |
| **recsig - p50**  | 367.82 ms              | 145.53 ms             | **−60.4%**       |
| **recsig - p90**  | 491.30 ms              | 246.39 ms             | **−49.9%**       |
| **recsig - p99**  | 562.76 ms              | 313.32 ms             | **−44.3%**       |
| **recsig - max**  | 603.32 ms              | 359.99 ms             | **−40.3%**       |

Currently on main net, we see on average ~1.5-2 second time to lock transactions. Based on the 250ms average reduction locally, this implies that we may see 1.25 - 1.75 second average time to lock with this. Although, the reduction in latency may be more or less with significantly larger quorums.

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

