### PR TITLE
refactor: replace count check with contains method for better readabi…

### DIFF
--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -682,7 +682,7 @@ bool CSigSharesManager::ProcessPendingSigShares(PeerManager& peerman, const CCon
     LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- verified sig shares. count=%d, pt=%d, vt=%d, nodes=%d\n", __func__, verifyCount, prepareTimer.count(), verifyTimer.count(), sigSharesByNodes.size());
 
     for (const auto& [nodeId, v] : sigSharesByNodes) {
-        if (batchVerifier.badSources.count(nodeId) != 0) {
+        if (batchVerifier.badSources.contains(nodeId)) {
             LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- invalid sig shares from other node, banning peer=%d\n",
                      __func__, nodeId);
             // this will also cause re-requesting of the shares that were sent by this node


### PR DESCRIPTION
…lity

Updated the condition in CSigSharesManager::ProcessPendingSigShares to use the contains method instead of count for checking bad sources. This change improves code clarity and aligns with modern C++ practices.

***Please remove the italicized help prompts before submitting or merging***

_Provide a general summary of your changes in the Title above_

_Pull requests without a rationale and clear improvement may be closed
immediately._

_Please provide clear motivation for your patch and explain how it improves
Dash Core user experience or Dash Core developer experience
significantly:_

* _Any test improvements or new tests that improve coverage are always welcome._
* _All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change._
* _Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed._
* _Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Dash Core, if possible._


## Issue being fixed or feature implemented
 - _Why is this change required? What problem does it solve?_
 - _If it fixes an open issue, please link to the issue here._


## What was done?
  _Describe your changes in detail_


## How Has This Been Tested?
  _Please describe in detail how you tested your changes._

  _Include details of your testing environment, and the tests you ran
to see how your change affects other areas of the code, etc._


## Breaking Changes
  _Please describe any breaking changes your code introduces_


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

