### PR TITLE
refactor: replace size check with is_single_member() method for clarity

### DIFF
--- a/src/llmq/commitment.cpp
+++ b/src/llmq/commitment.cpp
@@ -51,7 +51,7 @@ bool CFinalCommitment::VerifySignatureAsync(CDeterministicMNManager& dmnman, CQu
         LogPrint(BCLog::LLMQ, "CFinalCommitment::%s members[%s] quorumPublicKey[%s] commitmentHash[%s]\n", __func__,
                  ss3.str(), quorumPublicKey.ToString(), commitmentHash.ToString());
     }
-    if (llmq_params.size == 1) {
+    if (llmq_params.is_single_member()) {
         LogPrintf("pubkey operator: %s\n", members[0]->pdmnState->pubKeyOperator.Get().ToString());
         if (!membersSig.VerifyInsecure(members[0]->pdmnState->pubKeyOperator.Get(), commitmentHash)) {
             LogPrint(BCLog::LLMQ, "CFinalCommitment -- q[%s] invalid member signature\n", quorumHash.ToString());
@@ -138,7 +138,7 @@ bool CFinalCommitment::Verify(CDeterministicMNManager& dmnman, CQuorumSnapshotMa
         LogPrint(BCLog::LLMQ, "CFinalCommitment -- q[%s] invalid quorumPublicKey\n", quorumHash.ToString());
         return false;
     }
-    if (llmq_params.size != 1 && quorumVvecHash.IsNull()) {
+    if (!llmq_params.is_single_member() && quorumVvecHash.IsNull()) {
         LogPrint(BCLog::LLMQ, "CFinalCommitment -- q[%s] invalid quorumVvecHash\n", quorumHash.ToString());
         return false;
     }

--- a/src/llmq/dkgsessionhandler.cpp
+++ b/src/llmq/dkgsessionhandler.cpp
@@ -551,7 +551,7 @@ void CDKGSessionHandler::HandleDKGRound(CConnman& connman, PeerManager& peerman)
         return changed;
     });
 
-    if (params.size == 1) {
+    if (params.is_single_member()) {
         auto finalCommitment = curSession->FinalizeSingleCommitment();
         if (!finalCommitment.IsNull()) { // it can be null only if we are not member
             if (auto inv_opt = quorumBlockProcessor.AddMineableCommitment(finalCommitment); inv_opt.has_value()) {

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -121,6 +121,7 @@ public:
 
     // For how many blocks recent DKG info should be kept
     [[nodiscard]] constexpr int max_store_depth() const { return max_cycles(keepOldKeys) * dkgInterval; }
+    [[nodiscard]] constexpr bool is_single_member() const { return size == 1; }
 };
 
 //static_assert(std::is_trivial_v<Consensus::LLMQParams>, "LLMQParams is not a trivial type");

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -781,7 +781,7 @@ void CSigSharesManager::TryRecoverSig(PeerManager& peerman, const CQuorumCPtr& q
             return;
         }
 
-        if (quorum->params.size == 1) {
+        if (quorum->params.is_single_member()) {
             if (sigSharesForSignHash->empty()) {
                 LogPrint(BCLog::LLMQ_SIGS, /* Continued */
                          "CSigSharesManager::%s -- impossible to recover single-node signature - no shares yet. id=%s, "
@@ -1550,7 +1550,7 @@ std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorumCPtr& qu
         return std::nullopt;
     }
 
-    if (quorum->params.size == 1) {
+    if (quorum->params.is_single_member()) {
         int memberIdx = quorum->GetMemberIndex(activeMasterNodeProTxHash);
         if (memberIdx == -1) {
             // this should really not happen (IsValidMember gave true)

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -211,7 +211,7 @@ static UniValue BuildQuorumInfo(const llmq::CQuorumBlockProcessor& quorum_block_
             mo.pushKV("pubKeyOperator", dmn->pdmnState->pubKeyOperator.ToString());
             mo.pushKV("valid", static_cast<bool>(quorum->qc->validMembers[i]));
             if (quorum->qc->validMembers[i]) {
-                if (quorum->params.size == 1) {
+                if (quorum->params.is_single_member()) {
                     mo.pushKV("pubKeyShare", dmn->pdmnState->pubKeyOperator.ToString());
                 } else {
                     CBLSPublicKey pubKey = quorum->GetPubKeyShare(i);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Avoiding using raw size as indication for special logic; use a helper function in-case the conditions change in the future (however unlikely that may be)

## What was done?
added helper for `is_single_member`

## How Has This Been Tested?
builds

## Breaking Changes

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

