### PR TITLE
perf: bail out in RelayInvFiltered early if !CanRelay

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2406,11 +2406,13 @@ void PeerManagerImpl::RelayInvFiltered(const CInv& inv, const CTransaction& rela
 {
     // TODO: Migrate to iteration through m_peer_map
     m_connman.ForEachNode([&](CNode* pnode) {
+        if (!pnode->CanRelay()) return;
+
         PeerRef peer = GetPeerRef(pnode->GetId());
         if (peer == nullptr) return;
 
         auto tx_relay = peer->GetTxRelay();
-        if (!pnode->CanRelay() || tx_relay == nullptr) {
+        if (tx_relay == nullptr) {
             return;
         }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
m_peer_mutex, acquired in GetPeerRef, is relatively highly contended. Move the pnode->CanRelay up higher to bail out early if possible and avoid the need to acquire m_peer_mutex.

## What was done?


## How Has This Been Tested?
Builds

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

