### PR TITLE
perf: improve signing latency by collecting lazy signatures under lock

### DIFF
--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -592,8 +592,11 @@ std::shared_ptr<CRecoveredSig> CSigSharesManager::TryRecoverSig(const CQuorum& q
         return nullptr;
     }
 
-    std::vector<CBLSSignature> sigSharesForRecovery;
+    // Collect lazy signatures (cheap copy) under lock, then materialize outside lock
+    std::vector<CBLSLazySignature> lazySignatures;
     std::vector<CBLSId> idsForRecovery;
+    bool isSingleNode = false;
+
     {
         LOCK(cs);
 
@@ -603,7 +606,6 @@ std::shared_ptr<CRecoveredSig> CSigSharesManager::TryRecoverSig(const CQuorum& q
             return nullptr;
         }
 
-        std::shared_ptr<CRecoveredSig> singleMemberRecoveredSig;
         if (quorum.params.is_single_member()) {
             if (sigSharesForSignHash->empty()) {
                 LogPrint(BCLog::LLMQ_SIGS, /* Continued */
@@ -613,29 +615,42 @@ std::shared_ptr<CRecoveredSig> CSigSharesManager::TryRecoverSig(const CQuorum& q
                 return nullptr;
             }
             const auto& sigShare = sigSharesForSignHash->begin()->second;
-            CBLSSignature recoveredSig = sigShare.sigShare.Get();
+            // Copy the lazy signature (cheap), materialize later outside lock
+            lazySignatures.emplace_back(sigShare.sigShare);
+            isSingleNode = true;
             LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- recover single-node signature. id=%s, msgHash=%s\n",
                      __func__, id.ToString(), msgHash.ToString());
+        } else {
+            // Collect lazy signatures and IDs under lock (cheap operations)
+            lazySignatures.reserve((size_t) quorum.params.threshold);
+            idsForRecovery.reserve((size_t) quorum.params.threshold);
+            for (auto it = sigSharesForSignHash->begin();
+                 it != sigSharesForSignHash->end() && lazySignatures.size() < size_t(quorum.params.threshold);
+                 ++it) {
+                const auto& sigShare = it->second;
+                lazySignatures.emplace_back(sigShare.sigShare); // Cheap copy of lazy wrapper
+                idsForRecovery.emplace_back(quorum.members[sigShare.getQuorumMember()]->proTxHash);
+            }
 
-            singleMemberRecoveredSig = std::make_shared<CRecoveredSig>(quorum.params.type, quorum.qc->quorumHash, id, msgHash,
-                                                      recoveredSig);
+            // check if we can recover the final signature
+            if (lazySignatures.size() < size_t(quorum.params.threshold)) {
+                return nullptr;
+            }
         }
+    } // Release lock before expensive materialization
 
-        sigSharesForRecovery.reserve((size_t) quorum.params.threshold);
-        idsForRecovery.reserve((size_t) quorum.params.threshold);
-        for (auto it = sigSharesForSignHash->begin(); it != sigSharesForSignHash->end() && sigSharesForRecovery.size() < size_t(quorum.params.threshold); ++it) {
-            const auto& sigShare = it->second;
-            sigSharesForRecovery.emplace_back(sigShare.sigShare.Get());
-            idsForRecovery.emplace_back(quorum.members[sigShare.getQuorumMember()]->proTxHash);
-        }
+    // Materialize signatures outside the critical section (expensive BLS operations)
+    if (quorum.params.is_single_member()) {
+        CBLSSignature recoveredSig = lazySignatures[0].Get();
+        return std::make_shared<CRecoveredSig>(quorum.params.type, quorum.qc->quorumHash, id, msgHash,
+                                                  recoveredSig);
+    }
 
-        // check if we can recover the final signature
-        if (sigSharesForRecovery.size() < size_t(quorum.params.threshold)) {
-            return nullptr;
-        }
-        if (quorum.params.is_single_member()) {
-            return singleMemberRecoveredSig; // end of single-quorum processing
-        }
+    // Multi-node case: materialize all signatures
+    std::vector<CBLSSignature> sigSharesForRecovery;
+    sigSharesForRecovery.reserve(lazySignatures.size());
+    for (const auto& lazySig : lazySignatures) {
+        sigSharesForRecovery.emplace_back(lazySig.Get()); // Expensive, but outside lock
     }
 
     // now recover it

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -635,8 +635,11 @@ std::shared_ptr<CRecoveredSig> CSigSharesManager::TryRecoverSig(const CQuorum& q
         return nullptr;
     }
 
-    std::vector<CBLSSignature> sigSharesForRecovery;
+    // For the multi-member case, collect lazy signatures under the lock and defer the expensive
+    // BLS deserialization (Get) until after the lock is released to minimize time spent holding cs.
+    std::vector<CBLSLazySignature> lazySignatures;
     std::vector<CBLSId> idsForRecovery;
+
     {
         LOCK(cs);
 
@@ -646,8 +649,8 @@ std::shared_ptr<CRecoveredSig> CSigSharesManager::TryRecoverSig(const CQuorum& q
             return nullptr;
         }
 
-        std::shared_ptr<CRecoveredSig> singleMemberRecoveredSig;
         if (quorum.params.is_single_member()) {
+            // Single share means a single Get(); no contention benefit to deferring it, so recover inline.
             if (sigSharesForSignHash->empty()) {
                 LogPrint(BCLog::LLMQ_SIGS, /* Continued */
                          "CSigSharesManager::%s -- impossible to recover single-node signature - no shares yet. id=%s, "
@@ -656,29 +659,34 @@ std::shared_ptr<CRecoveredSig> CSigSharesManager::TryRecoverSig(const CQuorum& q
                 return nullptr;
             }
             const auto& sigShare = sigSharesForSignHash->begin()->second;
-            CBLSSignature recoveredSig = sigShare.sigShare.Get();
             LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- recover single-node signature. id=%s, msgHash=%s\n",
                      __func__, id.ToString(), msgHash.ToString());
-
-            singleMemberRecoveredSig = std::make_shared<CRecoveredSig>(quorum.params.type, quorum.qc->quorumHash, id, msgHash,
-                                                      recoveredSig);
+            return std::make_shared<CRecoveredSig>(quorum.params.type, quorum.qc->quorumHash, id, msgHash,
+                                                   sigShare.sigShare.Get());
         }
 
-        sigSharesForRecovery.reserve((size_t) quorum.params.threshold);
+        // Collect lazy signatures and IDs under the lock (cheap); materialize them outside.
+        lazySignatures.reserve((size_t) quorum.params.threshold);
         idsForRecovery.reserve((size_t) quorum.params.threshold);
-        for (auto it = sigSharesForSignHash->begin(); it != sigSharesForSignHash->end() && sigSharesForRecovery.size() < size_t(quorum.params.threshold); ++it) {
+        for (auto it = sigSharesForSignHash->begin();
+             it != sigSharesForSignHash->end() && lazySignatures.size() < size_t(quorum.params.threshold);
+             ++it) {
             const auto& sigShare = it->second;
-            sigSharesForRecovery.emplace_back(sigShare.sigShare.Get());
+            lazySignatures.emplace_back(sigShare.sigShare); // Collect lazy wrapper, defer BLS deserialization
             idsForRecovery.emplace_back(quorum.members[sigShare.getQuorumMember()]->proTxHash);
         }
 
         // check if we can recover the final signature
-        if (sigSharesForRecovery.size() < size_t(quorum.params.threshold)) {
+        if (lazySignatures.size() < size_t(quorum.params.threshold)) {
             return nullptr;
         }
-        if (quorum.params.is_single_member()) {
-            return singleMemberRecoveredSig; // end of single-quorum processing
-        }
+    } // Release lock before expensive materialization
+
+    // Materialize signatures outside the critical section (expensive BLS operations)
+    std::vector<CBLSSignature> sigSharesForRecovery;
+    sigSharesForRecovery.reserve(lazySignatures.size());
+    for (const auto& lazySig : lazySignatures) {
+        sigSharesForRecovery.emplace_back(lazySig.Get()); // Expensive, but outside lock
     }
 
     // now recover it


### PR DESCRIPTION
## Issue being fixed or feature implemented

see benchmark code here: https://gist.github.com/PastaPastaPasta/01e2e3a22c7dbacf957a2b3222b1457c

|             ns/sigs |              sigs/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|           59,266.86 |           16,872.84 |    0.0% |      0.76 | `LLMQSigShares_LockOccupancy_Inside`
|                2.43 |      411,787,414.75 |    0.0% |      0.00 | `LLMQSigShares_LockOccupancy_Outside`
|           60,162.66 |           16,621.60 |    0.0% |      0.77 | `LLMQSigShares_MaterializeInsideLock`
|           58,093.54 |           17,213.62 |    0.0% |      0.74 | `LLMQSigShares_MaterializeOutsideLock`

this appears to show that calling the .Get inside the lock is very expensive, and that the impact to overall performance may actually improve a few percentage points as well. The main gain here is reducing the time spent inside of signing_shares.cpp cs lock to minimize overall contention.

## AI interpretation

Benchmark Interpretation

The benchmarks demonstrate that performing CBLSLazySignature::Get() calls inside the cs lock is extremely expensive, and moving that work outside of the critical section nearly eliminates lock contention:

| Metric | Inside Lock | Outside Lock | Improvement |
|:--|--:|--:|--:|
| **Lock occupancy (ns/sig)** | 59,266.86 | 2.43 | **≈ 24,000× reduction** |
| **Total time per sig (ns/sig)** | 60,162.66 | 58,093.54 | **~3–4% faster overall** |

Interpretation:
Total signing work remains roughly constant, but the time spent holding the lock drops from ~3.8 ms per 64-share recovery to ~0.00015 ms. This drastically reduces contention in signing_shares.cpp, improving throughput and tail latency under concurrent load.

In multi-threaded real-world conditions, this means:
	•	Fewer stalls on cs
	•	Faster signature recovery for all participants
	•	Lower p95/p99 signing latency in high-load LLMQ signing scenarios


## What was done?
Collect the pointers inside the lock, perform expensive BLS serialization outside the lock.

## How Has This Been Tested?
builds; benched; this isn't super easy to detect in proper integration level benchmarks because only 1 of 15 nodes is the "recovery" member, so contention in this spot kinda gets overshadowed by all the other typical contention over this cs. The data I do have, shows the number of contentions over this lock isn't too bad, but the time spent in contention when there is contention is pretty bad, averaging 500μs (0.5ms).

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

