### PR TITLE
refactor: extract buildSignHash outside acquiring cs

### DIFF
--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -1728,8 +1728,9 @@ void CSigSharesManager::ForceReAnnouncement(const CQuorumCPtr& quorum, Consensus
 
 MessageProcessingResult CSigSharesManager::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
 {
+    auto signHash = recoveredSig.buildSignHash().Get();
     LOCK(cs);
-    RemoveSigSharesForSession(recoveredSig.buildSignHash().Get());
+    RemoveSigSharesForSession(signHash);
     return {};
 }
 } // namespace llmq


### PR DESCRIPTION
## Issue being fixed or feature implemented
extract recoveredSig.buildSignHash from mutex

https://github.com/dashpay/dash/blob/fd6ad86f8b8822e291ffbe7b9b4b949d7b1aad77/src/llmq/signhash.cpp#L14-L22

buildSignHash is non-trivial; let's extract it to avoid locking cs longer than needed.


## How Has This Been Tested?

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

