### PR TITLE
test: wait for new trigger for up to 1s while mining in maturity window

### DIFF
--- a/test/functional/feature_governance.py
+++ b/test/functional/feature_governance.py
@@ -353,9 +353,8 @@ class DashGovernanceTest (DashTestFramework):
         assert n > 0
 
         self.log.info("Move remaining n blocks until the next maturity window")
-        for _ in range(n):
-            self.bump_mocktime(1)
-            self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks())
+        self.bump_mocktime(n)
+        self.generate(self.nodes[0], n, sync_fun=self.sync_blocks())
 
         self.log.info("Move inside maturity window until the next Superblock")
         for _ in range(sb_maturity_window - 1):
@@ -373,9 +372,8 @@ class DashGovernanceTest (DashTestFramework):
         self.log.info("Mine and check a couple more superblocks")
         for i in range(2):
             sb_block_height = 180 + (i + 1) * sb_cycle
-            for _ in range(sb_immaturity_window):
-                self.bump_mocktime(1)
-                self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks())
+            self.bump_mocktime(sb_immaturity_window)
+            self.generate(self.nodes[0], sb_immaturity_window, sync_fun=self.sync_blocks())
             for _ in range(sb_maturity_window - 1):
                 self.bump_mocktime(1)
                 self.generate(self.nodes[0], 1, sync_fun=self.sync_blocks())


### PR DESCRIPTION
## Issue being fixed or feature implemented
Mining too fast can result in creation of multiple triggers none of which is going to win - too many "no" votes from competing mns for `AbsoluteYesCount` to go above 0.

## What was done?
Wait for new trigger for up to 1s while mining in maturity window. If no winning trigger was found in 1s we move to the next block. When there is a winning trigger `wait_until` is basically instant.

## How Has This Been Tested?
Run multiple `feature_governance.py` jobs in parallel.

develop: some jobs fail on `wait_until(lambda: have_trigger_for_height(...))`

this PR: should be no to little difference in test duration times comparing to develop with no failures on `wait_until(lambda: have_trigger_for_height(...))`

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

