### PR TITLE
test: fix some non-determinism in `feature_governance_cl.py`

### DIFF
--- a/test/functional/feature_governance_cl.py
+++ b/test/functional/feature_governance_cl.py
@@ -5,7 +5,6 @@
 """Tests governance checks can be skipped for blocks covered by the best chainlock."""
 
 import json
-import time
 
 from test_framework.governance import have_trigger_for_height
 from test_framework.messages import uint256_to_string
@@ -140,12 +139,17 @@ class DashGovernanceTest (DashTestFramework):
         self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_blocks(self.nodes[0:5]))
         # re-enable spork and continue
         self.nodes[0].sporkupdate("SPORK_9_SUPERBLOCKS_ENABLED", 0)
+
+        self.log.info("Bump time to trigger governance cleanup")
         # Trigger scheduler to mark old triggers for deletion
-        self.bump_mocktime(5 * 60)
-        # Let it do the job
-        time.sleep(1)
+        for node in self.nodes:
+            with node.assert_debug_log(expected_msgs=['UpdateCachesAndClean']):
+                self.bump_mocktime(5 * 60 + 1, nodes=[node])
         # Move forward to satisfy GOVERNANCE_DELETION_DELAY, should actually remove old triggers now
-        self.bump_mocktime(10 * 60)
+        for node in self.nodes:
+            with node.assert_debug_log(expected_msgs=['UpdateCachesAndClean -- Governance Objects: 0']):
+                # Trigger scheduler to mark old triggers for deletion
+                self.bump_mocktime(10 * 60 + 1, nodes=[node])
         self.wait_until(lambda: len(self.nodes[0].gobject("list", "valid", "triggers")) == 0, timeout=5)
 
         self.log.info("Reconnect isolated node and confirm the next ChainLock will let it sync")


### PR DESCRIPTION
## Issue being fixed or feature implemented
1. simply mining the cycle non-stop doesn't mean you get no triggers, disable spork temporary to be sure
2. sleeping 1s might not be enough for scheduled jobs, wait for the actual log lines

## What was done?


## How Has This Been Tested?
run `feature_governance_cl.py`

## Breaking Changes

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

