### PR TITLE
ci: fetch fast in clang-diff-format.yml

### DIFF
--- a/.github/workflows/clang-diff-format.yml
+++ b/.github/workflows/clang-diff-format.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Fetch git
-        run: git fetch
+        run: git fetch -fu origin develop:develop
       - name: Run Clang-Format-Diff.py
         run: |
           git diff -U0 origin/develop -- $(git ls-files -- $(cat test/util/data/non-backported.txt)) | ./contrib/devtools/clang-format-diff.py -p1 > diff_output.txt


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fetch fast in clang-diff CI. It used 268 minutes in last ~30 days. Each run I look at shows ~80% of the time being spent fetching.

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

