### PR TITLE
ci: streamline Python installation using uv and system Python

### DIFF
--- a/contrib/containers/ci/ci-slim.Dockerfile
+++ b/contrib/containers/ci/ci-slim.Dockerfile
@@ -32,7 +32,6 @@ ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/London"
 ENV APT_ARGS="-y --no-install-recommends --no-upgrade"
 
 # Packages needed for builds and tests
-# Note: Python build deps (libbz2-dev, libffi-dev, etc.) removed since uv installs Python binaries
 RUN set -ex; \
     apt-get update && apt-get install ${APT_ARGS} \
     build-essential \
@@ -40,8 +39,14 @@ RUN set -ex; \
     curl \
     g++ \
     git \
+    libbz2-dev \
+    liblzma-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
     make \
     xz-utils \
+    zlib1g-dev \
     zstd \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Use `uv` instead of `pyenv` for python installation and depends.

Before
```
 => [ci-sliea241b  4/10] RUN set -ex;     curl https://pyenv.run | bash     && pyenv update     && pyenv install 3.9.18     && pyenv global 3.9.18     && pyenv rehash                                                                                                             63.3s
 => [ci-sliea241b  5/10] RUN set -ex;     pip3 install --no-cache-dir     codespell==2.1.0     flake8==4.0.1     jinja2     lief==0.13.2     multiprocess     mypy==0.942     pyzmq==22.3.0     vulture==2.3                                                                       12.9s
 => [ci-sliea241b  6/10] RUN set -ex;     cd /tmp;     git clone --depth 1 --no-tags --branch=1.4.0 https://github.com/dashpay/dash_hash;     cd dash_hash && pip3 install -r requirements.txt .;     cd .. && rm -rf dash_hash                                                     9.1s
```

After
```
 => [ci-sliea241b  4/11] COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/                                                                                                                                                                                                     0.6s
 => [ci-sliea241b  5/11] RUN uv python install 3.9.18                                                                                                                                                                                                                               5.7s
 => [ci-sliea241b  6/11] RUN uv pip install --system --break-system-packages     codespell==2.1.0     flake8==4.0.1     jinja2     lief==0.13.2     multiprocess     mypy==0.942     pyzmq==22.3.0     vulture==2.3                                                                 3.9s
 => [ci-sliea241b  7/11] RUN set -ex;     cd /tmp;     git clone --depth 1 --no-tags --branch=1.4.0 https://github.com/dashpay/dash_hash;     cd dash_hash && uv pip install --system --break-system-packages -r requirements.txt .;     cd .. && rm -rf dash_hash                 10.8s
```

switching to UV cuts the shown portion of the CI build by ~64 seconds, ~75% overall faster, with huge wins in Python setup and package installs; the dash_hash step is slightly slower but dwarfed by the other gains.


## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

