### PR TITLE
fix: bump PORT_RANGE 5000->10000

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -311,7 +311,7 @@ MAX_NODES = 20
 # Don't assign rpc or p2p ports lower than this
 PORT_MIN = int(os.getenv('TEST_RUNNER_PORT_MIN', default=11000))
 # The number of ports to "reserve" for p2p and rpc, each
-PORT_RANGE = 5000
+PORT_RANGE = 10000
 
 
 class PortSeed:


### PR DESCRIPTION
## Issue being fixed or feature implemented
Alternative solution to the issue described here https://github.com/dashpay/dash/pull/6901#discussion_r2487892920

>The fix was included in this PR to deal with sporadic errors that affect CI results for this PR (the builds cited above are from this PR). The failure seems to be because of HTTP server port conflict and because the test is short, all 3 attempts can be exhausted before the test that is already using that HTTP port exits.

## What was done?

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

