### PR TITLE
[WIP] fix: update MI_ATOMIC_VAR_INIT definition for C23 compatibility

### DIFF
--- a/src/dashbls/depends/mimalloc/include/mimalloc-atomic.h
+++ b/src/dashbls/depends/mimalloc/include/mimalloc-atomic.h
@@ -39,7 +39,11 @@ terms of the MIT license. A copy of the license can be found in the file
 #include <stdatomic.h>
 #define  mi_atomic(name)        atomic_##name
 #define  mi_memory_order(name)  memory_order_##name
-#define  MI_ATOMIC_VAR_INIT(x)  ATOMIC_VAR_INIT(x)
+#if !defined(ATOMIC_VAR_INIT) || (__STDC_VERSION__ >= 202311L) // C23, ATOMIC_VAR_INIT was removed
+ #define MI_ATOMIC_VAR_INIT(x)  x
+#else
+ #define MI_ATOMIC_VAR_INIT(x)  ATOMIC_VAR_INIT(x)
+#endif
 #endif
 
 // Various defines for all used memory orders in mimalloc


### PR DESCRIPTION
Modified the definition of MI_ATOMIC_VAR_INIT to handle cases where ATOMIC_VAR_INIT is not defined or when compiling with C23, where it has been removed. This change ensures compatibility with newer C standards while maintaining support for older versions.

## Issue being fixed or feature implemented
 - _Why is this change required? What problem does it solve?_
 - _If it fixes an open issue, please link to the issue here._


## What was done?
  _Describe your changes in detail_


## How Has This Been Tested?
  _Please describe in detail how you tested your changes._

  _Include details of your testing environment, and the tests you ran
to see how your change affects other areas of the code, etc._


## Breaking Changes
  _Please describe any breaking changes your code introduces_


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

