### PR TITLE
fix: don't treat arrays/objects as string literals for composite methods

### DIFF
--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -12,10 +12,10 @@
 #include <univalue.h>
 
 /** Convert positional arguments to command-specific RPC representation */
-UniValue RPCConvertValues(const std::string& strMethod, const std::vector<std::string>& strParams);
+UniValue RPCConvertValues(std::string strMethod, const std::vector<std::string>& strParams);
 
 /** Convert named arguments to command-specific RPC representation */
-UniValue RPCConvertNamedValues(const std::string& strMethod, const std::vector<std::string>& strParams);
+UniValue RPCConvertNamedValues(std::string strMethod, const std::vector<std::string>& strParams);
 
 /** Non-RFC4627 JSON parser, accepts internal values (such as numbers, true, false, null)
  * as well as objects and arrays.

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -32,7 +32,7 @@ def process_mapping(fname):
                 if line.startswith('};'):
                     in_rpcs = False
                 elif '{' in line and '"' in line:
-                    m = re.search(r'{ *("[^"]*"), *([0-9]+) *, *("[^"]*") *},', line)
+                    m = re.search(r'{ *("[^"]*"), *([0-9]+) *, *("[^"]*")(?:, *(true|false))? *},', line)
                     assert m, 'No match to table expression: %s' % line
                     name = parse_string(m.group(1))
                     idx = int(m.group(2))
@@ -59,6 +59,8 @@ class HelpRpcTest(BitcoinTestFramework):
         mapping_client = process_mapping(file_conversion_table)
         # Ignore echojson in client table
         mapping_client = [m for m in mapping_client if m[0] != 'echojson']
+        # Filter out composite commands
+        mapping_client = [m for m in mapping_client if ' ' not in m[0]]
 
         mapping_server = self.nodes[0].help("dump_all_command_conversions")
         # Filter all RPCs whether they need conversion


### PR DESCRIPTION
## Additional Information

thephez identified a bug where attempting to specify arrays as expected by `coreP2PAddrs`, `platformHTTPSAddrs` or `platformP2PAddrs` using `dash-cli` or the Qt wallet resulted in errors (see below)

```
$ ./src/dash-cli --testnet protx register_prepare "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000" 1 '["1.1.1.1:19999"]' "yhq7ifNCtTKEpY4Yu5XPCcztQco6Fh6JsZ" "93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4" "yTretFTpoi3oQ3maZk5QadGaDWPiKnmDBc" 0 "yNbNZyCiTYSFtDwEXt7jChV7tZVYX862ua"
error code: -8
error message:
Error setting coreP2PAddrs[0] to '["1.1.1.1:19999"]' (invalid input)
```

This was not caught by functional tests as they send fully formed JSON messages and do not require JSON client interpretation, which both `dash-cli` and Dash Qt require, this pull request adds additional handling to ensure that arrays and objects are interpreted if they are likely to be so (starting and ending with curly or square brackets) or otherwise passed as-is as a string.

What this pull request _isn't_ is full fledged conversion support for composite RPC arguments to other non-string types like integers, the scope here is specifically to allow for the backwards compatibility logic for `coreP2PAddrs`, `platformHTTPSAddrs` or `platformP2PAddrs` to work as intended.

With this pull request, the following result is expected (see below)

```
$ ./src/dash-cli --testnet protx register_prepare "6fe28c0ab6f1b372c1a6a246ae63f74f931e8365e15a089c68d6190000000000" 1 '["1.1.1.1:19999"]' "yhq7ifNCtTKEpY4Yu5XPCcztQco6Fh6JsZ" "93746e8731c57f87f79b3620a7982924e2931717d49540a85864bd543de11c43fb868fd63e501a1db37e19ed59ae6db4" "yTretFTpoi3oQ3maZk5QadGaDWPiKnmDBc" 0 "yNbNZyCiTYSFtDwEXt7jChV7tZVYX862ua"
error code: -32603
error message:
No funds at specified address yNbNZyCiTYSFtDwEXt7jChV7tZVYX862ua
```

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

