### PR TITLE
ci: enhance guix-build workflow to run on label and tags by default

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -70,9 +70,6 @@ jobs:
     needs: build-image
     # runs-on: [ "self-hosted", "linux", "x64", "ubuntu-core" ]
     runs-on: ubuntu-24.04-arm
-    if: |
-      (github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/') || vars.RUN_GUIX_ON_ALL_PUSH == 'true')) ||
-      contains(github.event.pull_request.labels.*.name, 'guix-build')
     strategy:
       matrix:
         build_target: [x86_64-linux-gnu, arm-linux-gnueabihf, aarch64-linux-gnu, riscv64-linux-gnu, powerpc64-linux-gnu, x86_64-w64-mingw32, x86_64-apple-darwin, arm64-apple-darwin]


### PR DESCRIPTION
## Issue being fixed or feature implemented
See commits; not explicitly tested, but workflow is currently disabled.

## What was done?


## How Has This Been Tested?
## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

