### PR TITLE
feat: convert CSigSharesManager to use Mutex instead of RecursiveMutex

### DIFF
--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -805,8 +805,6 @@ void CSigSharesManager::TryRecoverSig(const CQuorum& quorum, const uint256& id, 
 
             singleMemberRecoveredSig = std::make_shared<CRecoveredSig>(quorum.params.type, quorum.qc->quorumHash, id, msgHash,
                                                       recoveredSig);
-            // Release lock before calling ProcessRecoveredSig to avoid double lock in HandleNewRecoveredSig
-            // ProcessRecoveredSig will synchronously call HandleNewRecoveredSig which requires the lock
         }
 
         sigSharesForRecovery.reserve((size_t) quorum.params.threshold);
@@ -825,7 +823,7 @@ void CSigSharesManager::TryRecoverSig(const CQuorum& quorum, const uint256& id, 
 
     // Handle single-member quorum case after releasing the lock
     if (singleMemberRecoveredSig) {
-        ProcessRecoveredSigUnlocked(singleMemberRecoveredSig);
+        sigman.ProcessRecoveredSig(singleMemberRecoveredSig, m_peerman);
         return; // end of single-quorum processing
     }
 
@@ -857,12 +855,7 @@ void CSigSharesManager::TryRecoverSig(const CQuorum& quorum, const uint256& id, 
         }
     }
 
-    ProcessRecoveredSigUnlocked(rs);
-}
-
-void CSigSharesManager::ProcessRecoveredSigUnlocked(const std::shared_ptr<const CRecoveredSig>& recoveredSig)
-{
-    sigman.ProcessRecoveredSig(recoveredSig, m_peerman);
+    sigman.ProcessRecoveredSig(rs, m_peerman);
 }
 
 CDeterministicMNCPtr CSigSharesManager::SelectMemberForRecovery(const CQuorum& quorum, const uint256 &id, int attempt)

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -477,9 +477,6 @@ private:
     void ProcessSigShare(const CSigShare& sigShare, const CQuorumCPtr& quorum) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void TryRecoverSig(const CQuorum& quorum, const uint256& id, const uint256& msgHash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
-private:
-    void ProcessRecoveredSigUnlocked(const std::shared_ptr<const CRecoveredSig>& recoveredSig) LOCKS_EXCLUDED(cs);
-
     bool GetSessionInfoByRecvId(NodeId nodeId, uint32_t sessionId, CSigSharesNodeState::SessionInfo& retInfo)
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
     static CSigShare RebuildSigShare(const CSigSharesNodeState::SessionInfo& session, const std::pair<uint16_t, CBLSLazySignature>& in);


### PR DESCRIPTION
 update lock requirements for various methods. This change enhances thread safety and simplifies locking semantics throughout the class.

## Issue being fixed or feature implemented
After other recent lock contention improvements, this RecursiveMutex is now the source of the most contention during high load. Convert the mutex from Recursive to non-recursive. Surprisingly compiler is happy with this and we don't need more invasive changes

## What was done?


## How Has This Been Tested?
Builds

## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

