### PR TITLE
fix: correct BLS scheme setting in `MigrateLegacyDiffs()` when `nVersion` is present

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1496,9 +1496,9 @@ bool CDeterministicMNManager::MigrateLegacyDiffs(const CBlockIndex* const tip_in
                     stateDiff.fields |= CDeterministicMNStateDiff::Field_nVersion;
                     stateDiff.state.nVersion = dmn->pdmnState->nVersion;
                 }
-                if (stateDiff.fields & CDeterministicMNStateDiff::Field_pubKeyOperator) {
-                    stateDiff.state.pubKeyOperator.SetLegacy(stateDiff.state.nVersion == ProTxVersion::LegacyBLS);
-                }
+            }
+            if (stateDiff.fields & CDeterministicMNStateDiff::Field_pubKeyOperator) {
+                stateDiff.state.pubKeyOperator.SetLegacy(stateDiff.state.nVersion == ProTxVersion::LegacyBLS);
             }
             convertedDiff.updatedMNs.emplace(internalId, stateDiff);
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
BLS public key legacy scheme is only being set when `nVersion` field is missing and needed to be auto-filled, instead of being set whenever a `pubKeyOperator` field is present.

## What was done?
Moved the `SetLegacy()` call outside the `nVersion` check.

## How Has This Been Tested?
Migrate on mainnet at block 2367886

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

