### PR TITLE
perf: remove duplicated check of same key in the instant send database

### DIFF
--- a/src/instantsend/db.cpp
+++ b/src/instantsend/db.cpp
@@ -279,11 +279,7 @@ InstantSendLockPtr CInstantSendDb::GetInstantSendLockByHashInternal(const uint25
     ret = std::make_shared<InstantSendLock>();
     bool exists = db->Read(std::make_tuple(DB_ISLOCK_BY_HASH, hash), *ret);
     if (!exists || (::SerializeHash(*ret) != hash)) {
-        ret = std::make_shared<InstantSendLock>();
-        exists = db->Read(std::make_tuple(DB_ISLOCK_BY_HASH, hash), *ret);
-        if (!exists || (::SerializeHash(*ret) != hash)) {
-            ret = nullptr;
-        }
+        ret = nullptr;
     }
     islockCache.insert(hash, ret);
     return ret;


### PR DESCRIPTION
## Issue being fixed or feature implemented

Previous implementation checked both Deterministic and Non-deterministic instant send locks; though once non-determinstic has been removed, implementation has been updated and now the same key is checked twice.


## What was done?
This PR removes duplicated check


## How Has This Been Tested?
See CI

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone