### PR TITLE
fix: avoid 2 atomic loads, where 1 is intended

### DIFF
--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -1658,7 +1658,8 @@ std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorum& quorum
 
         // TODO: This one should be SIGN by QUORUM key, not by OPERATOR key
         // see TODO in CDKGSession::FinalizeSingleCommitment for details
-        sigShare.sigShare.Set(m_mn_activeman.Sign(signHash, bls::bls_legacy_scheme.load()), bls::bls_legacy_scheme.load());
+        auto bls_scheme = bls::bls_legacy_scheme.load();
+        sigShare.sigShare.Set(m_mn_activeman.Sign(signHash, bls_scheme), bls_scheme);
 
         if (!sigShare.sigShare.Get().IsValid()) {
             LogPrintf("CSigSharesManager::%s -- failed to sign sigShare. signHash=%s, id=%s, msgHash=%s, time=%s\n",
@@ -1692,7 +1693,8 @@ std::optional<CSigShare> CSigSharesManager::CreateSigShare(const CQuorum& quorum
     CSigShare sigShare(quorum.params.type, quorum.qc->quorumHash, id, msgHash, uint16_t(memberIdx), {});
     uint256 signHash = sigShare.buildSignHash().Get();
 
-    sigShare.sigShare.Set(skShare.Sign(signHash, bls::bls_legacy_scheme.load()), bls::bls_legacy_scheme.load());
+    auto bls_scheme = bls::bls_legacy_scheme.load();
+    sigShare.sigShare.Set(skShare.Sign(signHash, bls_scheme), bls_scheme);
     if (!sigShare.sigShare.Get().IsValid()) {
         LogPrintf("CSigSharesManager::%s -- failed to sign sigShare. signHash=%s, id=%s, msgHash=%s, time=%s\n", __func__,
                   signHash.ToString(), sigShare.getId().ToString(), sigShare.getMsgHash().ToString(), t.count());


### PR DESCRIPTION
## Issue being fixed or feature implemented
replace 2 atomic loads with 1, to avoid possible race

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

