### PR TITLE
fix: improve atomic load and set for cleanup height in CDeterministicMNManager

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -722,8 +722,10 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, gsl::not_null<co
         }
         LogPrintf("CDeterministicMNManager::%s -- DIP3 is enforced now. nHeight=%d\n", __func__, nHeight);
     }
-    if (nHeight > to_cleanup) to_cleanup = nHeight;
-
+    int current = to_cleanup.load();
+    while (nHeight > current && !to_cleanup.compare_exchange_weak(current, nHeight)) {
+        // Loop continues if compare_exchange_weak failed (another thread changed it) (current is updated to the new value in to_cleanup)
+    }
     return true;
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
prior logic could have two threads race and overwrite updates, losing the max of those set; new logic ensures the max is always the final stored state.

## What was done?

## How Has This Been Tested?
compiles


## Breaking Changes
None

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

