### PR TITLE
fix: bls benchmarks crash when ran independently

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -4,6 +4,7 @@
 
 #include <bench/bench.h>
 
+#include <bls/bls.h>
 #include <clientversion.h>
 #include <crypto/sha256.h>
 #include <crypto/x11/dispatch.h>
@@ -64,6 +65,8 @@ int main(int argc, char** argv)
     SetupBenchArgs(argsman);
     SapphireAutoDetect();
     SHA256AutoDetect();
+    BLSInit();
+    bls::bls_legacy_scheme.store(false);
     std::string error;
     if (!argsman.ParseParameters(argc, argv, error)) {
         tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Crashes like below happen when BLS bench's are ran w/o BLS_DKG bench's
```
> $ ./src/bench/bench_dash --filter="BLS_.*"                                                                     [±ci/run-bench ●]

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|           70,625.77 |           14,159.14 |    0.5% |      0.08 | `BLS_PubKeyAggregate_Batch_100`
|          143,101.94 |            6,988.03 |    0.6% |      0.17 | `BLS_PubKeyAggregate_Batch_200`
|           16,714.92 |           59,826.77 |    1.4% |      0.02 | `BLS_PubKeyAggregate_Batch_25`
|            2,733.86 |          365,783.71 |    0.9% |      0.01 | `BLS_PubKeyAggregate_Batch_5`
|           34,708.34 |           28,811.52 |    0.7% |      0.04 | `BLS_PubKeyAggregate_Batch_50`
|           77,659.39 |           12,876.74 |    0.5% |      0.09 | `BLS_PubKeyAggregate_Iterative_100`
|          155,927.75 |            6,413.23 |    0.8% |      0.19 | `BLS_PubKeyAggregate_Iterative_200`
|           18,291.67 |           54,669.70 |    1.3% |      0.02 | `BLS_PubKeyAggregate_Iterative_25`
|            2,830.29 |          353,320.46 |    0.5% |      0.01 | `BLS_PubKeyAggregate_Iterative_5`
|           37,932.04 |           26,362.94 |    0.9% |      0.05 | `BLS_PubKeyAggregate_Iterative_50`
|              777.73 |        1,285,787.58 |    1.5% |      0.01 | `BLS_PubKeyAggregate_Normal`
|              390.42 |        2,561,315.62 |    1.2% |      0.01 | `BLS_SecKeyAggregate_Normal`
|          516,138.10 |            1,937.47 |    0.3% |      0.62 | `BLS_Sign_Normal`
|            1,463.50 |          683,294.10 |    0.8% |      0.01 | `BLS_SignatureAggregate_Normal`
expected valid but it is invalid
Assertion failure:
  assertion: false
  file: bls.cpp, line: 301
  function: operator()
   0#: (0x103732300) stacktraces.cpp:640   - __assert_rtn
   1#: (0x102AB46CC) basic_ostream.h       - BLS_Verify_Batched(ankerl::nanobench::Bench&)::$_0::operator()() const
   2#: (0x102AB46CC) nanobench.h:1221      - ankerl::nanobench::Bench& ankerl::nanobench::Bench::run<BLS_Verify_Batched(ankerl::nanobench::Bench&)::$_0>(BLS_Verify_Batched(ankerl::nanobench::Bench&)::$_0&&)
   3#: (0x102AAFBE4) vector:1933           - std::__1::vector<bool, std::__1::allocator<bool>>::__destroy_vector::operator()[abi:ne190102]()
   4#: (0x102AAFBE4) vector:1942           - std::__1::vector<bool, std::__1::allocator<bool>>::~vector[abi:ne190102]()
   5#: (0x102AAFBE4) vector:1942           - std::__1::vector<bool, std::__1::allocator<bool>>::~vector[abi:ne190102]()
   6#: (0x102AAFBE4) bls.cpp:305           - BLS_Verify_Batched(ankerl::nanobench::Bench&)
   7#: (0x102A9605C) function.h            - std::__1::__function::__value_func<void (ankerl::nanobench::Bench&)>::operator()[abi:ne190102](ankerl::nanobench::Bench&) const
   8#: (0x102A9605C) function.h:989        - std::__1::function<void (ankerl::nanobench::Bench&)>::operator()(ankerl::nanobench::Bench&) const
   9#: (0x102A9605C) bench.cpp:120         - benchmark::BenchRunner::RunAll(benchmark::Args const&)
  10#: (0x102AA8EE4) string:1881           - std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::__is_long[abi:ne190102]() const
  11#: (0x102AA8EE4) string:1212           - std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::~basic_string()
  12#: (0x102AA8EE4) string:1210           - std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::~basic_string()
  13#: (0x102AA8EE4) bench.h:54            - benchmark::Args::~Args()
  14#: (0x102AA8EE4) bench.h:54            - benchmark::Args::~Args()
  15#: (0x102AA8EE4) bench_bitcoin.cpp:137 - main
  16#: (0x1919C0274) <unknown-file>        - ???
Assertion failed: (false), function operator(), file bls.cpp, line 301.
[1]    20836 abort      ./src/bench/bench_dash --filter="BLS_.*"
```

## What was done?
Don't assume scheme

## How Has This Been Tested?
Bench ran

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

