### PR TITLE
ci: Remove test datadir after extracting logs to free up CI disk space

### DIFF
--- a/ci/dash/test_integrationtests.sh
+++ b/ci/dash/test_integrationtests.sh
@@ -69,7 +69,7 @@ if [ "$BASEDIR" != "" ]; then
       mv "testdatadirs/$BASEDIR/$d/$f" "$d2/"
     done
     # Remove test datadir after extracting logs to free up CI disk space
-    rm -rf "testdatadirs/$BASEDIR/$d"
+    rm -rf "testdatadirs/$BASEDIR/$d" || echo "Warning: Failed to remove test datadir $d"
   done
 fi
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
CI started to fail with `System.IO.IOException: No space left on device` for otherwise successful jobs recently. Example: https://github.com/dashpay/dash/actions/runs/19371409140/job/55429155189.

## What was done?
Remove test datadir after extracting logs to free up CI disk space.

## How Has This Been Tested?
See CI for this PR

## Breaking Changes
n/a, we don't store test datadirs in artifacts or anywhere else afaik

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

