### PR TITLE
ci: Remove blocks folder from test datadir to free up CI disk space

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -16,6 +16,7 @@ import argparse
 from collections import deque
 import configparser
 import datetime
+import itertools
 import os
 import time
 import shutil
@@ -546,9 +547,10 @@ def main():
         failfast=args.failfast,
         use_term_control=args.ansi,
         skipunit=args.skipunit,
+        ci=args.ci,
     )
 
-def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, attempts=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, use_term_control, skipunit=False):
+def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, attempts=1, enable_coverage=False, args=None, combined_logs_len=0, failfast=False, use_term_control, skipunit=False, ci=False):
     args = args or []
 
     # Warn if dashd is already running
@@ -621,6 +623,19 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, attempts=1, enab
             done_str = f"{len(test_results)}/{test_count} - {BOLD[1]}{test_result.name}{BOLD[0]}"
             if test_result.status == "Passed":
                 logging.debug("%s passed, Duration: %s s" % (done_str, test_result.time))
+                # Remove blocks folder from test datadir to free up CI disk space
+                if ci and os.path.isdir(testdir):
+                    for i in itertools.count():
+                        blocksdir = f"{testdir}/node{i}/regtest/blocks"
+                        if not os.path.isdir(blocksdir):
+                            break
+                        if os.path.islink(blocksdir):
+                            # Skip symlinks to avoid breaking custom test setups
+                            continue
+                        try:
+                            shutil.rmtree(blocksdir)
+                        except (OSError, PermissionError) as e:
+                            logging.debug(f"Failed to remove {blocksdir}: {e}")
             elif test_result.status == "Skipped":
                 logging.debug(f"{done_str} skipped ({skip_reason})")
             else:


### PR DESCRIPTION
## Issue being fixed or feature implemented
CI started to fail with `System.IO.IOException: No space left on device` for otherwise successful jobs recently. Example: https://github.com/dashpay/dash/actions/runs/19371409140/job/55429155189. Unfortunately, #6978 wasn't enough to fix the issue https://github.com/dashpay/dash/actions/runs/19380753498/job/55475384865?pr=6978#step:6:4873.

## What was done?
Remove blocks folder from test datadir to free up CI disk space.

## How Has This Been Tested?
https://github.com/UdjinM6/dash/actions/runs/19390408530 + see CI for this PR.

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

