### PR TITLE
ci: Add missing CI_FAILFAST_TEST_LEAVE_DANGLING env var to GH test workflow

### DIFF
--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -18,6 +18,7 @@ on:
 
 env:
   INTEGRATION_TESTS_ARGS: "--extended --exclude feature_pruning,feature_dbcrash"
+  CI_FAILFAST_TEST_LEAVE_DANGLING: 1  # GHA does not care about dangling processes and setting this variable avoids killing the CI script itself on error
 
 jobs:
   test-src:


### PR DESCRIPTION
## Issue being fixed or feature implemented
CI script is killed on test failures and can't collect/upload logs.

https://github.com/dashpay/dash/actions/runs/19392476511/job/55488607745.


## What was done?
Set CI_FAILFAST_TEST_LEAVE_DANGLING env var

## How Has This Been Tested?
https://github.com/UdjinM6/dash/actions/runs/19404370303/job/55516930132

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

