### PR TITLE
fix: adjust condition to detect suitable pending masternodes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3454,13 +3454,12 @@ void CConnman::ThreadOpenMasternodeConnections(CDeterministicMNManager& dmnman, 
                 // Check if we should connect to this masternode
                 // We already hold m_nodes_mutex here, so check m_masternode_connection directly
                 if (dmn && !connectedNodes.count(dmn->pdmnState->netInfo->GetPrimary())) {
-                    if (const CNode* pnode = FindNode(dmn->pdmnState->netInfo->GetPrimary())) {
-                        if (!pnode->m_masternode_connection) {
-                            LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- opening pending masternode connection to %s, service=%s\n",
-                                                         _func_, dmn->proTxHash.ToString(),
-                                                         dmn->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
-                            return dmn;
-                        }
+                    const CNode* pnode = FindNode(dmn->pdmnState->netInfo->GetPrimary(), /*fExcludeDisconnecting=*/false);
+                    if (pnode == nullptr || (!pnode->m_masternode_connection && !pnode->fDisconnect)) {
+                        LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- opening pending masternode connection to %s, service=%s\n",
+                                                     _func_, dmn->proTxHash.ToString(),
+                                                     dmn->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
+                        return dmn;
                     }
                 }
             }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Mixing is broken on develop, mixing wallet can't connect to masternodes.

This condition was incorrectly refactored in #6912, https://github.com/dashpay/dash/pull/6912/files#diff-00021eed586a482abdb09d6cdada1d90115abe988a91421851960e26658bed02R3454-R3458.

## What was done?
see commit

## How Has This Been Tested?
Mixing works again

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

