### PR TITLE
fix: correctly detect and skip disconnecting pending quorum masternodes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3382,9 +3382,9 @@ void CConnman::ThreadOpenMasternodeConnections(CDeterministicMNManager& dmnman, 
                         continue;
                     }
                     const auto addr2 = dmn->pdmnState->netInfo->GetPrimary();
-                    CNode* pnode = FindNodeMutable(addr2);
-                    if (pnode && pnode->m_masternode_connection) {
-                        // node is masternode, skip it
+                    CNode* pnode = FindNodeMutable(addr2, /*fExcludeDisconnecting=*/false);
+                    if (pnode && (pnode->m_masternode_connection || pnode->fDisconnect)) {
+                        // node is either a masternode or disconnecting, skip it
                         continue;
                     }
                     if (connectedNodes.count(addr2)) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Similar to #6983, incorrect refactoring in #6912

## What was done?
Correctly detect and skip disconnecting pending quorum masternodes

## How Has This Been Tested?
Run tests

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

