### PR TITLE
fix: reduce debug level for rpc/evo.cpp to avoid clang crash

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -617,8 +617,9 @@ libbitcoin_node_a_SOURCES += dummywallet.cpp
 endif
 
 # Workaround for LLVM 18.1.8 bug: reduce debug level for rpc/evo.cpp to avoid crash
-# in debug info generation for complex std::function template
-rpc/libbitcoin_node_a-evo.$(OBJEXT): CXXFLAGS += -g0
+# in debug info generation for complex std::function template.
+# Only apply this workaround when using Clang.
+rpc/libbitcoin_node_a-evo.$(OBJEXT): CXXFLAGS += $(shell $(CXX) --version | grep -q clang && echo "-g0")
 
 if ENABLE_ZMQ
 libbitcoin_zmq_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS) $(ZMQ_CFLAGS)


### PR DESCRIPTION
## Issue being fixed or feature implemented
The LLVM 18.1.8 compiler is crashing when generating debug information for rpc/evo.cpp:
https://github.com/dashpay/dash/actions/runs/19477052188/job/55739582899
https://github.com/UdjinM6/dash/actions/runs/19470819712/job/55717447032

2699740081f9d70d6c2a4dbbd1ec57a5b2d1d473 from #6966 triggered a bug in clang - no crash after reverting it:
https://github.com/UdjinM6/dash/actions/runs/19495040944

## What was done?
Implement a workaround.

## How Has This Been Tested?
https://github.com/UdjinM6/dash/actions/runs/19495218479

## Breaking Changes
Not exactly breaking but the tradeoff is that rpc/evo.cpp won't have debug symbols which is acceptable imo.

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

