### PR TITLE
fix: use proper host objcopy/readelf

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -354,7 +354,7 @@ mkdir -p "$DISTSRC"
                             find "${DISTNAME}/lib" -type f -print0
                         } | while IFS= read -r -d '' elf; do
                             if file "$elf" | grep -q "ELF.*executable\|ELF.*shared object"; then
-                                build_id=$(${HOST}-readelf -n "$elf" 2>/dev/null | awk '/Build ID/ {print $3; exit}')
+                                build_id=$("${HOST}"-readelf -n "$elf" 2>/dev/null | awk '/Build ID/ {print $3; exit}')
                                 if [ -n "$build_id" ] && [ -f "${elf}.dbg" ]; then
                                     dir="${DISTNAME}/usr/lib/debug/.build-id/${build_id:0:2}"
                                     mkdir -p "$dir"
@@ -374,13 +374,13 @@ mkdir -p "$DISTSRC"
                                 while IFS= read -r -d '' elf; do
                                     if file "$elf" | grep -q "ELF.*executable\|ELF.*shared object"; then
                                         # Check for build-id
-                                        if ! ${HOST}-readelf -n "$elf" 2>/dev/null | grep -q "Build ID"; then
+                                        if ! "${HOST}"-readelf -n "$elf" 2>/dev/null | grep -q "Build ID"; then
                                             echo "ERROR: No build-id found in $elf" >&2
                                             verification_failed=1
                                         fi
 
                                         # Check for .gnu_debuglink
-                                        if ! ${HOST}-readelf --string-dump=.gnu_debuglink "$elf" >/dev/null 2>&1; then
+                                        if ! "${HOST}"-readelf --string-dump=.gnu_debuglink "$elf" >/dev/null 2>&1; then
                                             echo "ERROR: No .gnu_debuglink found in $elf" >&2
                                             verification_failed=1
                                         fi


### PR DESCRIPTION
## Issue being fixed or feature implemented
Our script didn't use host specific objcopy, so it would crash with not being able to interpret them depending on what we were building on and for.


## What was done?
Use proper objcopy

## How Has This Been Tested?
CI after: https://github.com/PastaPastaPasta/dash/actions/runs/19547578950
CI before: https://github.com/PastaPastaPasta/dash/actions/runs/19544501408

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

