### PR TITLE
refactor: optimize node disconnection logic to avoid unnecessary locks

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2039,29 +2039,42 @@ void CConnman::DisconnectNodes()
     // m_reconnections_mutex while holding m_nodes_mutex.
     decltype(m_reconnections) reconnections_to_add;
 
+    // Quick check without exclusive lock to avoid unnecessary locking
+    // Note: This is a best-effort optimization. If network is active and no nodes
+    // are marked for disconnect, we can skip the expensive exclusive lock.
+    // If network is inactive or nodes need cleanup, we must take the lock.
     bool has_to_disconnect = false;
-    {
-        READ_LOCK(m_nodes_mutex);
-
-        for (CNode* pnode : m_nodes) {
-            // Disconnect any connected nodes, if network is not active
-            if (!fNetworkActive && !pnode->fDisconnect) {
-                LogPrint(BCLog::NET_NETCONN, "Network not active, dropping peer=%d\n", pnode->GetId());
-                pnode->fDisconnect = true;
+    if (fNetworkActive) {
+        {
+            READ_LOCK(m_nodes_mutex);
+            for (CNode* pnode : m_nodes) {
+                if (pnode->fDisconnect) {
+                    has_to_disconnect = true;
+                    break;
+                }
             }
-            if (!has_to_disconnect && pnode->fDisconnect) {
-                has_to_disconnect = true;
-            }
+        }
+        // Only return early if network is active AND no nodes need disconnection
+        // AND no disconnected nodes need cleanup (checked below)
+        if (!has_to_disconnect && m_nodes_disconnected.empty()) {
+            return;
         }
     }
 
-    // Avoid taking locks if there's nothing to do
-    if (!has_to_disconnect) return;
-
-    {
+    if (has_to_disconnect || !fNetworkActive) {
         LOCK(m_nodes_mutex);
 
-        // Disconnect unused nodes
+        if (!fNetworkActive) {
+            // Disconnect any connected nodes
+            for (CNode* pnode : m_nodes) {
+                if (!pnode->fDisconnect) {
+                    LogPrint(BCLog::NET_NETCONN, "Network not active, dropping peer=%d\n", pnode->GetId());
+                    pnode->fDisconnect = true;
+                }
+            }
+        }
+
+        // Disconnect unused nodes, if we have any
         for (auto it = m_nodes.begin(); it != m_nodes.end(); )
         {
             CNode* pnode = *it;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Avoid taking exclusive lock on m_nodes_mutex EVERY run of DisconnectNodes which is called in every loop of ThreadSocketHandler. 

This location's exclusive mutex is currently third most contended by time, and fifth by count:

```
Lock Name                                Location                               Count    Total(μs)    Avg(μs)    Max(μs)  Nodes
------------------------------------------------------------------------------------------------------------------------
m_nodes_mutex                            net.cpp:2043                           27914     32777805     1174.2      70013      6
```

But; most loops / times we run DisconnectNodes, we probably don't do any disconnecting. Let's optimize for this case and only take a read lock if we have no peers to disconnect. 

## What was done?


## How Has This Been Tested?
builds

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

