### PR TITLE
fix: include QDebug directly

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -49,6 +49,7 @@
 #include <memory>
 
 #include <QApplication>
+#include <QDebug>
 #include <QLatin1String>
 #include <QLibraryInfo>
 #include <QLocale>


### PR DESCRIPTION
## Issue being fixed or feature implemented
QT packages shipped with Debian 13 currently doesn't build, due to missing QDebug include.

## What was done?
directly include

## How Has This Been Tested?
Builds on Debian 13 w/ system packages

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

