### PR TITLE
ci: Free disk space by removing no longer needed build files

### DIFF
--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -108,6 +108,8 @@ jobs:
         run: |
           export BUILD_TARGET="${{ inputs.build-target }}"
           export BUNDLE_KEY="build-${BUILD_TARGET}-$(git rev-parse --short=8 HEAD)"
+          find "build-ci/dashcore-${BUILD_TARGET}/src/" -name "*.a" -type f -delete
+          find "build-ci/dashcore-${BUILD_TARGET}/src/" -name "*.o" -type f -delete
           ./ci/dash/bundle-artifacts.sh create
           echo "key=${BUNDLE_KEY}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Some CI src builds started to fail for me with `No space left on device` https://github.com/UdjinM6/dash/actions/runs/19684695976/job/56395728306

## What was done?
Free disk space by removing heavy no longer needed build files, they are excluded in `bundle-artifacts.sh` anyway

## How Has This Been Tested?
https://github.com/UdjinM6/dash/actions/runs/19704232668

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

