### PR TITLE
feat(qt): Add flag to allow duplicate recipient addresses in GUI

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -498,6 +498,7 @@ static void SetupUIArgs(ArgsManager& argsman)
     argsman.AddArg("-splash", strprintf(QObject::tr("Show splash screen on startup (default: %u)").toStdString(), DEFAULT_SPLASHSCREEN), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-uiplatform", strprintf("Select platform to customize UI for (one of windows, macosx, other; default: %s)", BitcoinGUI::DEFAULT_UIPLATFORM), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::GUI);
     argsman.AddArg("-debug-ui", "Updates the UI's stylesheets in realtime with changes made to the css files in -custom-css-dir and forces some widgets to show up which are usually only visible under certain circumstances. (default: 0)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::GUI);
+    argsman.AddArg("-allowduplicaterecipients", "Allow sending to duplicate recipient addresses in a single transaction. For testing purposes only. (default: 0)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::GUI);
     argsman.AddArg("-windowtitle=<name>", _("Sets a window title which is appended to \"Dash Core - \"").translated, ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -212,6 +212,9 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         return TransactionCreationFailed;
     }
 
+    // Check if duplicate recipients are allowed (debug/testing feature)
+    bool fAllowDuplicateDestAddr = gArgs.GetBoolArg("-allowduplicaterecipients", false);
+
     QSet<QString> setAddress; // Used to detect duplicates
     int nAddresses = 0;
 
@@ -239,7 +242,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             total += rcp.amount;
         }
     }
-    if(setAddress.size() != nAddresses)
+    if(setAddress.size() != nAddresses && !fAllowDuplicateDestAddr)
     {
         return DuplicateAddress;
     }


### PR DESCRIPTION
This enables users of the Qt wallet to send to the same address in a single transaction. This is useful for setting up multiple MN collateral transactions, but probably only for advanced users and developers.

Usage: ./qt/dash-qt -allowduplicaterecipients

I'm ok if there's no desire to merge this. I just thought it was a nice feature to send all collateral in a single TX instead of having to send multiple. I presume this is mostly just useful for testnet, as a hardware wallet would be preferred for mainnet, but it may also work to create an unsigned TX which could be signed by a HW wallet w/the right UI.