### PR TITLE
fix: update BuildTestVectors call to adjust batch size based on output flag

### DIFF
--- a/src/bench/bls.cpp
+++ b/src/bench/bls.cpp
@@ -255,7 +255,7 @@ static void BLS_Verify_Batched(benchmark::Bench& bench)
     std::vector<CBLSSignature> sigs;
     std::vector<uint256> msgHashes;
     std::vector<bool> invalid;
-    BuildTestVectors(bench.output() ? 1000 : 1, 10, pubKeys, secKeys, sigs, msgHashes, invalid);
+    BuildTestVectors(bench.output() ? 1000 : 1, bench.output() ? 10 : 1, pubKeys, secKeys, sigs, msgHashes, invalid);
 
     // Benchmark.
     size_t i = 0;
@@ -311,7 +311,7 @@ static void BLS_Verify_BatchedParallel(benchmark::Bench& bench)
     std::vector<CBLSSignature> sigs;
     std::vector<uint256> msgHashes;
     std::vector<bool> invalid;
-    BuildTestVectors(bench.output() ? 1000 : 1, 10, pubKeys, secKeys, sigs, msgHashes, invalid);
+    BuildTestVectors(bench.output() ? 1000 : 1, bench.output() ? 10 : 1, pubKeys, secKeys, sigs, msgHashes, invalid);
 
     std::list<std::pair<size_t, std::future<bool>>> futures;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
see https://github.com/dashpay/dash/issues/7011

## What was done?


## How Has This Been Tested?
runs locally; but I didn't reproduce the failure, likely due to different compilation flags. Even with undefined sanitizer, I couldn't reproduce.

## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

