### PR TITLE
ci: don't use pull_request in guix-build.yml

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -7,7 +7,6 @@ permissions:
 
 on:
   pull_request_target:
-  pull_request:
     types: [labeled]
   push:
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
`pull_request` doesn't have enough permissions. Only works for a branch in the same repo e.g. https://github.com/UdjinM6/dash/actions/runs/19731863320.

#6951 follow-up

## What was done?

## How Has This Been Tested?
For a branch from a forked repo https://github.com/UdjinM6/dash/pull/24:
develop: https://github.com/UdjinM6/dash/actions/runs/19732188359?pr=24
this PR (develop in my repo updated with this patch): https://github.com/UdjinM6/dash/actions/runs/19732354343?pr=24

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

