### PR TITLE
feat(qt): warn when sending to duplicate recipients

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -334,9 +334,26 @@ bool SendCoinsDialog::send(const QList<SendCoinsRecipient>& recipients, QString&
     processSendCoinsReturn(prepareStatus,
         BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), m_current_transaction->getTransactionFee()));
 
-    if(prepareStatus.status != WalletModel::OK) {
+    // Handle DuplicateAddress as a warning that requires user confirmation
+    if (prepareStatus.status == WalletModel::DuplicateAddress) {
+        QMessageBox::StandardButton reply = QMessageBox::question(
+            this,
+            tr("Confirm duplicate recipients"),
+            tr("You are sending to the same address multiple times in a single transaction. "
+               "This is unusual and may not be what you intended. "
+               "Are you sure you want to proceed?"),
+            QMessageBox::Yes | QMessageBox::Cancel,
+            QMessageBox::Cancel
+        );
+
+        if (reply != QMessageBox::Yes) {
+            fNewRecipientAllowed = true;
+            return false;
+        }
+        // User confirmed, continue
+    } else if (prepareStatus.status != WalletModel::OK) {
         fNewRecipientAllowed = true;
-          return false;
+        return false;
     }
 
     QStringList formatted;
@@ -812,9 +829,6 @@ void SendCoinsDialog::processSendCoinsReturn(const WalletModel::SendCoinsReturn 
     case WalletModel::AmountWithFeeExceedsBalance:
         msgParams.first = tr("The total exceeds your balance when the %1 transaction fee is included.").arg(msgArg);
         break;
-    case WalletModel::DuplicateAddress:
-        msgParams.first = tr("Duplicate address found: addresses should only be used once each.");
-        break;
     case WalletModel::TransactionCreationFailed:
         msgParams.first = tr("Transaction creation failed!");
         msgParams.second = CClientUIInterface::MSG_ERROR;
@@ -823,6 +837,7 @@ void SendCoinsDialog::processSendCoinsReturn(const WalletModel::SendCoinsReturn 
         msgParams.first = tr("A fee higher than %1 is considered an absurdly high fee.").arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), model->wallet().getDefaultMaxTxFee()));
         break;
     // included to prevent a compiler warning.
+    case WalletModel::DuplicateAddress:
     case WalletModel::OK:
     default:
         return;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -239,10 +239,6 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
             total += rcp.amount;
         }
     }
-    if(setAddress.size() != nAddresses)
-    {
-        return DuplicateAddress;
-    }
 
     CAmount nBalance = m_wallet->getAvailableBalance(coinControl);
 
@@ -277,6 +273,11 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
     // m_default_max_tx_fee. This merely a belt-and-suspenders check).
     if (nFeeRequired > m_wallet->getDefaultMaxTxFee()) {
         return AbsurdFee;
+    }
+
+    // Return warning if duplicate addresses detected, but allow transaction to proceed
+    if (setAddress.size() != nAddresses) {
+        return DuplicateAddress;
     }
 
     return SendCoinsReturn(OK);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Having duplicated recipients is ok on protocol level, we could be less restrictive in GUI.

Inspired by #7012 

## What was done?
Handle `DuplicateAddress` as a warning status instead of an error. Show a confirmation dialog when duplicates are detected, allowing the transaction to proceed if the user confirms.

<img width="532" height="297" alt="Screenshot 2025-11-27 at 22 34 56" src="https://github.com/user-attachments/assets/b76f7204-9127-456b-ba80-72cbd230b7ec" />


## How Has This Been Tested?
Run dash-qt, send a tx

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

