### PR TITLE
test: fix intermittent qt test failure

### DIFF
--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -157,12 +157,12 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     // Submit a new address which should add successfully - we expect the
     // warning message to be blank.
     EditAddressAndSubmit(
-        &editAddressDialog, QString("io - new A"), new_address_a, QString(""));
+        &editAddressDialog, QString("i0 - new A"), new_address_a, QString(""));
     check_addbook_size(3);
     QCOMPARE(table_view->model()->rowCount(), 2);
 
     EditAddressAndSubmit(
-        &editAddressDialog, QString("io - new B"), new_address_b, QString(""));
+        &editAddressDialog, QString("i0 - new B"), new_address_b, QString(""));
     check_addbook_size(4);
     QCOMPARE(table_view->model()->rowCount(), 3);
 
@@ -174,17 +174,17 @@ void TestAddAddressesToSendBook(interfaces::Node& node)
     search_line->setText(s_label);
     QCOMPARE(table_view->model()->rowCount(), 1);
 
-    search_line->setText("io");
+    search_line->setText("i0");
     QCOMPARE(table_view->model()->rowCount(), 2);
 
     // Check wilcard "?".
-    search_line->setText("io?new");
+    search_line->setText("i0?new");
     QCOMPARE(table_view->model()->rowCount(), 0);
-    search_line->setText("io???new");
+    search_line->setText("i0???new");
     QCOMPARE(table_view->model()->rowCount(), 2);
 
     // Check wilcard "*".
-    search_line->setText("io*new");
+    search_line->setText("i0*new");
     QCOMPARE(table_view->model()->rowCount(), 2);
     search_line->setText("*");
     QCOMPARE(table_view->model()->rowCount(), 3);


### PR DESCRIPTION
## Issue being fixed or feature implemented
qt tests fail sometimes: https://github.com/UdjinM6/dash/actions/runs/19789400004/job/56700920992#step:10:203

The reason is `io` is a valid set of base58 characters (`ybEBNswQyMLQPjMXN6ytuRetioxS4CrAu2` is a valid address for example), so one of preexisting addresses can match the filter and row count check will fail.

## What was done?
Use non-base58 character `io` -> `i0`

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

