### PR TITLE
ci: simplify checkout refs

### DIFF
--- a/.github/workflows/cache-depends-sources.yml
+++ b/.github/workflows/cache-depends-sources.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check for cached sources
         id: cache-check

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           path: dash
           fetch-depth: 0
 
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           path: dash
           fetch-depth: 0
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`ref`
>    The branch, tag or SHA to checkout. When checking out the repository that
>    triggered a workflow, this defaults to the reference or SHA for that event.
>    Otherwise, uses the default branch.

https://github.com/actions/checkout?tab=readme-ov-file#usage

`github.sha`
> The commit SHA that triggered the workflow. The value of this commit SHA depends on the event that triggered the workflow. For more information, see [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows).

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context

## What was done?
remove redundant refs

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

