### PR TITLE
fix: drop gsl usage from RebuildListFromBlock function wrapper

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2430,7 +2430,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 LogPrintf("Verifying and repairing masternode list diffs...\n");
                 const auto start{SteadyClock::now()};
                 // Create a callback that wraps CSpecialTxProcessor::BuildNewListFromBlock
-                auto build_list_func = [&node](const CBlock& block, gsl::not_null<const CBlockIndex*> pindexPrev,
+                auto build_list_func = [&node](const CBlock& block, const CBlockIndex* const pindexPrev,
                                                        const CDeterministicMNList& prevList, const CCoinsViewCache& view,
                                                        bool debugLogs, BlockValidationState& state,
                                                        CDeterministicMNList& mnListRet) -> bool {

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1801,7 +1801,7 @@ static UniValue evodb_verify_or_repair_impl(const JSONRPCRequest& request, bool 
     }
 
     // Create a callback that wraps CSpecialTxProcessor::RebuildListFromBlock
-    auto build_list_func = [&chain_helper](const CBlock& block, gsl::not_null<const CBlockIndex*> pindexPrev,
+    auto build_list_func = [&chain_helper](const CBlock& block, const CBlockIndex* const pindexPrev,
                                            const CDeterministicMNList& prevList, const CCoinsViewCache& view,
                                            bool debugLogs, BlockValidationState& state,
                                            CDeterministicMNList& mnListRet) -> bool {


### PR DESCRIPTION
## Issue being fixed or feature implemented
This fixes guix non-determinism for apple-darwin builds.

kudos to knst@ for discovering this

## What was done?

## How Has This Been Tested?

## Breaking Changes

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

