### PR TITLE
refactor: move MnemonicVerificationDialog css, drop excessive styling

### DIFF
--- a/src/qt/res/css/dark.css
+++ b/src/qt/res/css/dark.css
@@ -845,6 +845,18 @@ MasternodeList
 /***** No dark.css specific coloring here yet *****/
 
 /******************************************************
+MnemonicVerificationDialog
+******************************************************/
+
+QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll {
+    border-color: #3c3c3c;
+}
+
+QDialog#MnemonicVerificationDialog QWidget#mnemonicGridWidget {
+    background-color: #2d2d2e;
+}
+
+/******************************************************
 ModalOverlay
 ******************************************************/
 
@@ -1092,54 +1104,4 @@ QScrollBar:right-arrow:disabled {
 }
 
 /**
- * MnemonicVerificationDialog (Dark Theme)
- */
-
-QDialog#MnemonicVerificationDialog QLabel {
-    color: #c7c7c7; /* light text for dark theme */
-}
-
-QDialog#MnemonicVerificationDialog QCheckBox {
-    color: #c7c7c7; /* light text for checkbox */
-}
-
-QDialog#MnemonicVerificationDialog QCheckBox#writtenDownCheckbox {
-    color: #c7c7c7; /* ensure checkbox text is visible */
-}
-
-QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll {
-    background-color: #2d2d2e !important; /* dark background for scroll area */
-    border: 1px solid #3c3c3c !important; /* subtle border */
-    border-radius: 8px;
-}
-
-QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll QWidget#mnemonicGridWidget {
-    background-color: #2d2d2e !important; /* dark background matching scroll area */
-}
-
-QDialog#MnemonicVerificationDialog QWidget#mnemonicGridWidget {
-    background-color: #2d2d2e !important; /* dark background matching scroll area */
-}
-
-QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll QWidget#mnemonicGridWidget QLabel {
-    color: #c7c7c7 !important; /* ensure grid labels are visible */
-    background-color: transparent !important;
-}
-
-QDialog#MnemonicVerificationDialog QLineEdit {
-    background-color: #2d2d2e; /* dark background for input fields */
-    border-color: #00599a;
-    color: #c7c7c7;
-}
-
-QDialog#MnemonicVerificationDialog QLineEdit:focus {
-    border-color: #4da3ff; /* subtle macOS-like blue */
-}
-
-QDialog#MnemonicVerificationDialog QLabel#word1Status,
-QDialog#MnemonicVerificationDialog QLabel#word2Status,
-QDialog#MnemonicVerificationDialog QLabel#word3Status {
-    color: #c7c7c7; /* ensure status labels are visible */
-}
-
 </os>

--- a/src/qt/res/css/general.css
+++ b/src/qt/res/css/general.css
@@ -1249,6 +1249,47 @@ MasternodeList QLabel#countLabelDIP3 {
 }
 
 /******************************************************
+MnemonicVerificationDialog
+******************************************************/
+
+QDialog#MnemonicVerificationDialog QLabel#warningLabel {
+    font-size: 17px;
+    font-weight: 700;
+}
+
+QDialog#MnemonicVerificationDialog QLabel#instructionLabel {
+    font-size: 14px;
+}
+
+QDialog#MnemonicVerificationDialog QLabel#verificationLabel {
+    margin-top: 0px;
+    margin-bottom: 4px;
+}
+
+QDialog#MnemonicVerificationDialog QLabel#word1Status,
+QDialog#MnemonicVerificationDialog QLabel#word2Status,
+QDialog#MnemonicVerificationDialog QLabel#word3Status {
+    font-weight: 700;
+    min-width: 18px;
+}
+
+QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll {
+    border-radius: 8px;
+    border: 1px solid;
+}
+
+QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll QWidget#mnemonicGridWidget QLabel {
+    font-family: monospace;
+    font-size: 13pt;
+}
+
+QDialog#MnemonicVerificationDialog QLineEdit#word1Edit,
+QDialog#MnemonicVerificationDialog QLineEdit#word2Edit,
+QDialog#MnemonicVerificationDialog QLineEdit#word3Edit {
+    max-width: 320px;
+}
+
+/******************************************************
 ModalOverlay
 ******************************************************/
 
@@ -2011,39 +2052,3 @@ QDialog#HelpMessageDialog QScrollBar:horizontal {
 }
 
 </os>
-/**
- * MnemonicVerificationDialog (Layout)
- */
-
-QDialog#MnemonicVerificationDialog QLabel#warningLabel {
-    font-size: 17px;
-    font-weight: 700;
-}
-
-QDialog#MnemonicVerificationDialog QLabel#instructionLabel {
-    font-size: 14px;
-}
-
-QDialog#MnemonicVerificationDialog QLabel#verificationLabel {
-    margin-top: 0px;
-    margin-bottom: 4px;
-}
-
-QDialog#MnemonicVerificationDialog QLabel#word1Status,
-QDialog#MnemonicVerificationDialog QLabel#word2Status,
-QDialog#MnemonicVerificationDialog QLabel#word3Status {
-    font-weight: 700;
-    min-width: 18px;
-}
-
-QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll QWidget#mnemonicGridWidget QLabel {
-    font-family: monospace;
-    font-size: 13pt;
-}
-
-QDialog#MnemonicVerificationDialog QLineEdit#word1Edit,
-QDialog#MnemonicVerificationDialog QLineEdit#word2Edit,
-QDialog#MnemonicVerificationDialog QLineEdit#word3Edit {
-    max-width: 320px;
-}
-

--- a/src/qt/res/css/light.css
+++ b/src/qt/res/css/light.css
@@ -831,6 +831,18 @@ MasternodeList
 /***** No light.css specific coloring here yet *****/
 
 /******************************************************
+MnemonicVerificationDialog
+******************************************************/
+
+QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll {
+    border-color: #dcdcdc;
+}
+
+QDialog#MnemonicVerificationDialog QWidget#mnemonicGridWidget {
+    background-color: #eaeaec;
+}
+
+/******************************************************
 ModalOverlay
 ******************************************************/
 
@@ -1077,54 +1089,4 @@ QScrollBar:right-arrow:disabled {
 }
 
 /**
- * MnemonicVerificationDialog (Light Theme)
- */
-
-QDialog#MnemonicVerificationDialog QLabel {
-    color: #555; /* ensure good contrast for all labels */
-}
-
-QDialog#MnemonicVerificationDialog QCheckBox {
-    color: #555; /* ensure checkbox text is visible */
-}
-
-QDialog#MnemonicVerificationDialog QCheckBox#writtenDownCheckbox {
-    color: #555; /* ensure checkbox text has good contrast */
-}
-
-QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll {
-    background-color: #eaeaec !important; /* light background for scroll area */
-    border: 1px solid #dcdcdc !important; /* subtle border */
-    border-radius: 8px;
-}
-
-QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll QWidget#mnemonicGridWidget {
-    background-color: #eaeaec !important; /* light background matching scroll area */
-}
-
-QDialog#MnemonicVerificationDialog QWidget#mnemonicGridWidget {
-    background-color: #eaeaec !important; /* light background matching scroll area */
-}
-
-QDialog#MnemonicVerificationDialog QScrollArea#mnemonicScroll QWidget#mnemonicGridWidget QLabel {
-    color: #555 !important; /* ensure grid labels are visible */
-    background-color: transparent !important;
-}
-
-QDialog#MnemonicVerificationDialog QLineEdit {
-    background-color: #ffffff; /* white background for input fields */
-    border-color: #008de4;
-    color: #555;
-}
-
-QDialog#MnemonicVerificationDialog QLineEdit:focus {
-    border-color: #4da3ff; /* macOS-like blue */
-}
-
-QDialog#MnemonicVerificationDialog QLabel#word1Status,
-QDialog#MnemonicVerificationDialog QLabel#word2Status,
-QDialog#MnemonicVerificationDialog QLabel#word3Status {
-    color: #555; /* ensure status labels are visible */
-}
-
 </os>


### PR DESCRIPTION
## Issue being fixed or feature implemented
Move it to the right place, also clean it a bit while at it.

## What was done?

## How Has This Been Tested?
Run, check the dialog with dark/light theme while switching os themes too. Should be no visible changes.

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

