### PR TITLE
test: more reliable sheduler call for feature_governance_cl.py

### DIFF
--- a/test/functional/feature_governance_cl.py
+++ b/test/functional/feature_governance_cl.py
@@ -140,13 +140,14 @@ class DashGovernanceTest (DashTestFramework):
         assert len(self.nodes[0].gobject("list", "valid", "triggers")) >= 1
         assert not have_trigger_for_height(self.nodes[0:5], sb_block_height + sb_cycle)
         self.bump_mocktime(156)
-        self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_blocks(self.nodes[0:5]))
 
         self.log.info("Bump mocktime to trigger governance cleanup")
         for delta, expected in (
             (5 * 60, ['UpdateCachesAndClean -- Governance Objects:']),  # mark old triggers for deletion
             (10 * 60, ['UpdateCachesAndClean -- Governance Objects: 0']),  # deletion after delay
         ):
+            self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_blocks(self.nodes[0:5]))
+
             self.mocktime += delta
             for node in self.nodes:
                 with node.assert_debug_log(expected_msgs=expected):


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes intermittent failure in feature_governance_cl.py

This error happens ~10-20% on my localhost in case of multi-parallel runs of this specific test.

        raise AssertionError(self._node_msg(msg))
    AssertionError: [node 0] Expected messages "['UpdateCachesAndClean -- Governance Objects: 0']" does not partially match log:

     - 2025-12-04T13:01:49.091536Z (mocktime: 1417720362) [      http] [httpserver.cpp:250] [http_request_cb] [http] Received a POST request for / from 127.0.0.1:47922
     - 2025-12-04T13:01:49.091576Z (mocktime: 1417720362) [httpworker.3] [rpc/request.cpp:180] [parse] [rpc] ThreadRPCServer method=setmocktime user=__cookie__
     - 2025-12-04T13:01:49.091601Z (mocktime: 1417720962) [httpworker.3] [httprpc.cpp:92] [~RpcHttpRequest] [bench] HTTP RPC request handled: user=__cookie__ command=setmocktime external=false status=200 elapsed_time_ms=0
     - 2025-12-04T13:01:49.091855Z (mocktime: 1417720962) [      http] [httpserver.cpp:250] [http_request_cb] [http] Received a POST request for / from 127.0.0.1:47922
     - 2025-12-04T13:01:49.091900Z (mocktime: 1417720962) [httpworker.0] [rpc/request.cpp:180] [parse] [rpc] ThreadRPCServer method=mockscheduler user=__cookie__
     - 2025-12-04T13:01:49.091945Z (mocktime: 1417720962) [httpworker.0] [httprpc.cpp:92] [~RpcHttpRequest] [bench] HTTP RPC request handled: user=__cookie__ command=mockscheduler external=false status=200 elapsed_time_ms=0
     - 2025-12-04T13:01:49.091960Z (mocktime: 1417720962) [ scheduler] [wallet/bdb.cpp:604] [PeriodicFlush] [walletdb] Flushing wallet.dat
     - 2025-12-04T13:01:49.092156Z (mocktime: 1417720962) [ scheduler] [wallet/bdb.cpp:612] [PeriodicFlush] [walletdb] Flushed wallet.dat 0ms
     - 2025-12-04T13:01:49.092194Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:1149] [RequestGovernanceObjectVotes] [gobject] CGovernanceManager::RequestGovernanceObjectVotes -- start: vTriggerObjHashes 1 vOtherObjHashes 0 mapAskedRecently 3
     - 2025-12-04T13:01:49.092203Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:1194] [RequestGovernanceObjectVotes] [gobject] CGovernanceManager::RequestGovernanceObjectVotes -- end: vTriggerObjHashes 0 vOtherObjHashes 0 mapAskedRecently 3
     - 2025-12-04T13:01:49.092268Z (mocktime: 1417720962) [ scheduler] [net_processing.cpp:5761] [CheckForStaleTipAndEvictPeers] Potential stale tip detected, will try using extra outbound peer (last tip update: 600 seconds ago)
     - 2025-12-04T13:01:49.092279Z (mocktime: 1417720962) [ scheduler] [net.cpp:2787] [SetTryNewOutboundPeer] [net] setting try another outbound peer=true
     - 2025-12-04T13:01:49.103502Z (mocktime: 1417720962) [ scheduler] [net.cpp:2754] [DumpAddresses] [net] Flushed 0 addresses to peers.dat  0ms
     - 2025-12-04T13:01:49.103538Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:1393] [RequestOrphanObjects] [gobject] CGovernanceObject::RequestOrphanObjects -- number objects = 0
     - 2025-12-04T13:01:49.103543Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:470] [CheckAndRemove] [gobject] CGovernanceManager::UpdateCachesAndClean
     - 2025-12-04T13:01:49.103556Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:1519] [CleanAndRemoveTriggers] [gobject] CGovernanceManager::CleanAndRemoveTriggers -- mapTrigger.size() = 1
     - 2025-12-04T13:01:49.103560Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:1535] [CleanAndRemoveTriggers] [gobject] CGovernanceManager::CleanAndRemoveTriggers -- superblock status = 2
     - 2025-12-04T13:01:49.103564Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:1545] [CleanAndRemoveTriggers] [gobject] CGovernanceManager::CleanAndRemoveTriggers -- Valid trigger found
     - 2025-12-04T13:01:49.103569Z (mocktime: 1417720962) [ scheduler] [governance/classes.cpp:354] [IsExpired] [gobject] CSuperblock::IsExpired -- nBlockHeight = 260, nExpirationBlock = 280
     - 2025-12-04T13:01:49.103572Z (mocktime: 1417720962) [ scheduler] [governance/classes.cpp:357] [IsExpired] [gobject] CSuperblock::IsExpired -- Outdated trigger found
     - 2025-12-04T13:01:49.103577Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:1557] [CleanAndRemoveTriggers] [gobject] CGovernanceManager::CleanAndRemoveTriggers -- marked for removal
     - 2025-12-04T13:01:49.103583Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:1566] [CleanAndRemoveTriggers] [gobject] CGovernanceManager::CleanAndRemoveTriggers -- Removing trigger object {"event_block_height": 260, "payment_addresses": "yZV6odagTGg4KNNTLUSH5Zbtmes4niNGsz|ySG7HrWALVPAdaQ7n7ua6gZ1JpD3rkRkJH", "payment_amounts": "1.10000000|3.30000000", "proposal_hashes": "fb196adc9f048cef43a5f138163a8925e8d7f992da14f9e23a1384e9587261e5|f75c0c0a77977191178b22c93bc09539d7e8e4445df837da30d00c662c3623b2", "type":2}
     - 2025-12-04T13:01:49.103591Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:510] [CheckAndRemove] [gobject] CGovernanceManager::UpdateCachesAndClean -- Checking object for deletion: 38c677b5b9803d0be5a3e4159280d8d6dce6dc731068e897044eea39ad628f23, deletion time = 1417720962, time since deletion = 0, delete flag = 1, expired flag = 1
     - 2025-12-04T13:01:49.103598Z (mocktime: 1417720962) [ scheduler] [governance/governance.cpp:575] [CheckAndRemove] [gobject] CGovernanceManager::UpdateCachesAndClean -- Governance Objects: 1 (Proposals: 0, Triggers: 1, Other: 0; Erased: 2), Votes: 4, m_requested_hash_time size=0

## What was done?
Generated one more block to trigger scheduler.
I am not sure why it helps, but it drops failure rate to almost 0% (unrelated failures) for my local environment.
See this PR https://github.com/dashpay/dash/pull/6926 which improved reliability of feature_governance_cl.py significantly in the past.


## How Has This Been Tested?
Run multiple times with and without changes from this PR:

    test/functional/test_runner.py -j20 feature_governance_cl.py feature_governance_cl.py feature_governance_cl.py feature_governance_cl.py feature_governance_cl.py feature_governance_cl.py feature_governance_cl.py feature_governance_cl.py feature_governance_cl.py 


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
