### PR TITLE
fix: add `mutable` to make the captured `work` non-const, allowing it to be properly moved

### DIFF
--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -1668,7 +1668,7 @@ void CSigSharesManager::DispatchPendingSigns()
     for (auto& work : signs) {
         if (workInterrupt) break;
 
-        workerPool.push([this, work = std::move(work)](int) {
+        workerPool.push([this, work = std::move(work)](int) mutable {
             SignAndProcessSingleShare(std::move(work));
         });
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
clang-tidy complains on develop https://github.com/dashpay/dash/actions/runs/20066954644/job/57558275807

#7004 follow-up

## What was done?
Lambda captures are const by default, so `std::move(work)` inside the lambda had no effect. Add `mutable` to make the captured `work` non-const, allowing it to be properly moved.

## How Has This Been Tested?
https://github.com/UdjinM6/dash/actions/runs/20079838716/job/57605752892

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

