### PR TITLE
ci: bump CCACHE_MAXSIZE to 600M

### DIFF
--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Build source
         run: |
-          CCACHE_MAXSIZE="400M"
+          CCACHE_MAXSIZE="600M"
           CACHE_DIR="/cache"
           mkdir /output
           BASE_OUTDIR="/output"


### PR DESCRIPTION
## Issue being fixed or feature implemented
A simple commit like bac6bfadffe6fcf323e5e0208c8619e1e68401fe should result in at least 90%+ cache hit.

But it's not the case for some jobs:
~22%: https://github.com/dashpay/dash/actions/runs/20113011572/job/57715279431
~25%: https://github.com/dashpay/dash/actions/runs/20113011572/job/57715279411

## What was done?
Bump CCACHE_MAXSIZE to 600M

## How Has This Been Tested?
Running CI on develop twice after this change:
~94%: https://github.com/UdjinM6/dash/actions/runs/20118156411/job/57736628182
~94%: https://github.com/UdjinM6/dash/actions/runs/20118156411/job/57736628179

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

