### PR TITLE
perf: faster calculation for versionbits

### DIFF
--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -61,6 +61,11 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
             cache[pindexPrev] = ThresholdState::DEFINED;
             break;
         }
+        if (pindexPrev->nHeight < params.MinBIP9WarningHeight) {
+            // Optimization: don't compute below MinBIP9WarningHeight, consider it defined.
+            cache[pindexPrev] = ThresholdState::DEFINED;
+            break;
+        }
         if (pindexPrev->GetMedianTimePast() < nTimeStart || pindexPrev->nHeight < masternodeStartHeight) {
             // Optimization: don't recompute down further, as we know every earlier block will be before the start time
             cache[pindexPrev] = ThresholdState::DEFINED;

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -97,15 +97,16 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
                 // We need to count
                 const CBlockIndex* pindexCount = pindexPrev;
                 int count = 0;
-                for (int i = 0; i < nPeriod; i++) {
+                int nAttempt = (pindexCount->nHeight - nStartHeight) / nPeriod;
+                int threshold = Threshold(params, nAttempt);
+                for (int i = 0; count + (nPeriod - i) >= threshold && i < nPeriod; ++i) {
                     if (Condition(pindexCount, params)) {
                         count++;
                     }
                     pindexCount = pindexCount->pprev;
                 }
                 assert(nStartHeight > 0 && nStartHeight < std::numeric_limits<int>::max());
-                int nAttempt = (pindexCount->nHeight + 1 - nStartHeight) / nPeriod;
-                if (count >= Threshold(params, nAttempt)) {
+                if (count >= threshold) {
                     stateNext = ThresholdState::LOCKED_IN;
                 } else if (pindexPrev->GetMedianTimePast() >= nTimeTimeout) {
                     stateNext = ThresholdState::FAILED;


### PR DESCRIPTION
## Issue being fixed or feature implemented
`::cs_main` mutex is kept after Dash-Qt starts until chain state is loaded.
Loading of changestate includes a step with calculations of BIP9-warnings about unknown bits.
It takes just 0.3s [far from instant, but reasonable fast] per bit in my environment. But knowing that `VERSIONBITS_NUM_BITS=29` it makes Dash Core start for 5-8seconds slower.
Main window is shown on screen, UI is responsible during this calculations; but many RPC such as `getblockchaininfo` can not be called yet; sync of new blocks and governance objects is delayed for all time that `::cs_main` is held.

This slow calculation for bip-9 warnings doesn't affect further consecutive blocks validation, because cache is used there and it's fulfilled after 1st time. Issue is relevant only for cold load of chainstate.

## What was done?
This PR makes calculations of `AbstractThresholdConditionChecker::GetStateFor` for case of `ThresholdState::STARTED`  faster by early exit from internal loop over 2016 [`nPeriod`] blocks.

This PR makes Dash Core (dash-qt, dashd) to sync 5-10 seconds faster after start.

## How Has This Been Tested?
I added extra logs and made a guix build with all optimizations:

```diff
diff --git a/src/validation.cpp b/src/validation.cpp
index 7686968416..9b8bf4e7a8 100644
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2996,6 +2996,7 @@ void CChainState::UpdateTip(const CBlockIndex* pindexNew)
     bilingual_str warning_messages;
     if (!this->IsInitialBlockDownload())
     {
+        LogPrintf("knst Check for warning bits...\n");
         const CBlockIndex* pindex = pindexNew;
         for (int bit = 0; bit < VERSIONBITS_NUM_BITS; bit++) {
             WarningBitsConditionChecker checker(bit);
@@ -3009,6 +3010,7 @@ void CChainState::UpdateTip(const CBlockIndex* pindexNew)
                 }
             }
         }
+        LogPrintf("knst Checked\n");
     }
     UpdateTipLog(coins_tip, pindexNew, m_params, m_evoDb, __func__, "", warning_messages.original);
 }
```

Current `develop`:
```
2025-12-11T16:29:08Z knst Check for warning bits... 
2025-12-11T16:29:13Z knst Checked
```

With changes from PR:
```
2025-12-13T19:46:05Z knst Check for warning bits...
2025-12-13T19:46:06Z knst Checked
```

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_