### PR TITLE
fix: protx_register_common_wrapper to include Prepare action for wallet unlock checks

### DIFF
--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -683,9 +683,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return UniValue::VNULL;
 
-    if (action == ProTxRegisterAction::External || action == ProTxRegisterAction::Fund || action == ProTxRegisterAction::Prepare) {
-        EnsureWalletIsUnlocked(*pwallet);
-    }
+    EnsureWalletIsUnlocked(*pwallet);
 
     size_t paramIdx = 0;
 

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -683,7 +683,7 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
     std::shared_ptr<CWallet> const pwallet = GetWalletForJSONRPCRequest(request);
     if (!pwallet) return UniValue::VNULL;
 
-    if (action == ProTxRegisterAction::External || action == ProTxRegisterAction::Fund) {
+    if (action == ProTxRegisterAction::External || action == ProTxRegisterAction::Fund || action == ProTxRegisterAction::Prepare) {
         EnsureWalletIsUnlocked(*pwallet);
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Commands such as 

```
protx register_prepare_evo b3b36f52bbc960edfe66867e0621a52bd5ac08011390959b3455d65aaec6893b 1 1.1.1.1:19999 yNGcrezN6NrRgf1DUuPP6pYsko3K9AdgHt 9889874ec1df289931886afee957c802bf0e751a6ec8461ac774f5affdabf06e7aa0c47ff94399e1d2ad597318733b8c yRkYwCNcXZQ3SfNp8hPP7sJHTdPMFna92y 8 yNfsHUoAysATEzxn5ZYD526Cw8AK8UTBdY eaa200ff6b7dde61ac4f943218307bcc249ea37b 36656 1443 yMm632VcVkZwndDvTVphmABvA6vWWMjxDh
```

may fail if the wallet isn't unlocked with `GetKey: DecryptHDChain failed` where it should fail with `Error: Please enter the wallet passphrase with walletpassphrase first`

## What was done?
include prepare in checking that wallet is unlocked

## How Has This Been Tested?


## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

