### PR TITLE
ci: free disk space by removing `/output` folder when it's no longer needed

### DIFF
--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -99,6 +99,8 @@ jobs:
           ./ci/dash/build_src.sh
           ccache -X 9
           ccache -c
+          du -hd0 "${BASE_OUTDIR}"
+          rm -rf "${BASE_OUTDIR}"
         shell: bash
 
       - name: Save ccache cache
@@ -121,7 +123,6 @@ jobs:
 
       - name: Run unit tests
         run: |
-          BASE_OUTDIR="/output"
           BUILD_TARGET="${{ inputs.build-target }}"
           source ./ci/dash/matrix.sh
           ./ci/dash/test_unittests.sh


### PR DESCRIPTION
## Issue being fixed or feature implemented
`/output` folder just sits there wasting disk space after `Build source` step:
- multiprocess 0.6GB
- ubsan 1.7GB
- tsan 2.4GB
- nowallet 2.6GB
- arm-linux 2.7GB
- linux64 and linux64_sqlite 3.3GB

(NOTE: fuzz, mac and win64 don't produce anything in `/output` folder)

## What was done?
Remove the folder at the end of `Build source` step. Also drop unused `BASE_OUTDIR` env var pointing to it from `Run unit tests` step to avoid confusion.

## How Has This Been Tested?
https://github.com/UdjinM6/dash/actions/runs/20355332620

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

