### PR TITLE
chore: enforce ban for re-propagation of stale `QFCOMMIT`s

### DIFF
--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -131,8 +131,9 @@ MessageProcessingResult CQuorumBlockProcessor::ProcessMessage(const CNode& peer,
         if (pQuorumBaseBlockIndex->nHeight < (m_chainstate.m_chain.Height() - llmq_params_opt->dkgInterval)) {
             LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- block %s is too old, peer=%d\n", __func__,
                      qc.quorumHash.ToString(), peer.GetId());
-            // TODO: enable punishment in some future version when all/most nodes are running with this fix
-            // ret.m_error = MisbehavingError{100};
+            if (peer.GetCommonVersion() >= QFCOMMIT_STALE_REPROP_BAN_VERSION) {
+                ret.m_error = MisbehavingError{100};
+            }
             return ret;
         }
         if (HasMinedCommitment(type, qc.quorumHash)) {

--- a/src/version.h
+++ b/src/version.h
@@ -10,8 +10,7 @@
  * network protocol versioning
  */
 
-
-static const int PROTOCOL_VERSION = 70238;
+static const int PROTOCOL_VERSION = 70239;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -52,12 +51,14 @@ static const int INCREASE_MAX_HEADERS2_VERSION = 70235;
 //! Behavior of QRINFO is changed in this protocol version
 static const int EFFICIENT_QRINFO_VERSION = 70236;
 
-
 //! cycleHash in isdlock message switched to using quorum's base block in this version
 static const int ISDLOCK_CYCLEHASH_UPDATE_VERSION = 70237;
 
 //! Introduced new p2p message platform pose BAN
 static const int PLATFORM_BAN_VERSION = 70238;
+
+//! Ban of re-propagation of old QFCOMMIT enforcement
+static const int QFCOMMIT_STALE_REPROP_BAN_VERSION = 70239;
 
 // Make sure that none of the values above collide with `ADDRV2_FORMAT`.
 


### PR DESCRIPTION
## Additional Information

Spun off from [dash#7066](https://github.com/dashpay/dash/pull/7066) due to breaking change, enforces policy introduced in [dash#5145](https://github.com/dashpay/dash/pull/5145).

## Breaking changes

Broadcasting stale `QFCOMMIT`s will result in the offending node getting banned.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
