### PR TITLE
fix: don't assume that successful `weightFromArg` links to valid index

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -564,16 +564,22 @@ QVariant OptionsModel::data(const QModelIndex & index, int role) const
         case FontScale:
             return settings.value("fontScale");
         case FontWeightNormal: {
-            QFont::Weight weight{GUIUtil::g_font_registry.GetWeightNormalDefault()};
-            GUIUtil::weightFromArg(settings.value("fontWeightNormal").toInt(), weight);
-            int nIndex = GUIUtil::g_font_registry.WeightToIdx(weight);
+            int nIndex = [&]() -> int {
+                if (QFont::Weight weight; GUIUtil::weightFromArg(settings.value("fontWeightNormal").toInt(), weight) && GUIUtil::g_font_registry.IsValidWeight(weight)) {
+                    return GUIUtil::g_font_registry.WeightToIdx(weight);
+                }
+                return GUIUtil::g_font_registry.WeightToIdx(GUIUtil::g_font_registry.GetWeightNormalDefault());
+            }();
             assert(nIndex != -1);
             return nIndex;
         }
         case FontWeightBold: {
-            QFont::Weight weight{GUIUtil::g_font_registry.GetWeightBoldDefault()};
-            GUIUtil::weightFromArg(settings.value("fontWeightBold").toInt(), weight);
-            int nIndex = GUIUtil::g_font_registry.WeightToIdx(weight);
+            int nIndex = [&]() -> int {
+                if (QFont::Weight weight; GUIUtil::weightFromArg(settings.value("fontWeightBold").toInt(), weight) && GUIUtil::g_font_registry.IsValidWeight(weight)) {
+                    return GUIUtil::g_font_registry.WeightToIdx(weight);
+                }
+                return GUIUtil::g_font_registry.WeightToIdx(GUIUtil::g_font_registry.GetWeightBoldDefault());
+            }();
             assert(nIndex != -1);
             return nIndex;
         }


### PR DESCRIPTION
## Additional Information

[dash#7068](https://github.com/dashpay/dash/pull/7068) introduced a regression where Qt clients with no GUI settings are unable to run at all due to failed weight to index conversion. This was covered in 9cd9d44a but made an incorrect assumption that earlier iterations of the fix (see ef34868a) did not make.

The assumption made that resulted in this regression was that if the argument to weight conversion is successful, then the weight to index conversion will also be successful.

The earlier iteration of the fix checked the return value of the index conversion and set a sane default if it was invalid. The final iteration set the default weight value to the sane weight, expecting `weightFromArg()` to fail (hence using the sane weight), not `supportedWeightToIndex()` (which might not be able to process even a valid weight from argument).

This was not caught in testing as over the course of working on [dash#6833](https://github.com/dashpay/dash/pull/6833), my GUI settings were migrated to `settings.json`, which has precedence over `QSettings` and therefore, the client always ran with known good Montserrat parameters.

Fix can be verified by deleting your QSettings parameters and running the client anew.

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

