### PR TITLE
test: fix flaky v2transport_test off-by-one in Dash short ID range

### DIFF
--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1549,13 +1549,15 @@ BOOST_AUTO_TEST_CASE(v2transport_test)
         tester.CompareSessionIDs();
         auto msg_data_1 = g_insecure_rand_ctx.randbytes<uint8_t>(MAX_PROTOCOL_MESSAGE_LENGTH); // test that receiving max size payload works
         auto msg_data_2 = g_insecure_rand_ctx.randbytes<uint8_t>(MAX_PROTOCOL_MESSAGE_LENGTH); // test that sending max size payload works
+        // Send an unknown/invalid short ID. Valid Bitcoin IDs are [0, V2_BITCOIN_IDS.size()-1],
+        // valid Dash IDs are [128, 128+V2_DASH_IDS.size()-1]. Generate IDs outside these ranges.
         tester.SendMessage([]() {
             if (g_insecure_rand_ctx.randbool()) {
-                return static_cast<uint8_t>(InsecureRandRange(95) + 33); // Bitcoin's range
+                return static_cast<uint8_t>(InsecureRandRange(95) + 33); // Invalid Bitcoin range [33, 127]
             } else {
-                return static_cast<uint8_t>(InsecureRandRange(88) + 40 + 128); // Dash's range
+                return static_cast<uint8_t>(InsecureRandRange(87) + 169); // Invalid Dash range [169, 255]
             }
-        }(), {}); // unknown short id
+        }(), {});
         tester.SendMessage(uint8_t(2), msg_data_1); // "block" short id
         tester.AddMessage("blocktxn", msg_data_2); // schedule blocktxn to be sent to us
         ret = tester.Interact();


### PR DESCRIPTION
## Issue being fixed or feature implemented
The test was generating "unknown" short IDs in range [168, 255], but 168 is PLATFORMBAN (last valid Dash ID). When InsecureRandRange(88) returned 0, the test would send a valid message that decoded successfully, causing the BOOST_CHECK(!(*ret)[0]) assertion to fail.

Follow-up to #7082

## What was done?
Fix by starting the invalid range at 169 instead of 168.

Fixes #7093

## How Has This Been Tested?
Run `./src/test/test_dash --run_test=net_tests/v2transport_test` in a loop

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

