### PR TITLE
backport: merge bitcoin#34227 (Fix `osslsigncode` tests)

### DIFF
--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -3,6 +3,7 @@
              ((gnu packages bash) #:select (bash-minimal))
              (gnu packages bison)
              ((gnu packages certs) #:select (nss-certs))
+             ((gnu packages check) #:select (libfaketime))
              ((gnu packages cmake) #:select (cmake-minimal))
              (gnu packages commencement)
              (gnu packages compression)
@@ -210,7 +211,17 @@ and abstract ELF, PE and MachO formats.")
                (base32
                 "1j47vwq4caxfv0xw68kw5yh00qcpbd56d7rq6c483ma3y7s96yyz"))))
     (build-system cmake-build-system)
-    (inputs (list openssl))
+    (arguments
+     (list
+      #:phases
+      #~(modify-phases %standard-phases
+          (replace 'check
+            (lambda* (#:key tests? #:allow-other-keys)
+              (if tests?
+                  (invoke "faketime" "-f" "@2025-01-01 00:00:00" ;; Tests fail after 2025.
+                          "ctest" "--output-on-failure" "--no-tests=error")
+                  (format #t "test suite not run~%")))))))
+    (inputs (list libfaketime openssl))
     (home-page "https://github.com/mtrojnar/osslsigncode")
     (synopsis "Authenticode signing and timestamping tool")
     (description "osslsigncode is a small tool that implements part of the


### PR DESCRIPTION
## Additional Information

Required to fix Guix build failures on `develop` (74829569), see below

```
$ HOSTS=x86_64-w64-mingw32 guix-start
Checking that we can connect to the guix-daemon...
[...]
substitute: updating substitutes from 'https://berlin.guix.gnu.org'... 100.0%
substitute: updating substitutes from 'https://bordeaux.guix.gnu.org'... 100.0%
substitute: updating substitutes from 'https://ci.guix.gnu.org'... 100.0%
substitute: updating substitutes from 'https://bordeaux-singapore-mirror.cbaines.net'... 100.0%
substitute: updating substitutes from 'https://bordeaux-us-east-mirror.cbaines.net'... 100.0%
substitute: updating substitutes from 'https://hydra-guix-129.guix.gnu.org'... 100.0%
The following derivation will be built:
  /gnu/store/dwg4c8nvvylxx3y8l4rw6pmfz7b45mpr-osslsigncode-2.5.drv

building /gnu/store/dwg4c8nvvylxx3y8l4rw6pmfz7b45mpr-osslsigncode-2.5.drv...
\ 'check' phasenote: keeping build directory `/tmp/guix-build-osslsigncode-2.5.drv-2'
builder for `/gnu/store/dwg4c8nvvylxx3y8l4rw6pmfz7b45mpr-osslsigncode-2.5.drv' failed with exit code 1
build of /gnu/store/dwg4c8nvvylxx3y8l4rw6pmfz7b45mpr-osslsigncode-2.5.drv failed
View build log at '/var/log/guix/drvs/dw/g4c8nvvylxx3y8l4rw6pmfz7b45mpr-osslsigncode-2.5.drv.gz'.
guix shell: error: build of `/gnu/store/dwg4c8nvvylxx3y8l4rw6pmfz7b45mpr-osslsigncode-2.5.drv' failed
```

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
