### PR TITLE
ci: fix sdk cache check

### DIFF
--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -49,6 +49,7 @@ jobs:
             depends/hosts
             contrib/containers/ci/ci.Dockerfile
             contrib/containers/ci/ci-slim.Dockerfile
+            contrib/containers/guix/scripts/setup-sdk
 
       - name: Compute cache key
         id: setup
@@ -75,6 +76,19 @@ jobs:
           key: ${{ steps.setup.outputs.cache-key }}
           lookup-only: true
 
+      - name: Cache SDKs
+        id: cache-sdk-check
+        uses: actions/cache@v4
+        if: inputs.build-target == 'mac'
+        with:
+          path: depends/SDKs
+          key: depends-sdks-${{ hashFiles('depends/hosts/darwin.mk') }}
+          restore-keys: depends-sdks-
+
+      - name: Prepare SDKs
+        if: inputs.build-target == 'mac' && steps.cache-sdk-check.outputs.cache-hit != 'true'
+        run: ./contrib/containers/guix/scripts/setup-sdk
+
   build:
     name: Build depends
     needs: [check-cache]
@@ -96,13 +110,14 @@ jobs:
           key: depends-sources-${{ hashFiles('depends/packages/*') }}
           restore-keys: depends-sources-
 
-      - name: Cache SDKs
-        uses: actions/cache@v4
+      - name: Restore SDKs cache
+        uses: actions/cache/restore@v4
         if: inputs.build-target == 'mac'
         with:
           path: depends/SDKs
           key: depends-sdks-${{ hashFiles('depends/hosts/darwin.mk') }}
           restore-keys: depends-sdks-
+          fail-on-cache-miss: true
 
       - name: Restore cached depends
         uses: actions/cache/restore@v4
@@ -115,9 +130,6 @@ jobs:
       - name: Build depends
         run: |
           export HOST="${{ needs.check-cache.outputs.host }}"
-          if [ "${HOST}" = "x86_64-apple-darwin" ]; then
-            ./contrib/containers/guix/scripts/setup-sdk
-          fi
           env ${{ needs.check-cache.outputs.dep-opts }} make -j$(nproc) -C depends
 
       - name: Save depends cache


### PR DESCRIPTION
## Issue being fixed or feature implemented
It's possible to end up in a situation where `depends-<hash>-mac` cache still exists but `depends-sdks` one was purged by github already. (example https://github.com/UdjinM6/dash/actions/runs/21221002352)

## What was done?
Make sure SDKs cache exists regardless of `depends-<hash>-mac` presence.

## How Has This Been Tested?
patched develop, w/o sdks cache: https://github.com/UdjinM6/dash/actions/runs/21293050632/job/61291689128
patched develop, w/ sdks cache: https://github.com/UdjinM6/dash/actions/runs/21293174715/job/61292153721
this branch, no sdks cache on develop: https://github.com/UdjinM6/dash/actions/runs/21292572578/job/61290004717

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

