### PR TITLE
fix: resolve font weights dynamically for live slider updates

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -29,7 +29,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent, SecureStri
 {
     ui->setupUi(this);
 
-    GUIUtil::setFont({ui->capsLabel}, {GUIUtil::g_font_registry.GetWeightBold()});
+    GUIUtil::setFont({ui->capsLabel}, {GUIUtil::FontWeight::Bold});
 
     GUIUtil::updateFonts();
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -758,7 +758,7 @@ void BitcoinGUI::createToolBars()
         connect(tabGroup, qOverload<QAbstractButton *, bool>(&QButtonGroup::buttonToggled), this, &BitcoinGUI::highlightTabButton);
 
         for (auto button : tabGroup->buttons()) {
-            GUIUtil::setFont({button}, {GUIUtil::g_font_registry.GetWeightNormal(), 16});
+            GUIUtil::setFont({button}, {GUIUtil::FontWeight::Normal, 16});
             button->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
             button->setToolTip(button->statusTip());
             button->setCheckable(true);
@@ -1242,7 +1242,7 @@ void BitcoinGUI::openClicked()
 
 void BitcoinGUI::highlightTabButton(QAbstractButton *button, bool checked)
 {
-    GUIUtil::setFont({button}, {checked ? GUIUtil::g_font_registry.GetWeightBold() : GUIUtil::g_font_registry.GetWeightNormal(), 16});
+    GUIUtil::setFont({button}, {checked ? GUIUtil::FontWeight::Bold : GUIUtil::FontWeight::Normal, 16});
     GUIUtil::updateFonts();
 }
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -58,7 +58,7 @@ CoinControlDialog::CoinControlDialog(CCoinControl& coin_control, WalletModel* _m
                       ui->labelCoinControlFeeText,
                       ui->labelCoinControlAfterFeeText,
                       ui->labelCoinControlChangeText
-                     }, {GUIUtil::g_font_registry.GetWeightBold()});
+                     }, {GUIUtil::FontWeight::Bold});
 
     GUIUtil::updateFonts();
 

--- a/src/qt/governancelist.cpp
+++ b/src/qt/governancelist.cpp
@@ -313,8 +313,8 @@ GovernanceList::GovernanceList(QWidget* parent) :
     ui->setupUi(this);
 
     GUIUtil::setFont({ui->label_count_2, ui->countLabel, ui->label_mn_count, ui->mnCountLabel},
-                     {GUIUtil::g_font_registry.GetWeightBold(), 14});
-    GUIUtil::setFont({ui->label_filter_2}, {GUIUtil::g_font_registry.GetWeightNormal(), 15});
+                     {GUIUtil::FontWeight::Bold, 14});
+    GUIUtil::setFont({ui->label_filter_2}, {GUIUtil::FontWeight::Normal, 15});
 
     proposalModelProxy->setSourceModel(proposalModel);
     ui->govTableView->setModel(proposalModelProxy);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -289,8 +289,8 @@ void setupAppearance(QWidget* parent, OptionsModel* model)
         layout.addWidget(&buttonBox);
         dlg.setLayout(&layout);
         // Adjust the headings
-        setFont({&lblHeading}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
-        setFont({&lblSubHeading}, {GUIUtil::g_font_registry.GetWeightNormal(), 14, true});
+        setFont({&lblHeading}, {GUIUtil::FontWeight::Bold, 16});
+        setFont({&lblSubHeading}, {GUIUtil::FontWeight::Normal, 14, true});
         // Make sure the dialog closes and accepts the settings if save has been pressed
         QObject::connect(&buttonBox, &QDialogButtonBox::accepted, [&]() {
             QSettings().setValue("fAppearanceSetupDone", true);

--- a/src/qt/guiutil_font.cpp
+++ b/src/qt/guiutil_font.cpp
@@ -186,10 +186,42 @@ int weightToArg(const QFont::Weight weight)
     return mapWeightArgs.second.find(weight)->second;
 }
 
+//! Internal helper to create a font with explicit weight (used for font detection)
+static QFont getFontWithWeight(const QString& font_name, QFont::Weight weight, double point_size)
+{
+    QFont font;
+    if (font_name == MONTSERRAT_FONT_STR) {
+        if (mapMontserrat.count(weight)) {
+#ifdef Q_OS_MACOS
+            font.setFamily(font_name);
+            font.setStyleName(QString::fromStdString(mapMontserrat.at(weight).first));
+#else
+            if (weight == QFont::Normal || weight == QFont::Bold) {
+                font.setFamily(font_name);
+            } else {
+                font.setFamily(qstrprintf("%s %s", font_name.toStdString(), mapMontserrat.at(weight).first));
+            }
+#endif
+        }
+    } else if (font_name == OS_FONT_STR && g_default_font) {
+        font.setFamily(g_default_font->family());
+    } else {
+        font.setFamily(font_name);
+    }
+#ifdef Q_OS_MACOS
+    if (font_name != MONTSERRAT_FONT_STR)
+#endif
+    {
+        font.setWeight(weight);
+    }
+    font.setPointSizeF(point_size);
+    return font;
+}
+
 void FontInfo::CalcSupportedWeights(const QString& font_name)
 {
     auto getTestWidth = [](const QString& font_name, QFont::Weight weight) -> int {
-        QFont font = getFont({font_name, weight, FontRegistry::DEFAULT_FONT_SIZE, false});
+        QFont font = getFontWithWeight(font_name, weight, FontRegistry::DEFAULT_FONT_SIZE);
         return TextWidth(QFontMetrics(font), ("Check the width of this text to see if the weight change has an impact!"));
     };
     QFont::Weight prevWeight = vecWeightConsider.front();
@@ -243,17 +275,17 @@ void FontInfo::CalcDefaultWeights(const QString& font_name)
     }
 }
 
-FontAttrib::FontAttrib(QString font, QFont::Weight weight, double point_size, bool is_italic) :
+FontAttrib::FontAttrib(QString font, FontWeight weight_type, double point_size, bool is_italic) :
     m_font{font},
-    m_weight{weight},
+    m_weight_type{weight_type},
     m_point_size{point_size},
     m_is_italic{is_italic}
 {
 }
 
-FontAttrib::FontAttrib(QFont::Weight weight, double point_size, bool is_italic) :
+FontAttrib::FontAttrib(FontWeight weight_type, double point_size, bool is_italic) :
     m_font{g_font_registry.GetFont()},
-    m_weight{weight},
+    m_weight_type{weight_type},
     m_point_size{point_size},
     m_is_italic{is_italic}
 {
@@ -425,7 +457,7 @@ void updateFonts()
             if (nSize == -1) {
                 nSize = itDefault.first->second;
             }
-            font = getFont({it->second.m_font, it->second.m_weight, nSize, it->second.m_is_italic});
+            font = getFont({it->second.m_font, it->second.m_weight_type, nSize, it->second.m_is_italic});
         } else {
             font.setPointSizeF(g_font_registry.GetScaledFontSize(itDefault.first->second));
         }
@@ -469,12 +501,16 @@ QFont getFont(const FontAttrib& font_attrib)
         return font;
     }
 
+    // Resolve weight from FontWeight type
+    const QFont::Weight weight = (font_attrib.m_weight_type == FontWeight::Bold) ? g_font_registry.GetWeightBold()
+                                                                                 : g_font_registry.GetWeightNormal();
+
     if (font_attrib.m_font == MONTSERRAT_FONT_STR) {
-        assert(mapMontserrat.count(font_attrib.m_weight));
+        assert(mapMontserrat.count(weight));
 #ifdef Q_OS_MACOS
         font.setFamily(font_attrib.m_font);
         font.setStyleName([&]() {
-            std::string ret{mapMontserrat.at(font_attrib.m_weight).first};
+            std::string ret{mapMontserrat.at(weight).first};
             if (font_attrib.m_is_italic) {
                 if (ret == "Regular") {
                     ret = "Italic";
@@ -485,10 +521,10 @@ QFont getFont(const FontAttrib& font_attrib)
             return QString::fromStdString(ret);
         }());
 #else
-        if (font_attrib.m_weight == QFont::Normal || font_attrib.m_weight == QFont::Bold) {
+        if (weight == QFont::Normal || weight == QFont::Bold) {
             font.setFamily(font_attrib.m_font);
         } else {
-            font.setFamily(qstrprintf("%s %s", font_attrib.m_font.toStdString(), mapMontserrat.at(font_attrib.m_weight).first));
+            font.setFamily(qstrprintf("%s %s", font_attrib.m_font.toStdString(), mapMontserrat.at(weight).first));
         }
 #endif // Q_OS_MACOS
     } else if (font_attrib.m_font == OS_FONT_STR) {
@@ -507,7 +543,7 @@ QFont getFont(const FontAttrib& font_attrib)
     if (font_attrib.m_font != MONTSERRAT_FONT_STR)
 #endif // Q_OS_MACOS
     {
-        font.setWeight(font_attrib.m_weight);
+        font.setWeight(weight);
         font.setStyle(font_attrib.m_is_italic ? QFont::StyleItalic : QFont::StyleNormal);
     }
 
@@ -535,12 +571,12 @@ std::vector<QString> getFonts(bool selectable_only)
 
 QFont getFontNormal()
 {
-    return getFont({g_font_registry.GetWeightNormal()});
+    return getFont({FontWeight::Normal});
 }
 
 QFont getFontBold()
 {
-    return getFont({g_font_registry.GetWeightBold()});
+    return getFont({FontWeight::Bold});
 }
 
 QFont::Weight FontRegistry::IdxToWeight(int index) const
@@ -565,7 +601,7 @@ QFont fixedPitchFont(bool use_embedded_font)
 {
     return getFont({
         use_embedded_font ? ROBOTO_MONO_FONT_STR.toUtf8() : OS_MONO_FONT_STR.toUtf8(),
-        g_font_registry.GetWeightNormal()
+        FontWeight::Normal
     });
 }
 } // namespace GUIUtil

--- a/src/qt/guiutil_font.h
+++ b/src/qt/guiutil_font.h
@@ -123,13 +123,13 @@ extern FontRegistry g_font_registry;
 
 struct FontAttrib {
     QString m_font;
-    QFont::Weight m_weight;
+    FontWeight m_weight_type;
     double m_point_size{-1};
     bool m_is_italic{false};
 
-    FontAttrib(QString font, QFont::Weight weight, double point_size = -1, bool is_italic = false);
+    FontAttrib(QString font, FontWeight weight_type, double point_size = -1, bool is_italic = false);
     // cppcheck-suppress noExplicitConstructor
-    FontAttrib(QFont::Weight weight, double point_size = -1, bool is_italic = false);
+    FontAttrib(FontWeight weight_type, double point_size = -1, bool is_italic = false);
     ~FontAttrib();
 };
 

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -40,10 +40,8 @@ MasternodeList::MasternodeList(QWidget* parent) :
 {
     ui->setupUi(this);
 
-    GUIUtil::setFont({ui->label_count_2,
-                      ui->countLabelDIP3
-                     }, {GUIUtil::g_font_registry.GetWeightBold(), 14});
-    GUIUtil::setFont({ui->label_filter_2}, {GUIUtil::g_font_registry.GetWeightNormal(), 15});
+    GUIUtil::setFont({ui->label_count_2, ui->countLabelDIP3}, {GUIUtil::FontWeight::Bold, 14});
+    GUIUtil::setFont({ui->label_filter_2}, {GUIUtil::FontWeight::Normal, 15});
 
     int columnAddressWidth = 200;
     int columnTypeWidth = 160;

--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -25,7 +25,7 @@ ModalOverlay::ModalOverlay(bool enable_wallet, QWidget* parent)
                       ui->labelSyncDone,
                       ui->labelProgressIncrease,
                       ui->labelEstimatedTimeLeft,
-                     }, {GUIUtil::g_font_registry.GetWeightBold()});
+                     }, {GUIUtil::FontWeight::Bold});
 
     ui->warningIcon->setPixmap(GUIUtil::getIcon("warning", GUIUtil::ThemedColor::ORANGE).pixmap(48, 48));
 

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -46,7 +46,7 @@ OptionsDialog::OptionsDialog(QWidget* parent, bool enableWallet)
 {
     ui->setupUi(this);
 
-    GUIUtil::setFont({ui->statusLabel}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
+    GUIUtil::setFont({ui->statusLabel}, {GUIUtil::FontWeight::Bold, 16});
 
     GUIUtil::updateFonts();
 
@@ -389,8 +389,8 @@ void OptionsDialog::showPage(int index)
         }
     }
 
-    GUIUtil::setFont({btnActive}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
-    GUIUtil::setFont(vecNormal, {GUIUtil::g_font_registry.GetWeightNormal(), 16});
+    GUIUtil::setFont({btnActive}, {GUIUtil::FontWeight::Bold, 16});
+    GUIUtil::setFont(vecNormal, {GUIUtil::FontWeight::Normal, 16});
     GUIUtil::updateFonts();
 
     ui->stackedWidgetOptions->setCurrentIndex(index);

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -71,7 +71,7 @@ public:
 
         // Draw first line (with slightly bigger font than the second line will get)
         // Content: Date/Time, Optional IS indicator, Amount
-        painter->setFont(GUIUtil::getFont({GUIUtil::g_font_registry.GetWeightNormal(), GUIUtil::g_font_registry.GetScaledFontSize(initialFontSize * 1.17), false}));
+        painter->setFont(GUIUtil::getFont({GUIUtil::FontWeight::Normal, GUIUtil::g_font_registry.GetScaledFontSize(initialFontSize * 1.17), false}));
         // Date/Time
         colorForeground = qvariant_cast<QColor>(indexDate.data(Qt::ForegroundRole));
         QString strDate = indexDate.data(Qt::DisplayRole).toString();
@@ -92,7 +92,7 @@ public:
 
         // Draw second line (with the initial font)
         // Content: Address/label, Optional Watchonly indicator
-        painter->setFont(GUIUtil::getFont({GUIUtil::g_font_registry.GetWeightNormal(), GUIUtil::g_font_registry.GetScaledFontSize(initialFontSize), false}));
+        painter->setFont(GUIUtil::getFont({GUIUtil::FontWeight::Normal, GUIUtil::g_font_registry.GetScaledFontSize(initialFontSize), false}));
         // Address/Label
         colorForeground = qvariant_cast<QColor>(indexAddress.data(Qt::ForegroundRole));
         QString address = indexAddress.data(Qt::DisplayRole).toString();
@@ -149,16 +149,16 @@ OverviewPage::OverviewPage(QWidget* parent) :
     GUIUtil::setFont({ui->label_4,
                       ui->label_5,
                       ui->labelCoinJoinHeader
-                     }, {GUIUtil::g_font_registry.GetWeightBold(), 16});
+                     }, {GUIUtil::FontWeight::Bold, 16});
 
-    GUIUtil::setFont({ui->labelTotalText}, {GUIUtil::g_font_registry.GetWeightBold(), 14});
+    GUIUtil::setFont({ui->labelTotalText}, {GUIUtil::FontWeight::Bold, 14});
 
     GUIUtil::setFont({ui->labelBalanceText,
                       ui->labelPendingText,
                       ui->labelImmatureText,
                       ui->labelWatchonly,
                       ui->labelSpendable
-                     }, {GUIUtil::g_font_registry.GetWeightBold()});
+                     }, {GUIUtil::FontWeight::Bold});
 
     GUIUtil::updateFonts();
 
@@ -379,7 +379,7 @@ void OverviewPage::setMonospacedFont(const QFont& f)
     GUIUtil::setFont({
         ui->labelTotal,
         ui->labelWatchTotal,
-    }, {f.family(), GUIUtil::g_font_registry.GetWeightBold(), 14});
+    }, {f.family(), GUIUtil::FontWeight::Bold, 14});
 
     GUIUtil::setFont({
         ui->labelAmountRounds,
@@ -391,7 +391,7 @@ void OverviewPage::setMonospacedFont(const QFont& f)
         ui->labelWatchAvailable,
         ui->labelWatchPending,
         ui->labelWatchImmature,
-    }, {f.family(), GUIUtil::g_font_registry.GetWeightBold()});
+    }, {f.family(), GUIUtil::FontWeight::Bold});
 
     GUIUtil::updateFonts();
 }

--- a/src/qt/proposalwizard.cpp
+++ b/src/qt/proposalwizard.cpp
@@ -44,7 +44,7 @@ ProposalWizard::ProposalWizard(interfaces::Node& node, WalletModel* walletModel,
 {
     m_ui->setupUi(this);
 
-    GUIUtil::setFont({m_ui->labelHeader}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
+    GUIUtil::setFont({m_ui->labelHeader}, {GUIUtil::FontWeight::Bold, 16});
     GUIUtil::disableMacFocusRect(this);
     GUIUtil::updateFonts();
 

--- a/src/qt/qrdialog.cpp
+++ b/src/qt/qrdialog.cpp
@@ -21,7 +21,7 @@ QRDialog::QRDialog(QWidget *parent) :
 {
     ui->setupUi(this);
 
-    GUIUtil::setFont({ui->labelQRCodeTitle}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
+    GUIUtil::setFont({ui->labelQRCodeTitle}, {GUIUtil::FontWeight::Bold, 16});
 
     GUIUtil::updateFonts();
 

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -22,10 +22,10 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) :
 {
     ui->setupUi(this);
 
-    GUIUtil::setFont({ui->label_6}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
+    GUIUtil::setFont({ui->label_6}, {GUIUtil::FontWeight::Bold, 16});
     GUIUtil::setFont({ui->label,
                       ui->label_2,
-                      ui->label_3}, {GUIUtil::g_font_registry.GetWeightNormal(), 15});
+                      ui->label_3}, {GUIUtil::FontWeight::Normal, 15});
     GUIUtil::updateFonts();
 
     // context menu

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -488,7 +488,7 @@ RPCConsole::RPCConsole(interfaces::Node& node, QWidget* parent, Qt::WindowFlags 
                       ui->peerHeading,
                       ui->label_repair_header,
                       ui->banHeading
-                     }, {GUIUtil::g_font_registry.GetWeightBold(), 16});
+                     }, {GUIUtil::FontWeight::Bold, 16});
 
     GUIUtil::updateFonts();
 
@@ -1165,8 +1165,8 @@ void RPCConsole::showPage(int index)
         }
     }
 
-    GUIUtil::setFont({btnActive}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
-    GUIUtil::setFont(vecNormal, {GUIUtil::g_font_registry.GetWeightNormal(), 16});
+    GUIUtil::setFont({btnActive}, {GUIUtil::FontWeight::Bold, 16});
+    GUIUtil::setFont(vecNormal, {GUIUtil::FontWeight::Normal, 16});
     GUIUtil::updateFonts();
 
     ui->stackedWidgetRPC->setCurrentIndex(index);

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -77,14 +77,14 @@ SendCoinsDialog::SendCoinsDialog(bool _fCoinJoin, QWidget* parent) :
                       ui->labelCoinControlChangeText,
                       ui->labelFeeHeadline,
                       ui->fallbackFeeWarningLabel
-                     }, {GUIUtil::g_font_registry.GetWeightBold()});
+                     }, {GUIUtil::FontWeight::Bold});
 
     GUIUtil::setFont({ui->labelBalance,
                       ui->labelBalanceName,
-                     }, {GUIUtil::g_font_registry.GetWeightBold(), 14});
+                     }, {GUIUtil::FontWeight::Bold, 14});
 
     GUIUtil::setFont({ui->labelCoinControlFeatures
-                     }, {GUIUtil::g_font_registry.GetWeightBold(), 16});
+                     }, {GUIUtil::FontWeight::Bold, 16});
 
     ui->checkBoxCoinControlChange->setEnabled(!_fCoinJoin);
     GUIUtil::setupAddressWidget(ui->lineEditCoinControlChange, this);

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -36,7 +36,7 @@ SendCoinsEntry::SendCoinsEntry(QWidget* parent) :
     GUIUtil::setFont({ui->payToLabel,
                      ui->labellLabel,
                      ui->amountLabel,
-                     ui->messageLabel}, {GUIUtil::g_font_registry.GetWeightNormal(), 15});
+                     ui->messageLabel}, {GUIUtil::FontWeight::Normal, 15});
 
     GUIUtil::updateFonts();
 

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -52,9 +52,9 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(QWidget* parent) :
     ui->messageIn_VM->installEventFilter(this);
     ui->signatureIn_VM->installEventFilter(this);
 
-    GUIUtil::setFont({ui->signatureOut_SM, ui->signatureIn_VM}, {GUIUtil::g_font_registry.GetWeightNormal(), 11, true});
-    GUIUtil::setFont({ui->signatureLabel_SM}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
-    GUIUtil::setFont({ui->statusLabel_SM, ui->statusLabel_VM}, {GUIUtil::g_font_registry.GetWeightBold()});
+    GUIUtil::setFont({ui->signatureOut_SM, ui->signatureIn_VM}, {GUIUtil::FontWeight::Normal, 11, true});
+    GUIUtil::setFont({ui->signatureLabel_SM}, {GUIUtil::FontWeight::Bold, 16});
+    GUIUtil::setFont({ui->statusLabel_SM, ui->statusLabel_VM}, {GUIUtil::FontWeight::Bold});
 
     GUIUtil::updateFonts();
 
@@ -110,8 +110,8 @@ void SignVerifyMessageDialog::showPage(int index)
         }
     }
 
-    GUIUtil::setFont({btnActive}, {GUIUtil::g_font_registry.GetWeightBold(), 16});
-    GUIUtil::setFont(vecNormal, {GUIUtil::g_font_registry.GetWeightNormal(), 16});
+    GUIUtil::setFont({btnActive}, {GUIUtil::FontWeight::Bold, 16});
+    GUIUtil::setFont(vecNormal, {GUIUtil::FontWeight::Normal, 16});
     GUIUtil::updateFonts();
 
     ui->stackedWidgetSig->setCurrentIndex(index);

--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -162,8 +162,8 @@ void TrafficGraphWidget::paintEvent(QPaintEvent *)
     const QString strReceived = tr("Received");
     const QString strSent = tr("Sent");
     // Get a bold font for the title and a normal one for the rest
-    QFont fontTotal = GUIUtil::getFont({GUIUtil::g_font_registry.GetWeightBold(), 16, false});
-    QFont fontInOut = GUIUtil::getFont({GUIUtil::g_font_registry.GetWeightNormal(), 12, false});
+    QFont fontTotal = GUIUtil::getFont({GUIUtil::FontWeight::Bold, 16, false});
+    QFont fontInOut = GUIUtil::getFont({GUIUtil::FontWeight::Normal, 12, false});
     // Use font metrics to determine minimum rect sizes depending on the font scale
     QFontMetrics fmTotal(fontTotal);
     QFontMetrics fmInOut(fontInOut);

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -69,7 +69,7 @@ WalletView::WalletView(WalletModel* wallet_model, QWidget* parent)
 
     GUIUtil::setFont({transactionSumLabel,
                       transactionSum,
-                     }, {GUIUtil::g_font_registry.GetWeightBold(), 14});
+                     }, {GUIUtil::FontWeight::Bold, 14});
     GUIUtil::updateFonts();
 
     hbox_buttons->addWidget(transactionSum);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Widgets registered via `GUIUtil::setFont()` stored the actual `QFont::Weight` value at registration time. When font weight sliders were adjusted, the stored weight remained unchanged, preventing live updates.

Discovered while reviewing #7112 

## What was done?
This refactors `FontAttrib` to use the existing `FontWeight` enum (`Bold`/`Normal`) instead of storing `QFont::Weight` values. Both `setFont()` and `getFont()` now accept `FontWeight`, which is resolved to the current registry value during `updateFonts()` and `getFont()` calls.

## How Has This Been Tested?
Run dash-qt, go to Preferences -> Appearance tab and move `Font Weight Bold` back and forth.
develop: no visual changes on Overview tab
this branch: text on Overview tab adjusts accordingly

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

