### PR TITLE
fix: template argument in `mapSporksCachedActive`

### DIFF
--- a/src/spork.h
+++ b/src/spork.h
@@ -219,7 +219,7 @@ private:
     // TODO: drop mutex cs_cache completely so far as sporks are used on testnet only
     // and simplify IsSporkActive to avoid any mutex for better mainnet performance
     mutable Mutex cs_cache;
-    mutable std::unordered_map<const SporkId, bool> mapSporksCachedActive GUARDED_BY(cs_cache);
+    mutable std::unordered_map<SporkId, bool> mapSporksCachedActive GUARDED_BY(cs_cache);
     mutable std::unordered_map<SporkId, SporkValue> mapSporksCachedValues GUARDED_BY(cs_cache);
 
     std::set<CKeyID> setSporkPubKeyIDs GUARDED_BY(cs);


### PR DESCRIPTION
## Issue being fixed or feature implemented
In some cases compilation yields an error, because there is no specialization of `std::hash<const SporkId>`.

In my case, during compilation on arm `macOS 26.2` using `llvm 21.1.8` this error appeared:
`error: type 'const std::hash<const SporkId>' does not provide a call operator`


## What was done?
Remove redundant `const` modifier for `mapSporksCachedActive` key. 
This is ok as associative containers already treat the key as const internally.

## Breaking changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
