### PR TITLE
feat(qt): add support for reporting `OP_RETURN` payloads as Data Transactions

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -15,9 +15,11 @@
 #include <qt/transactionrecord.h>
 
 #include <consensus/consensus.h>
-#include <key_io.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
+#include <key_io.h>
+#include <script/script.h>
+#include <util/strencodings.h>
 #include <util/system.h>
 #include <validation.h>
 #include <wallet/ismine.h>
@@ -293,6 +295,26 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";
     strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
     strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx.tx->GetTotalSize()) + " bytes<br>";
+
+    // Show OP_RETURN payload for this specific output
+    if (rec->type == TransactionRecord::DataTransaction &&
+        rec->idx >= 0 && static_cast<size_t>(rec->idx) < wtx.tx->vout.size() &&
+        TransactionRecord::IsDataScript(wtx.tx->vout[rec->idx].scriptPubKey)) {
+        const auto& script{wtx.tx->vout[rec->idx].scriptPubKey};
+        // Extract all data pushes after OP_RETURN
+        const auto payload = [&script]() {
+            auto pc = script.begin() + 1; // Skip opcode
+            opcodetype opcode;
+            std::vector<uint8_t> ret{}, vch{};
+            while (pc < script.end() && script.GetOp(pc, opcode, vch)) {
+                ret.insert(ret.end(), vch.begin(), vch.end());
+            }
+            return ret;
+        }();
+        if (!payload.empty()) {
+            strHTML += "<b>" + tr("Payload") + ":</b> " + QString::fromStdString(HexStr(payload)) + "<br>";
+        }
+    }
 
     // Message from normal dash:URI (dash:XyZ...?message=example)
     for (const std::pair<std::string, std::string>& r : orderForm) {

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -102,6 +102,16 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
 
                 parts.append(sub);
             }
+            else if (!wtx.is_coinbase && IsDataScript(txout.scriptPubKey))
+            {
+                TransactionRecord sub(hash, nTime);
+                sub.credit = txout.nValue;
+                sub.idx = i;
+                sub.involvesWatchAddress = false;
+                sub.strAddress = "";
+                sub.type = TransactionRecord::DataTransaction;
+                parts.append(sub);
+            }
         }
     }
     else
@@ -236,7 +246,13 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
                     continue;
                 }
 
-                if (!std::get_if<CNoDestination>(&wtx.txout_address[nOut]))
+                if (IsDataScript(txout.scriptPubKey))
+                {
+                    sub.strAddress = "";
+                    sub.txDest = DecodeDestination(sub.strAddress);
+                    sub.type = TransactionRecord::DataTransaction;
+                }
+                else if (!std::get_if<CNoDestination>(&wtx.txout_address[nOut]))
                 {
                     // Sent to Dash Address
                     sub.type = TransactionRecord::SendToAddress;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -6,8 +6,9 @@
 #define BITCOIN_QT_TRANSACTIONRECORD_H
 
 #include <consensus/amount.h>
-#include <uint256.h>
 #include <key_io.h>
+#include <script/script.h>
+#include <uint256.h>
 
 #include <QList>
 #include <QString>
@@ -87,10 +88,17 @@ public:
         CoinJoinSend,
         PlatformTransfer,
         DustReceive,
+        DataTransaction,
     };
 
     /** Number of confirmation recommended for accepting a transaction */
     static const int RecommendedNumConfirmations = 6;
+
+    /** Check if script is an OP_RETURN data script */
+    static bool IsDataScript(const CScript& script)
+    {
+        return !script.empty() && script[0] == OP_RETURN;
+    }
 
     TransactionRecord():
             hash(), time(0), type(Other), debit(0), credit(0), idx(0)

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -433,6 +433,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Mined");
     case TransactionRecord::PlatformTransfer:
         return tr("Platform Transfer");
+    case TransactionRecord::DataTransaction:
+        return tr("Data Transaction");
     case TransactionRecord::DustReceive:
         return tr("Dust Receive");
 
@@ -489,6 +491,7 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::CoinJoinCollateralPayment:
     case TransactionRecord::CoinJoinMakeCollaterals:
     case TransactionRecord::CoinJoinCreateDenominations:
+    case TransactionRecord::DataTransaction:
     case TransactionRecord::Other:
         break; // use fail-over here
     } // no default case, so the compiler can warn about missing cases
@@ -517,6 +520,7 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::CoinJoinMixing:
     case TransactionRecord::CoinJoinMakeCollaterals:
     case TransactionRecord::CoinJoinCollateralPayment:
+    case TransactionRecord::DataTransaction:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BAREADDRESS);
     case TransactionRecord::SendToOther:
     case TransactionRecord::RecvFromOther:
@@ -551,6 +555,7 @@ QVariant TransactionTableModel::amountColor(const TransactionRecord *rec) const
     case TransactionRecord::CoinJoinSend:
     case TransactionRecord::SendToAddress:
     case TransactionRecord::SendToOther:
+    case TransactionRecord::DataTransaction:
     case TransactionRecord::Other:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::RED);
     case TransactionRecord::SendToSelf:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -96,6 +96,7 @@ TransactionView::TransactionView(QWidget* parent) :
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Platform Transfer"), TransactionFilterProxy::TYPE(TransactionRecord::PlatformTransfer));
+    typeWidget->addItem(tr("Data Transaction"), TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction));
     typeWidget->addItem(tr("Dust Receive"), TransactionFilterProxy::TYPE(TransactionRecord::DustReceive));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
     typeWidget->setCurrentIndex(settings.value("transactionType").toInt());


### PR DESCRIPTION
## Additional Information

* Depends on https://github.com/dashpay/dash/pull/7147

| `develop` (06e761e2) | This PR (97ae6893) |
| ---------------------- | -------------------- |
| ![](https://github.com/user-attachments/assets/251830d0-41e8-4737-b758-cc0b64b81927) | ![](https://github.com/user-attachments/assets/215e491b-0457-43e9-a3c4-d8ff4786e9a0) |
| ![](https://github.com/user-attachments/assets/780cb660-d610-4f8d-af28-b1009732be35) | ![](https://github.com/user-attachments/assets/20bb43f6-b6d5-45a6-9afc-77ebb4aaedd6) |

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests **(note: N/A)**
- [x] I have made corresponding changes to the documentation **(note: N/A)**
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

