### PR TITLE
build: expand minimum Darwin version to macOS 11 (Big Sur)

### DIFF
--- a/contrib/guix/symbol-check.py
+++ b/contrib/guix/symbol-check.py
@@ -235,7 +235,7 @@ def check_MACHO_libraries(binary) -> bool:
     return ok
 
 def check_MACHO_min_os(binary) -> bool:
-    if binary.build_version.minos == [14,0,0]:
+    if binary.build_version.minos == [11,0,0]:
         return True
     return False
 

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -1,4 +1,4 @@
-OSX_MIN_VERSION=14.0
+OSX_MIN_VERSION=11.0
 OSX_SDK_VERSION=14.0
 XCODE_VERSION=15.0
 XCODE_BUILD_ID=15A240d
@@ -79,4 +79,4 @@ darwin_debug_CXXFLAGS=$(darwin_debug_CFLAGS)
 darwin_cmake_system_name=Darwin
 # Darwin version, which corresponds to OSX_MIN_VERSION.
 # See https://en.wikipedia.org/wiki/Darwin_(operating_system)
-darwin_cmake_system_version=23.0
+darwin_cmake_system_version=20.0

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,6 +1,6 @@
 # macOS Build Guide
 
-**Updated for macOS [14](https://developer.apple.com/documentation/macos-release-notes/macos-14-release-notes/)**
+**Updated for macOS [11](https://developer.apple.com/documentation/macos-release-notes/macos-big-sur-11_0_1-release-notes/)**
 
 This guide describes how to build dashd, command-line utilities, and GUI on macOS.
 
@@ -49,6 +49,20 @@ See [dependencies.md](dependencies.md) for a complete overview.
 ``` bash
 brew install automake libtool boost gmp pkg-config libevent
 ```
+
+For macOS 11 (Big Sur) and 12 (Monterey) you need to install a more recent version of llvm.
+
+``` bash
+brew install llvm
+```
+
+And append the following to the configure commands below:
+
+``` bash
+CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++
+```
+
+Try `llvm@17` if compilation fails with the default version of llvm.
 
 ### 4. Clone Dash repository
 

--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -32,7 +32,7 @@ likely require a reindex.
 # Compatibility
 
 Dash Core is supported and tested on operating systems using the
-Linux Kernel 3.17+, macOS 14+, and Windows 10+. Dash Core
+Linux Kernel 3.17+, macOS 11+, and Windows 10+. Dash Core
 should also work on most other Unix-like systems but is not as
 frequently tested on them. It is not recommended to use Dash Core on
 unsupported systems.

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -3,7 +3,7 @@
 <plist version="0.9">
 <dict>
   <key>LSMinimumSystemVersion</key>
-  <string>14</string>
+  <string>11</string>
 
   <key>LSArchitecturePriority</key>
   <array>


### PR DESCRIPTION
## Additional Information

This pull request is a partial revert of introduced in [dash#6927](https://github.com/dashpay/dash/pull/6927) (in anticipation of [dash#7109](https://github.com/dashpay/dash/pull/7109), which missed the v23.1 merge cycle) resulting in the macOS minimum version going back to macOS 11 (Big Sur) from macOS 14 (Sonoma). 

**This change is for the v23.1.x family of releases only and should not be merged in `develop`.**

## Breaking Changes

None expected.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas **(note: N/A)**
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
