### PR TITLE
fix: MN update notifications had old_list/new_list swapped

### DIFF
--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -702,7 +702,7 @@ bool CDeterministicMNManager::ProcessBlock(const CBlock& block, gsl::not_null<co
     }
 
     if (diff.HasChanges()) {
-        updatesRet = {newList, oldList, diff};
+        updatesRet = {.old_list = oldList, .new_list = newList, .diff = diff};
     }
 
     if (::g_stats_client->active()) {
@@ -755,7 +755,7 @@ bool CDeterministicMNManager::UndoBlock(gsl::not_null<const CBlockIndex*> pindex
         curList.ApplyDiff(pindex, diff);
 
         auto inversedDiff{curList.BuildDiff(prevList)};
-        updatesRet = {curList, prevList, inversedDiff};
+        updatesRet = {.old_list = curList, .new_list = prevList, .diff = inversedDiff};
     }
 
     const auto& consensusParams = Params().GetConsensus();


### PR DESCRIPTION
## Issue being fixed or feature implemented
- UI: Masternode list tab displayed state at block X-1 while node was at block X
- Net: mnauth disconnect handling could miss removals, keeping removed masternode peers connected longer than intended

Noticed while reviewing #7146 

## What was done?

## How Has This Been Tested?
Run qt, open masternode list tab, sort by last paid (desc). Open Info dialog to see block height, wait for another block after full sync and compare.

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

