### PR TITLE
feat(qt): replace "toggle lock state" button with a new "(un)lock all" one

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <memory>
 #include <psbt.h>
+#include <set>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -170,7 +171,7 @@ public:
     virtual bool isLockedCoin(const COutPoint& output) = 0;
 
     //! List locked coins.
-    virtual std::vector<COutPoint> listLockedCoins() = 0;
+    virtual std::set<COutPoint> listLockedCoins() = 0;
 
     //! Lock the provided coins in a single batch.
     virtual bool lockCoins(const std::vector<COutPoint>& outputs) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -172,6 +172,12 @@ public:
     //! List locked coins.
     virtual std::vector<COutPoint> listLockedCoins() = 0;
 
+    //! Lock the provided coins in a single batch.
+    virtual bool lockCoins(const std::vector<COutPoint>& outputs) = 0;
+
+    //! Unlock the provided coins in a single batch.
+    virtual bool unlockCoins(const std::vector<COutPoint>& outputs) = 0;
+
     //! List protx coins.
     virtual std::vector<COutPoint> listProTxCoins() = 0;
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -189,6 +189,9 @@ void CoinControlDialog::buttonSelectAllClicked()
 // (un)lock all
 void CoinControlDialog::buttonLockAllClicked()
 {
+    // Fetch the wallet-wide locked set once (single cs_wallet acquisition)
+    const std::set<COutPoint> lockedSet{model->wallet().listLockedCoins()};
+
     // Collect all visible UTXOs; track locked ones separately for the unlock path
     // (works in both tree and list modes)
     std::vector<COutPoint> outputs;
@@ -200,7 +203,7 @@ void CoinControlDialog::buttonLockAllClicked()
             const COutPoint outpt(uint256S(item->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()),
                                   item->data(COLUMN_ADDRESS, VOutRole).toUInt());
             outputs.emplace_back(outpt);
-            if (model->wallet().isLockedCoin(outpt)) lockedOutputs.emplace_back(outpt);
+            if (lockedSet.contains(outpt)) lockedOutputs.emplace_back(outpt);
         } else {
             // Tree mode: top-level item is an address group; collect children
             for (int j = 0; j < item->childCount(); j++) {
@@ -208,7 +211,7 @@ void CoinControlDialog::buttonLockAllClicked()
                 const COutPoint outpt(uint256S(child->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()),
                                       child->data(COLUMN_ADDRESS, VOutRole).toUInt());
                 outputs.emplace_back(outpt);
-                if (model->wallet().isLockedCoin(outpt)) lockedOutputs.emplace_back(outpt);
+                if (lockedSet.contains(outpt)) lockedOutputs.emplace_back(outpt);
             }
         }
     }

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -114,9 +114,6 @@ CoinControlDialog::CoinControlDialog(CCoinControl& coin_control, WalletModel* _m
     // (un)select all
     connect(ui->pushButtonSelectAll, &QPushButton::clicked, this, &CoinControlDialog::buttonSelectAllClicked);
 
-    // Toggle lock state
-    connect(ui->pushButtonToggleLock, &QPushButton::clicked, this, &CoinControlDialog::buttonToggleLockClicked);
-
     // (un)lock all
     connect(ui->pushButtonLockAll, &QPushButton::clicked, this, &CoinControlDialog::buttonLockAllClicked);
 
@@ -187,43 +184,6 @@ void CoinControlDialog::buttonSelectAllClicked()
     if (state == Qt::Unchecked)
         m_coin_control.UnSelectAll(); // just to be sure
     CoinControlDialog::updateLabels(m_coin_control, model, this);
-}
-
-// Toggle lock state
-void CoinControlDialog::buttonToggleLockClicked()
-{
-    QTreeWidgetItem *item;
-    // Works in list-mode only
-    if(ui->radioListMode->isChecked()){
-        ui->treeWidget->setEnabled(false);
-        for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++){
-            item = ui->treeWidget->topLevelItem(i);
-            COutPoint outpt(uint256S(item->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()), item->data(COLUMN_ADDRESS, VOutRole).toUInt());
-            // Don't toggle the lock state of partially mixed coins if they are not hidden in CoinJoin mode
-            if (m_coin_control.IsUsingCoinJoin() && !fHideAdditional && !model->isFullyMixed(outpt)) {
-                continue;
-            }
-            if (model->wallet().isLockedCoin(outpt)) {
-                model->wallet().unlockCoin(outpt);
-                item->setDisabled(false);
-                item->setIcon(COLUMN_CHECKBOX, QIcon());
-            }
-            else{
-                model->wallet().lockCoin(outpt, /*write_to_db=*/true);
-                item->setDisabled(true);
-                item->setIcon(COLUMN_CHECKBOX, GUIUtil::getIcon("lock_closed", GUIUtil::ThemedColor::RED));
-            }
-            updateLabelLocked();
-        }
-        ui->treeWidget->setEnabled(true);
-        CoinControlDialog::updateLabels(m_coin_control, model, this);
-    }
-    else{
-        QMessageBox msgBox(this);
-        msgBox.setObjectName("lockMessageBox");
-        msgBox.setText(tr("Please switch to \"List mode\" to use this function."));
-        msgBox.exec();
-    }
 }
 
 // (un)lock all

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -117,6 +117,9 @@ CoinControlDialog::CoinControlDialog(CCoinControl& coin_control, WalletModel* _m
     // Toggle lock state
     connect(ui->pushButtonToggleLock, &QPushButton::clicked, this, &CoinControlDialog::buttonToggleLockClicked);
 
+    // (un)lock all
+    connect(ui->pushButtonLockAll, &QPushButton::clicked, this, &CoinControlDialog::buttonLockAllClicked);
+
     ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 94);
     ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 100);
     ui->treeWidget->setColumnWidth(COLUMN_LABEL, 170);
@@ -221,6 +224,45 @@ void CoinControlDialog::buttonToggleLockClicked()
         msgBox.setText(tr("Please switch to \"List mode\" to use this function."));
         msgBox.exec();
     }
+}
+
+// (un)lock all
+void CoinControlDialog::buttonLockAllClicked()
+{
+    // Collect all visible UTXOs; track locked ones separately for the unlock path
+    // (works in both tree and list modes)
+    std::vector<COutPoint> outputs;
+    std::vector<COutPoint> lockedOutputs;
+    for (int i = 0; i < ui->treeWidget->topLevelItemCount(); i++) {
+        QTreeWidgetItem* item = ui->treeWidget->topLevelItem(i);
+        if (item->data(COLUMN_ADDRESS, TxHashRole).toString().length() == 64) {
+            // List mode: top-level item is a UTXO
+            const COutPoint outpt(uint256S(item->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()),
+                                  item->data(COLUMN_ADDRESS, VOutRole).toUInt());
+            outputs.emplace_back(outpt);
+            if (model->wallet().isLockedCoin(outpt)) lockedOutputs.emplace_back(outpt);
+        } else {
+            // Tree mode: top-level item is an address group; collect children
+            for (int j = 0; j < item->childCount(); j++) {
+                QTreeWidgetItem* child = item->child(j);
+                const COutPoint outpt(uint256S(child->data(COLUMN_ADDRESS, TxHashRole).toString().toStdString()),
+                                      child->data(COLUMN_ADDRESS, VOutRole).toUInt());
+                outputs.emplace_back(outpt);
+                if (model->wallet().isLockedCoin(outpt)) lockedOutputs.emplace_back(outpt);
+            }
+        }
+    }
+    bool should_lock = lockedOutputs.empty();
+    bool success = should_lock ? model->wallet().lockCoins(outputs)
+                               : model->wallet().unlockCoins(lockedOutputs);
+    if (!success) {
+        QMessageBox::warning(this, tr("Wallet error"),
+            should_lock ? tr("Failed to lock some coins.")
+                        : tr("Failed to unlock some coins."));
+    }
+    updateView();
+    updateLabelLocked();
+    CoinControlDialog::updateLabels(m_coin_control, model, this);
 }
 
 // context menu

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -108,7 +108,6 @@ private Q_SLOTS:
     void headerSectionClicked(int);
     void buttonBoxClicked(QAbstractButton*);
     void buttonSelectAllClicked();
-    void buttonToggleLockClicked();
     void buttonLockAllClicked();
     void updateLabelLocked();
     void on_hideButton_clicked();

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -109,6 +109,7 @@ private Q_SLOTS:
     void buttonBoxClicked(QAbstractButton*);
     void buttonSelectAllClicked();
     void buttonToggleLockClicked();
+    void buttonLockAllClicked();
     void updateLabelLocked();
     void on_hideButton_clicked();
 };

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -254,7 +254,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0,0,0">
+       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0,0">
         <property name="spacing">
          <number>14</number>
         </property>
@@ -284,22 +284,6 @@
           </property>
           <property name="text">
            <string>(un)lock all</string>
-          </property>
-          <property name="autoDefault">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonToggleLock">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>toggle lock state</string>
           </property>
           <property name="autoDefault">
            <bool>false</bool>

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -254,7 +254,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0,0">
+       <layout class="QHBoxLayout" name="horizontalLayoutPanel" stretch="0,0,0,0,0,0,0,0">
         <property name="spacing">
          <number>14</number>
         </property>
@@ -268,6 +268,22 @@
           </property>
           <property name="text">
            <string>(un)select all</string>
+          </property>
+          <property name="autoDefault">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonLockAll">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>(un)lock all</string>
           </property>
           <property name="autoDefault">
            <bool>false</bool>

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -321,7 +321,7 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->IsLockedCoin(output);
     }
-    std::vector<COutPoint> listLockedCoins() override
+    std::set<COutPoint> listLockedCoins() override
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->ListLockedCoins();

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -326,6 +326,24 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->ListLockedCoins();
     }
+    bool lockCoins(const std::vector<COutPoint>& outputs) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        WalletBatch batch(m_wallet->GetDatabase());
+        for (const auto& output : outputs) {
+            if (!m_wallet->LockCoin(output, &batch)) return false;
+        }
+        return true;
+    }
+    bool unlockCoins(const std::vector<COutPoint>& outputs) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        WalletBatch batch(m_wallet->GetDatabase());
+        for (const auto& output : outputs) {
+            if (!m_wallet->UnlockCoin(output, &batch)) return false;
+        }
+        return true;
+    }
     std::vector<COutPoint> listProTxCoins() override
     {
         LOCK(m_wallet->cs_wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2742,10 +2742,10 @@ bool CWallet::IsLockedCoin(const COutPoint& output) const
     return setLockedCoins.count(output) > 0;
 }
 
-std::vector<COutPoint> CWallet::ListLockedCoins() const
+const std::set<COutPoint>& CWallet::ListLockedCoins() const
 {
     AssertLockHeld(cs_wallet);
-    return std::vector<COutPoint>(setLockedCoins.begin(), setLockedCoins.end());
+    return setLockedCoins;
 }
 
 std::vector<COutPoint> CWallet::ListProTxCoins() const { return ListProTxCoins(setWalletUTXO); }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -582,7 +582,7 @@ public:
     bool LockCoin(const COutPoint& output, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool UnlockCoin(const COutPoint& output, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool UnlockAllCoins() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    std::vector<COutPoint> ListLockedCoins() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    const std::set<COutPoint>& ListLockedCoins() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     std::vector<COutPoint> ListProTxCoins() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     std::vector<COutPoint> ListProTxCoins(const std::set<COutPoint>& utxos) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void LockProTxCoins(const std::set<COutPoint>& utxos, WalletBatch* batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
## Issue being fixed or feature implemented
With dust protection off user could have 10s (or even 100s) of outpoints locked in Coin Control and the only way to unlock them all is going one by one. There is a "toggle lock state" button (https://github.com/dashpay/dash/pull/589) which is not very useful in this case imo because it's like half of outpoints are locked and half are not.

## What was done?
Replace "toggle lock state" button with a new "(un)lock all" one which behaves similar to "(un)select all" - locks all outpoint when no outpoint is locked, unlocks all if any of them is locked. Works in both modes (tree/list) unlike the old button. Locking 100s of outpoints is also much faster because `lockAllCoins()` actually uses `WalletBatch` to batch operations instead of locking outpoints one by one.

## How Has This Been Tested?

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

