### PR TITLE
fix(qt): stable sort for equal items in Coin Control dialog

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -39,8 +39,17 @@ bool CoinControlDialog::fSubtractFeeFromAmount = false;
 
 bool CCoinControlWidgetItem::operator<(const QTreeWidgetItem &other) const {
     int column = treeWidget()->sortColumn();
-    if (column == CoinControlDialog::COLUMN_AMOUNT || column == CoinControlDialog::COLUMN_DATE || column == CoinControlDialog::COLUMN_CONFIRMATIONS || column == CoinControlDialog::COLUMN_COINJOIN_ROUNDS)
-        return data(column, Qt::UserRole).toLongLong() < other.data(column, Qt::UserRole).toLongLong();
+    if (column == CoinControlDialog::COLUMN_AMOUNT || column == CoinControlDialog::COLUMN_DATE || column == CoinControlDialog::COLUMN_CONFIRMATIONS || column == CoinControlDialog::COLUMN_COINJOIN_ROUNDS) {
+        long long a = data(column, Qt::UserRole).toLongLong();
+        long long b = other.data(column, Qt::UserRole).toLongLong();
+        if (a != b) return a < b;
+        // Stable tiebreaker: sort by outpoint (txid:vout) to ensure consistent ordering of equal items
+        int cmp = data(CoinControlDialog::COLUMN_ADDRESS, CoinControlDialog::TxHashRole).toString()
+                      .compare(other.data(CoinControlDialog::COLUMN_ADDRESS, CoinControlDialog::TxHashRole).toString());
+        if (cmp != 0) return cmp < 0;
+        return data(CoinControlDialog::COLUMN_ADDRESS, CoinControlDialog::VOutRole).toUInt() <
+               other.data(CoinControlDialog::COLUMN_ADDRESS, CoinControlDialog::VOutRole).toUInt();
+    }
     return QTreeWidgetItem::operator<(other);
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
`CCoinControlWidgetItem::operator<` had no tiebreaker for equal numeric values (amount, date, confirmations, CoinJoin rounds), causing Qt's unstable sort to produce a different ordering on each updateView() call whenever coins with identical values were present.

Noticed while testing  #7155 - clicking "(un)lock all" button shifted rows with the same amount when list was sorted by amounts.

## What was done?
Add a secondary sort by outpoint (txid:vout), which is unique and stable across view rebuilds.

## How Has This Been Tested?
Build it on top of #7155, run and click "(un)lock all" button in Coin Control dialog - should be stable now.

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

