### PR TITLE
fix(qt): prevent banned masternodes from returning status=0

### DIFF
--- a/src/qt/masternodemodel.cpp
+++ b/src/qt/masternodemodel.cpp
@@ -289,9 +289,9 @@ QVariant MasternodeModel::data(const QModelIndex& index, int role) const
                 if (entry->isBanned()) {
                     // Banned nodes use positive values
                     if (auto ban_height = entry->poseBanHeight(); ban_height && *ban_height > 0) {
-                        return m_current_height - *ban_height;
+                        return m_current_height - *ban_height + 1; // +1: freshly banned → 1, never 0
                     }
-                    return 0; // Unknown ban time, treat as freshly banned
+                    return 1; // Unknown ban time, treat as freshly banned
                 } else {
                     // Active nodes use negative values
                     int32_t active_height = entry->registeredHeight();


### PR DESCRIPTION
## Issue being fixed or feature implemented
Two code paths in `MasternodeModel::data()` could return `0` for banned nodes:
- `ban_height` == `m_current_height` (banned this block)
- `ban_height` unavailable (unknown ban time)

`0` is also valid for an active node registered in the current block, so the "Hide banned" filter (`status > 0`) could silently fail to hide freshly-banned nodes.

#7147 follow-up

## What was done?
Fix: add `+1` offset to the banned-node calculation and change the fallback return from 0 to 1. The encoding contract is now unambiguous:
  - Banned  → always ≥ 1 (age in blocks + 1)
  - Active  → always ≤ 0 (0 = registered this block)

Relative sort order among banned nodes is preserved.

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

