### PR TITLE
fix(wallet): commit DB write before updating in-memory lock state

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2730,10 +2730,19 @@ bool CWallet::UnlockAllCoins()
     AssertLockHeld(cs_wallet);
     bool success = true;
     WalletBatch batch(GetDatabase());
-    for (auto it = setLockedCoins.begin(); it != setLockedCoins.end(); ++it) {
-        success &= batch.EraseLockedUTXO(*it);
+    std::set<uint256> affectedTxids;
+    for (auto it = setLockedCoins.begin(); it != setLockedCoins.end(); ) {
+        if (batch.EraseLockedUTXO(*it)) {
+            affectedTxids.insert(it->hash);
+            it = setLockedCoins.erase(it);
+        } else {
+            success = false;
+            ++it;
+        }
     }
-    setLockedCoins.clear();
+    for (const auto& txid : affectedTxids) {
+        RecalculateMixedCredit(txid);
+    }
     return success;
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
`LockCoin` and `UnlockCoin` previously mutated `setLockedCoins` before writing to the DB.`UnlockAllCoins` cleared `setLockedCoins` regardless of success status. A failed batch write left in-memory and on-disk state diverged until wallet restart. 

Discovered in https://github.com/dashpay/dash/pull/7155#discussion_r2829949777 by @coderabbitai

## What was done?
Fix by writing to the DB first and only updating `setLockedCoins` (and calling `RecalculateMixedCredit`) on success. Also batch `RecalculateMixedCredit` by affected txid at the end of `UnlockAllCoins`.

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

