### PR TITLE
test: use BOOST_REQUIRE for fatal preconditions in coinjoin_tests

### DIFF
--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -169,7 +169,7 @@ public:
         {
             LOCK(wallet->cs_wallet);
             it = wallet->mapWallet.find(nTxHash);
-            assert(it != wallet->mapWallet.end());
+            BOOST_REQUIRE(it != wallet->mapWallet.end());
             blocktx = CMutableTransaction(*it->second.tx);
         }
         CreateAndProcessBlock({blocktx}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
@@ -188,14 +188,14 @@ public:
         {
             LOCK(wallet->cs_wallet);
             auto dest_opt = reserveDest.GetReservedDestination(false);
-            BOOST_CHECK(dest_opt);
+            BOOST_REQUIRE(dest_opt);
             tallyItem.txdest = *dest_opt;
         }
         for (CAmount nAmount : vecAmounts) {
             CTransactionRef tx;
             {
                 auto res = CreateTransaction(*wallet, {{GetScriptForDestination(tallyItem.txdest), nAmount, false}}, nChangePosRet, coinControl);
-                BOOST_CHECK(res);
+                BOOST_REQUIRE(res);
                 tx = res->tx;
                 nChangePosRet = res->change_pos;
             }
@@ -213,7 +213,7 @@ public:
                 tallyItem.nAmount += tx->vout[n].nValue;
             }
         }
-        assert(tallyItem.outpoints.size() == vecAmounts.size());
+        BOOST_REQUIRE_EQUAL(tallyItem.outpoints.size(), vecAmounts.size());
         reserveDest.KeepDestination();
         return tallyItem;
     }
@@ -270,7 +270,7 @@ BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
         BOOST_CHECK_EQUAL(txBuilder.CountOutputs(), 1);
 
         bilingual_str strResult;
-        BOOST_CHECK(txBuilder.Commit(strResult));
+        BOOST_REQUIRE(txBuilder.Commit(strResult));
         CWalletTx& wtx = AddTxToChain(uint256S(strResult.original));
         BOOST_CHECK_EQUAL(wtx.tx->vout.size(), txBuilder.CountOutputs()); // should have no change output
         BOOST_CHECK_EQUAL(wtx.tx->vout[0].nValue, output->GetAmount());
@@ -300,7 +300,7 @@ BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
         }
         BOOST_CHECK_EQUAL(vecOutputs.size(), 100);
         BOOST_CHECK_EQUAL(txBuilder.CountOutputs(), vecOutputs.size());
-        BOOST_CHECK(txBuilder.Commit(strResult));
+        BOOST_REQUIRE(txBuilder.Commit(strResult));
         CWalletTx& wtx = AddTxToChain(uint256S(strResult.original));
         BOOST_CHECK_EQUAL(wtx.tx->vout.size(), txBuilder.CountOutputs() + 1); // should have change output
         for (const auto& out : wtx.tx->vout) {


### PR DESCRIPTION
## Issue

Refs https://github.com/dashpay/dash/issues/6696

## Description

The `CTransactionBuilderTest` test intermittently crashes with a hard `assert()` failure in `AddTxToChain()`:

```
assertion: it != wallet->mapWallet.end()
file: wallet/test/coinjoin_tests.cpp, line: 171
```

This happens because `BOOST_CHECK(txBuilder.Commit(strResult))` is non-fatal — when `Commit()` fails intermittently (e.g., under UBSAN/sanitizer builds), execution continues and `AddTxToChain()` is called with an invalid/empty txid, hitting the hard `assert()`.

## Solution

Replace `assert()` and `BOOST_CHECK()` with `BOOST_REQUIRE()` at all points where subsequent code depends on the check result:

- `assert(it != wallet->mapWallet.end())` → `BOOST_REQUIRE(...)` in `AddTxToChain()`
- `BOOST_CHECK(txBuilder.Commit(strResult))` → `BOOST_REQUIRE(...)` (both call sites)
- `BOOST_CHECK(dest_opt)` and `BOOST_CHECK(res)` → `BOOST_REQUIRE(...)` in `GetTallyItem()` where the result is immediately dereferenced
- `assert(tallyItem.outpoints.size() == vecAmounts.size())` → `BOOST_REQUIRE_EQUAL(...)` in `GetTallyItem()`

`BOOST_REQUIRE` aborts the test case on failure, producing a clean failure message instead of a process abort via `assert()`. This prevents the cascading crash that makes debugging the root cause harder.

## Validation

**What was tested:**
- Full build and test suite including `wallet/test/coinjoin_tests.cpp`
- UBSAN build to verify the previously flaky assert path now produces a clean BOOST_REQUIRE failure instead of a process abort

**Results:**
- CI full suite: all applicable checks passed
  - `linux64-build / Build source` — pass
  - `linux64-test / Test source` — pass
  - `linux64_ubsan-build / Build source` — pass
  - `linux64_ubsan-test / Test source` — pass
  - `mac-build / Build source` — pass
  - `win64-build / Build source` — pass

**Environment:** GitHub Actions CI (linux64 + ubsan + mac + win64 matrix)
