### PR TITLE
ci: add fuzz regression testing and continuous fuzzing infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,12 +321,12 @@ jobs:
   test-linux64_fuzz:
     name: linux64_fuzz-test
     uses: ./.github/workflows/test-fuzz.yml
-    needs: [check-skip, container-slim, src-linux64_fuzz]
+    needs: [check-skip, container, src-linux64_fuzz]
     if: ${{ vars.SKIP_LINUX64_FUZZ == '' }}
     with:
       bundle-key: ${{ needs.src-linux64_fuzz.outputs.key }}
       build-target: linux64_fuzz
-      container-path: ${{ needs.container-slim.outputs.path }}
+      container-path: ${{ needs.container.outputs.path }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   test-linux64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,6 +318,17 @@ jobs:
       depends-dep-opts: ${{ needs.depends-win64.outputs.dep-opts }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
+  test-linux64_fuzz:
+    name: linux64_fuzz-test
+    uses: ./.github/workflows/test-fuzz.yml
+    needs: [check-skip, container-slim, src-linux64_fuzz]
+    if: ${{ vars.SKIP_LINUX64_FUZZ == '' }}
+    with:
+      bundle-key: ${{ needs.src-linux64_fuzz.outputs.key }}
+      build-target: linux64_fuzz
+      container-path: ${{ needs.container-slim.outputs.path }}
+      runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
+
   test-linux64:
     name: linux64-test
     uses: ./.github/workflows/test-src.yml

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -52,32 +52,51 @@ jobs:
         run: |
           mkdir -p /tmp/fuzz_corpus
 
+          BITCOIN_QA_ASSETS_SHA=ef5d7720f2a1ac20607bd5fba16137f4bfbcfec6
+          DASH_QA_ASSETS_SHA=b4d1a7ce41a9a21d522381944ba84b60b1ad5b60
+
           # Fail the job if neither external qa-assets source is reachable — otherwise we
           # silently degrade to synthetic-only/empty-corpus smoke runs and CI goes green on
           # no signal. Synthetic seeds are additive only; they do not substitute for the
           # curated external corpora.
           loaded_external=0
 
+          fetch_pinned_repo() {
+            local repo_url="$1"
+            local repo_sha="$2"
+            local dest_dir="$3"
+            local resolved_sha
+
+            rm -rf "$dest_dir"
+            git init --quiet "$dest_dir"
+            git -C "$dest_dir" remote add origin "$repo_url"
+            git -C "$dest_dir" fetch --depth=1 origin "$repo_sha" || return 1
+            git -C "$dest_dir" checkout --quiet --detach FETCH_HEAD || return 1
+            resolved_sha=$(git -C "$dest_dir" rev-parse HEAD) || return 1
+            echo "Resolved ${repo_url} to ${resolved_sha}"
+            [ "$resolved_sha" = "$repo_sha" ]
+          }
+
           # Layer 1: bitcoin-core inherited corpus
-          if git clone --depth=1 https://github.com/bitcoin-core/qa-assets /tmp/qa-assets; then
+          if fetch_pinned_repo https://github.com/bitcoin-core/qa-assets "$BITCOIN_QA_ASSETS_SHA" /tmp/qa-assets; then
             if [ -d "/tmp/qa-assets/fuzz_seed_corpus" ]; then
               cp -r /tmp/qa-assets/fuzz_seed_corpus/. /tmp/fuzz_corpus/
               echo "Loaded bitcoin-core corpus"
               loaded_external=1
             fi
           else
-            echo "::warning::Failed to clone bitcoin-core/qa-assets"
+            echo "::warning::Failed to fetch bitcoin-core/qa-assets at ${BITCOIN_QA_ASSETS_SHA}"
           fi
 
           # Layer 2: Dash-specific corpus (overlays on top)
-          if git clone --depth=1 https://github.com/dashpay/qa-assets /tmp/dash-qa-assets; then
+          if fetch_pinned_repo https://github.com/dashpay/qa-assets "$DASH_QA_ASSETS_SHA" /tmp/dash-qa-assets; then
             if [ -d "/tmp/dash-qa-assets/fuzz/corpora" ]; then
               cp -r /tmp/dash-qa-assets/fuzz/corpora/. /tmp/fuzz_corpus/
               echo "Loaded Dash-specific corpus"
               loaded_external=1
             fi
           else
-            echo "::warning::Failed to clone dashpay/qa-assets"
+            echo "::warning::Failed to fetch dashpay/qa-assets at ${DASH_QA_ASSETS_SHA}"
           fi
 
           if [ "$loaded_external" -eq 0 ]; then

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -126,8 +126,9 @@ jobs:
             exit 1
           fi
 
-          # detect_leaks=0 is intentional for fuzz regression due to libFuzzer/LSan noise.
-          export ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=0"
+          # Leak detection stays enabled; known-noisy dependency leaks are filtered via
+          # LSAN_OPTIONS suppressions instead of being globally disabled.
+          export ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
           export LSAN_OPTIONS="suppressions=${BUILD_DIR}/test/sanitizer_suppressions/lsan"
           export UBSAN_OPTIONS="suppressions=${BUILD_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"
 
@@ -185,7 +186,7 @@ jobs:
             echo "::group::${target} ($(find "$corpus_dir" -maxdepth 1 -type f | wc -l) inputs)"
             if FUZZ="$target" timeout 3600 "$FUZZ_BIN" \
                 -rss_limit_mb=4000 \
-                -runs=0 \
+                -runs=1 \
                 -artifact_prefix="$artifact_prefix" \
                 "$corpus_dir" 2>&1; then
               echo "PASS: $target"

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -52,14 +52,21 @@ jobs:
         run: |
           mkdir -p /tmp/fuzz_corpus
 
+          # Fail the job if neither external qa-assets source is reachable — otherwise we
+          # silently degrade to synthetic-only/empty-corpus smoke runs and CI goes green on
+          # no signal. Synthetic seeds are additive only; they do not substitute for the
+          # curated external corpora.
+          loaded_external=0
+
           # Layer 1: bitcoin-core inherited corpus
           if git clone --depth=1 https://github.com/bitcoin-core/qa-assets /tmp/qa-assets; then
             if [ -d "/tmp/qa-assets/fuzz_seed_corpus" ]; then
               cp -r /tmp/qa-assets/fuzz_seed_corpus/. /tmp/fuzz_corpus/
               echo "Loaded bitcoin-core corpus"
+              loaded_external=1
             fi
           else
-            echo "WARNING: Failed to clone bitcoin-core/qa-assets (non-fatal)"
+            echo "::warning::Failed to clone bitcoin-core/qa-assets"
           fi
 
           # Layer 2: Dash-specific corpus (overlays on top)
@@ -67,14 +74,22 @@ jobs:
             if [ -d "/tmp/dash-qa-assets/fuzz/corpora" ]; then
               cp -r /tmp/dash-qa-assets/fuzz/corpora/. /tmp/fuzz_corpus/
               echo "Loaded Dash-specific corpus"
+              loaded_external=1
             fi
           else
-            echo "WARNING: Failed to clone dashpay/qa-assets (non-fatal)"
+            echo "::warning::Failed to clone dashpay/qa-assets"
           fi
 
-          # Layer 3: Generate synthetic seeds for Dash-specific targets
+          if [ "$loaded_external" -eq 0 ]; then
+            echo "::error::No external corpus sources reachable - refusing to run synthetic-only/empty-corpus smoke tests that produce no signal"
+            exit 1
+          fi
+
+          # Layer 3: Generate synthetic seeds for Dash-specific targets (additive only —
+          # gated on external corpus being present so we never pass on synthetic-only runs).
           if [ -f "contrib/fuzz/seed_corpus_from_chain.py" ]; then
-            python3 contrib/fuzz/seed_corpus_from_chain.py --synthetic-only -o /tmp/fuzz_corpus
+            python3 contrib/fuzz/seed_corpus_from_chain.py --synthetic-only -o /tmp/fuzz_corpus || \
+              echo "::warning::Synthetic seed generation failed; continuing with external corpus only"
           fi
         shell: bash
 
@@ -112,10 +127,15 @@ jobs:
           FAILED=0
           PASSED=0
           FAILED_TARGETS=""
+          # libFuzzer writes crash-/leak-/oom-/timeout- files to this directory on failure
+          # via -artifact_prefix, so the "Upload crash artifacts" step below can collect them.
+          ARTIFACT_DIR=/tmp/fuzz_artifacts
+          mkdir -p "$ARTIFACT_DIR"
 
           while IFS= read -r target; do
             [ -z "$target" ] && continue
             corpus_dir="/tmp/fuzz_corpus/${target}"
+            artifact_prefix="${ARTIFACT_DIR}/${target}-"
 
             if [ ! -d "$corpus_dir" ] || [ -z "$(ls -A "$corpus_dir" 2>/dev/null)" ]; then
               # No corpus for this target — run with empty input for 10s
@@ -128,6 +148,7 @@ jobs:
                   -rss_limit_mb=4000 \
                   -max_total_time=10 \
                   -reload=0 \
+                  -artifact_prefix="$artifact_prefix" \
                   "$corpus_dir" 2>&1; then
                 echo "PASS: $target (empty corpus)"
                 PASSED=$((PASSED + 1))
@@ -146,6 +167,7 @@ jobs:
             if FUZZ="$target" timeout 3600 "$FUZZ_BIN" \
                 -rss_limit_mb=4000 \
                 -runs=0 \
+                -artifact_prefix="$artifact_prefix" \
                 "$corpus_dir" 2>&1; then
               echo "PASS: $target"
               PASSED=$((PASSED + 1))
@@ -171,3 +193,12 @@ jobs:
             exit 1
           fi
         shell: bash
+
+      - name: Upload crash artifacts
+        if: failure() && steps.fuzz-test.conclusion == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashes-${{ inputs.build-target }}
+          path: /tmp/fuzz_artifacts
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -54,8 +54,8 @@ jobs:
 
           # Layer 1: bitcoin-core inherited corpus
           if git clone --depth=1 https://github.com/bitcoin-core/qa-assets /tmp/qa-assets; then
-            if [ -d "/tmp/qa-assets/fuzz_corpora" ]; then
-              cp -r /tmp/qa-assets/fuzz_corpora/. /tmp/fuzz_corpus/
+            if [ -d "/tmp/qa-assets/fuzz_seed_corpus" ]; then
+              cp -r /tmp/qa-assets/fuzz_seed_corpus/. /tmp/fuzz_corpus/
               echo "Loaded bitcoin-core corpus"
             fi
           else

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -107,8 +107,7 @@ jobs:
           # Layer 3: Generate synthetic seeds for Dash-specific targets (additive only —
           # gated on external corpus being present so we never pass on synthetic-only runs).
           if [ -f "contrib/fuzz/seed_corpus_from_chain.py" ]; then
-            python3 contrib/fuzz/seed_corpus_from_chain.py --synthetic-only -o /tmp/fuzz_corpus || \
-              echo "::warning::Synthetic seed generation failed; continuing with external corpus only"
+            python3 contrib/fuzz/seed_corpus_from_chain.py --synthetic-only -o /tmp/fuzz_corpus
           fi
         shell: bash
 
@@ -152,12 +151,57 @@ jobs:
           ARTIFACT_DIR=/tmp/fuzz_artifacts
           mkdir -p "$ARTIFACT_DIR"
 
+          # Allowlist of Dash-specific fuzz targets (names beginning with "dash_") that are
+          # permitted to run as smoke-only when no corpus is present. Keep this list small
+          # and documented: every entry is a target we have explicitly decided cannot have
+          # a meaningful corpus yet (e.g. trivially-stateless harnesses). Adding a Dash
+          # target here MUST be justified in review — the default for new dash_* targets
+          # is to fail when the corpus is missing so they do not silently degrade to a
+          # 10-second smoke run that produces no signal.
+          DASH_SMOKE_ONLY_ALLOWLIST=""
+
+          is_dash_smoke_allowed() {
+            local t="$1"
+            for allowed in $DASH_SMOKE_ONLY_ALLOWLIST; do
+              [ "$t" = "$allowed" ] && return 0
+            done
+            return 1
+          }
+
           while IFS= read -r target; do
             [ -z "$target" ] && continue
             corpus_dir="/tmp/fuzz_corpus/${target}"
             artifact_prefix="${ARTIFACT_DIR}/${target}-"
 
+            # Classify a non-zero exit code from `timeout`/libFuzzer. timeout(1) reports
+            # 124 when the time budget elapsed, and 128+SIGNAL when the child was killed
+            # (137 = SIGKILL, 143 = SIGTERM). Treat those as "timeout/kill" and any other
+            # non-zero status as a generic crash. Both still fail the job.
+            classify_exit() {
+              case "$1" in
+                124|137|143) echo "timeout" ;;
+                *) echo "crash" ;;
+              esac
+            }
+
             if [ ! -d "$corpus_dir" ] || [ -z "$(ls -A "$corpus_dir" 2>/dev/null)" ]; then
+              # Dash-specific targets (names beginning "dash_") MUST have corpus inputs from
+              # either the pinned dashpay/qa-assets layer or the synthetic seeder. Falling
+              # back to a 10-second empty-corpus smoke run produces no real signal and was
+              # masking missing-corpus regressions for newly added Dash harnesses. Inherited
+              # upstream/non-Dash targets are still allowed the smoke fallback so we do not
+              # regress on bitcoin-core targets that legitimately ship without a corpus.
+              case "$target" in
+                dash_*)
+                  if ! is_dash_smoke_allowed "$target"; then
+                    echo "::error::FAIL: $target has no corpus inputs in /tmp/fuzz_corpus/${target} — Dash-specific targets must ship with corpus data (qa-assets or synthetic seeder); refusing to silently smoke-test"
+                    FAILED=$((FAILED + 1))
+                    FAILED_TARGETS="${FAILED_TARGETS}  - ${target} (missing-corpus)\n"
+                    continue
+                  fi
+                  echo "::warning::${target} is on the documented Dash smoke-only allowlist — running 10s empty-corpus check"
+                  ;;
+              esac
               # No corpus for this target — run with empty input for 10s
               # This catches basic initialization crashes
               echo "::group::${target} (empty corpus, 10s run)"
@@ -174,9 +218,10 @@ jobs:
                 PASSED=$((PASSED + 1))
               else
                 EXIT_CODE=$?
-                echo "::error::FAIL: $target exited with code $EXIT_CODE"
+                KIND=$(classify_exit "$EXIT_CODE")
+                echo "::error::FAIL: $target exited with code $EXIT_CODE (${KIND})"
                 FAILED=$((FAILED + 1))
-                FAILED_TARGETS="${FAILED_TARGETS}  - ${target} (exit code ${EXIT_CODE})\n"
+                FAILED_TARGETS="${FAILED_TARGETS}  - ${target} (${KIND}, exit code ${EXIT_CODE})\n"
               fi
               echo "::endgroup::"
               continue
@@ -192,9 +237,11 @@ jobs:
               echo "PASS: $target"
               PASSED=$((PASSED + 1))
             else
-              echo "::error::FAIL: $target"
+              EXIT_CODE=$?
+              KIND=$(classify_exit "$EXIT_CODE")
+              echo "::error::FAIL: $target exited with code $EXIT_CODE (${KIND})"
               FAILED=$((FAILED + 1))
-              FAILED_TARGETS="${FAILED_TARGETS}  - ${target}\n"
+              FAILED_TARGETS="${FAILED_TARGETS}  - ${target} (${KIND}, exit code ${EXIT_CODE})\n"
             fi
             echo "::endgroup::"
           done <<< "$TARGETS"

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -1,0 +1,173 @@
+name: Fuzz regression
+
+on:
+  workflow_call:
+    inputs:
+      bundle-key:
+        description: "Key needed to access bundle of fuzz build artifacts"
+        required: true
+        type: string
+      build-target:
+        description: "Target name as defined by inputs.sh"
+        required: true
+        type: string
+      container-path:
+        description: "Path to built container at registry"
+        required: true
+        type: string
+      runs-on:
+        description: "Runner label to use"
+        required: false
+        default: ubuntu-24.04
+        type: string
+
+jobs:
+  fuzz-regression:
+    name: Fuzz regression
+    runs-on: ${{ inputs.runs-on }}
+    container:
+      image: ${{ inputs.container-path }}
+      options: --user root
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.bundle-key }}
+
+      - name: Extract build artifacts
+        run: |
+          git config --global --add safe.directory "$PWD"
+          export BUILD_TARGET="${{ inputs.build-target }}"
+          export BUNDLE_KEY="${{ inputs.bundle-key }}"
+          ./ci/dash/bundle-artifacts.sh extract
+        shell: bash
+
+      - name: Download corpus
+        run: |
+          mkdir -p /tmp/fuzz_corpus
+
+          # Layer 1: bitcoin-core inherited corpus
+          if git clone --depth=1 https://github.com/bitcoin-core/qa-assets /tmp/qa-assets; then
+            if [ -d "/tmp/qa-assets/fuzz_corpora" ]; then
+              cp -r /tmp/qa-assets/fuzz_corpora/. /tmp/fuzz_corpus/
+              echo "Loaded bitcoin-core corpus"
+            fi
+          else
+            echo "WARNING: Failed to clone bitcoin-core/qa-assets (non-fatal)"
+          fi
+
+          # Layer 2: Dash-specific corpus (overlays on top)
+          if git clone --depth=1 https://github.com/dashpay/qa-assets /tmp/dash-qa-assets; then
+            if [ -d "/tmp/dash-qa-assets/fuzz/corpora" ]; then
+              cp -r /tmp/dash-qa-assets/fuzz/corpora/. /tmp/fuzz_corpus/
+              echo "Loaded Dash-specific corpus"
+            fi
+          else
+            echo "WARNING: Failed to clone dashpay/qa-assets (non-fatal)"
+          fi
+
+          # Layer 3: Generate synthetic seeds for Dash-specific targets
+          if [ -f "contrib/fuzz/seed_corpus_from_chain.py" ]; then
+            python3 contrib/fuzz/seed_corpus_from_chain.py --synthetic-only -o /tmp/fuzz_corpus
+          fi
+        shell: bash
+
+      - name: Run fuzz regression tests
+        id: fuzz-test
+        run: |
+          export BUILD_TARGET="${{ inputs.build-target }}"
+          source ./ci/dash/matrix.sh
+
+          BUILD_DIR="build-ci/dashcore-${BUILD_TARGET}"
+          FUZZ_BIN="${BUILD_DIR}/src/test/fuzz/fuzz"
+
+          if [ ! -x "$FUZZ_BIN" ]; then
+            echo "ERROR: Fuzz binary not found at $FUZZ_BIN"
+            exit 1
+          fi
+
+          # detect_leaks=0 is intentional for fuzz regression due to libFuzzer/LSan noise.
+          export ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=0"
+          export LSAN_OPTIONS="suppressions=${BUILD_DIR}/test/sanitizer_suppressions/lsan"
+          export UBSAN_OPTIONS="suppressions=${BUILD_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"
+
+          # Get list of all targets
+          TARGETS=$(PRINT_ALL_FUZZ_TARGETS_AND_ABORT=1 "$FUZZ_BIN" 2>/tmp/fuzz_target_discovery.err || true)
+          TARGET_COUNT=$(echo "$TARGETS" | grep -c '[^[:space:]]' || true)
+          if [ "$TARGET_COUNT" -eq 0 ]; then
+            if [ -s /tmp/fuzz_target_discovery.err ]; then
+              cat /tmp/fuzz_target_discovery.err
+            fi
+            echo "::error::No fuzz targets found — binary may have failed to start"
+            exit 1
+          fi
+          echo "Found $TARGET_COUNT fuzz targets"
+
+          FAILED=0
+          PASSED=0
+          FAILED_TARGETS=""
+
+          while IFS= read -r target; do
+            [ -z "$target" ] && continue
+            corpus_dir="/tmp/fuzz_corpus/${target}"
+
+            if [ ! -d "$corpus_dir" ] || [ -z "$(ls -A "$corpus_dir" 2>/dev/null)" ]; then
+              # No corpus for this target — run with empty input for 10s
+              # This catches basic initialization crashes
+              echo "::group::${target} (empty corpus, 10s run)"
+              mkdir -p "$corpus_dir"
+              # timeout(30) intentionally exceeds -max_total_time=10 to absorb startup/teardown jitter
+              # while still terminating genuinely hung processes.
+              if FUZZ="$target" timeout 30 "$FUZZ_BIN" \
+                  -rss_limit_mb=4000 \
+                  -max_total_time=10 \
+                  -reload=0 \
+                  "$corpus_dir" 2>&1; then
+                echo "PASS: $target (empty corpus)"
+                PASSED=$((PASSED + 1))
+              else
+                EXIT_CODE=$?
+                echo "::error::FAIL: $target exited with code $EXIT_CODE"
+                FAILED=$((FAILED + 1))
+                FAILED_TARGETS="${FAILED_TARGETS}  - ${target} (exit code ${EXIT_CODE})\n"
+              fi
+              echo "::endgroup::"
+              continue
+            fi
+
+            # Run corpus regression (replay all inputs)
+            echo "::group::${target} ($(find "$corpus_dir" -maxdepth 1 -type f | wc -l) inputs)"
+            if FUZZ="$target" timeout 3600 "$FUZZ_BIN" \
+                -rss_limit_mb=4000 \
+                -runs=0 \
+                "$corpus_dir" 2>&1; then
+              echo "PASS: $target"
+              PASSED=$((PASSED + 1))
+            else
+              echo "::error::FAIL: $target"
+              FAILED=$((FAILED + 1))
+              FAILED_TARGETS="${FAILED_TARGETS}  - ${target}\n"
+            fi
+            echo "::endgroup::"
+          done <<< "$TARGETS"
+
+          echo ""
+          echo "=== Fuzz Regression Summary ==="
+          echo "Passed: $PASSED"
+          echo "Failed: $FAILED"
+          echo "Total: $TARGET_COUNT"
+
+          if [ $FAILED -gt 0 ]; then
+            echo ""
+            echo "=== Failed Targets ==="
+            printf '%b' "$FAILED_TARGETS"
+            echo "::error::$FAILED fuzz target(s) failed regression testing"
+            exit 1
+          fi
+        shell: bash

--- a/contrib/fuzz/README.md
+++ b/contrib/fuzz/README.md
@@ -1,0 +1,103 @@
+# Dash Core Fuzz Testing Tools
+
+This directory contains tools for continuous fuzz testing of Dash Core.
+
+## Overview
+
+Dash Core inherits ~100 fuzz targets from Bitcoin Core and adds Dash-specific
+targets for:
+- Special transaction serialization (ProTx, CoinJoin, Asset Lock/Unlock, etc.)
+- BLS operations and IES encryption
+- LLMQ/DKG message handling
+- Governance object validation
+- Masternode list management
+
+Some Dash-specific fuzz targets are planned/in-progress. Corpus tooling
+pre-generates synthetic seeds for those target names so coverage is ready when
+the targets are added.
+
+## Tools
+
+### `continuous_fuzz_daemon.sh`
+
+A daemon script that continuously cycles through all fuzz targets with persistent
+corpus storage and crash detection.
+
+```bash
+# Run all targets, 10 minutes each, indefinitely
+./continuous_fuzz_daemon.sh --fuzz-bin /path/to/fuzz --time-per-target 600
+
+# Run specific targets only
+./continuous_fuzz_daemon.sh --targets bls_operations,bls_ies --time-per-target 3600
+
+# Single cycle (good for cron)
+./continuous_fuzz_daemon.sh --single-cycle --time-per-target 300
+
+# Dry run — list targets
+./continuous_fuzz_daemon.sh --dry-run
+```
+
+**Output directories:**
+- `~/fuzz_corpus/<target>/` — persistent corpus per target
+- `~/fuzz_crashes/<target>/` — crash artifacts (crash-*, timeout-*, oom-*)
+- `~/fuzz_logs/` — per-target logs and daemon log
+
+### `seed_corpus_from_chain.py`
+
+Extracts real-world data from a running Dash node into fuzzer-consumable corpus
+files. Connects via `dash-cli` RPC.
+
+```bash
+# Extract from a running node
+./seed_corpus_from_chain.py -o /path/to/corpus --blocks 500
+
+# Generate only synthetic seeds (no running node required)
+./seed_corpus_from_chain.py -o /path/to/corpus --synthetic-only
+```
+
+**What it extracts:**
+- Serialized blocks and block headers
+- Special transactions (ProRegTx, ProUpServTx, CoinJoin, Asset Lock, etc.)
+- Governance objects and votes
+- Masternode list entries
+- Quorum commitment data
+
+## CI Integration
+
+The `test-fuzz.yml` workflow runs fuzz regression tests on every PR:
+
+1. Builds fuzz targets with sanitizers (ASan + UBSan + libFuzzer)
+2. Downloads seed corpus from `bitcoin-core/qa-assets` + synthetic Dash seeds
+3. Replays all corpus inputs against every fuzz target
+4. Reports failures as CI errors
+
+This catches regressions in seconds — any code change that causes a previously-
+working input to crash will be caught.
+
+## Building Fuzz Targets
+
+```bash
+# Configure with fuzzing + sanitizers
+./configure --enable-fuzz --with-sanitizers=fuzzer,address,undefined \
+    CC='clang -ftrivial-auto-var-init=pattern' \
+    CXX='clang++ -ftrivial-auto-var-init=pattern'
+
+# Build
+make -j$(nproc)
+
+# The fuzz binary is at src/test/fuzz/fuzz
+# Select target with FUZZ=<target_name>
+FUZZ=bls_operations ./src/test/fuzz/fuzz corpus_dir/
+```
+
+## Contributing Corpus Inputs
+
+Found an interesting input? Add it to the appropriate corpus directory:
+
+```bash
+# The filename should be the sha256 of the content (for dedup)
+sha256sum input_file
+cp input_file fuzz_corpus/<target_name>/<sha256_prefix>
+```
+
+Crash-reproducing inputs are especially valuable — they become regression tests.

--- a/contrib/fuzz/continuous_fuzz_daemon.sh
+++ b/contrib/fuzz/continuous_fuzz_daemon.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Continuous fuzzing daemon — cycles through all fuzz targets with
+# persistent corpus storage, crash detection, and logging.
+#
+# Usage:
+#   ./continuous_fuzz_daemon.sh [options]
+#
+# Options:
+#   --fuzz-bin <path>       Path to the fuzz binary (default: auto-detect)
+#   --corpus-dir <path>     Base directory for corpus storage (default: ~/fuzz_corpus)
+#   --crashes-dir <path>    Directory for crash artifacts (default: ~/fuzz_crashes)
+#   --log-dir <path>        Directory for log files (default: ~/fuzz_logs)
+#   --time-per-target <s>   Seconds to fuzz each target per cycle (default: 600)
+#   --rss-limit <mb>        RSS memory limit in MB (default: 4000)
+#   --targets <list>        Comma-separated list of targets to fuzz (default: all)
+#   --exclude <list>        Comma-separated list of targets to exclude
+#   --single-cycle          Run one cycle and exit (for cron usage)
+#   --dry-run               List targets and exit without fuzzing
+
+export LC_ALL=C
+set -euo pipefail
+
+# --- Configuration defaults ---
+FUZZ_BIN=""
+TIMEOUT_BIN=""
+CORPUS_DIR="${HOME}/fuzz_corpus"
+CRASHES_DIR="${HOME}/fuzz_crashes"
+LOG_DIR="${HOME}/fuzz_logs"
+TIME_PER_TARGET=600
+RSS_LIMIT_MB=4000
+TARGET_LIST=""
+EXCLUDE_LIST=""
+SINGLE_CYCLE=false
+DRY_RUN=false
+
+shuffle_lines() {
+    if command -v shuf >/dev/null 2>&1; then
+        shuf
+    else
+        awk 'BEGIN{srand()} {print rand() "\t" $0}' | sort -k1,1n | cut -f2-
+    fi
+}
+
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fuzz-bin)      [[ $# -ge 2 ]] || { echo "ERROR: --fuzz-bin requires a value" >&2; exit 1; }; FUZZ_BIN="$2"; shift 2;;
+        --corpus-dir)    [[ $# -ge 2 ]] || { echo "ERROR: --corpus-dir requires a value" >&2; exit 1; }; CORPUS_DIR="$2"; shift 2;;
+        --crashes-dir)   [[ $# -ge 2 ]] || { echo "ERROR: --crashes-dir requires a value" >&2; exit 1; }; CRASHES_DIR="$2"; shift 2;;
+        --log-dir)       [[ $# -ge 2 ]] || { echo "ERROR: --log-dir requires a value" >&2; exit 1; }; LOG_DIR="$2"; shift 2;;
+        --time-per-target) [[ $# -ge 2 ]] || { echo "ERROR: --time-per-target requires a value" >&2; exit 1; }; TIME_PER_TARGET="$2"; shift 2;;
+        --rss-limit)     [[ $# -ge 2 ]] || { echo "ERROR: --rss-limit requires a value" >&2; exit 1; }; RSS_LIMIT_MB="$2"; shift 2;;
+        --targets)       [[ $# -ge 2 ]] || { echo "ERROR: --targets requires a value" >&2; exit 1; }; TARGET_LIST="$2"; shift 2;;
+        --exclude)       [[ $# -ge 2 ]] || { echo "ERROR: --exclude requires a value" >&2; exit 1; }; EXCLUDE_LIST="$2"; shift 2;;
+        --single-cycle)  SINGLE_CYCLE=true; shift;;
+        --dry-run)       DRY_RUN=true; shift;;
+        -h|--help)
+            sed -n '2,/^$/s/^# \?//p' "$0"
+            exit 0
+            ;;
+        *) echo "Unknown option: $1" >&2; exit 1;;
+    esac
+done
+
+# --- Validate numeric arguments ---
+if ! [[ "$TIME_PER_TARGET" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: --time-per-target must be a positive integer, got '$TIME_PER_TARGET'" >&2
+    exit 1
+fi
+if ! [[ "$RSS_LIMIT_MB" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: --rss-limit must be a positive integer, got '$RSS_LIMIT_MB'" >&2
+    exit 1
+fi
+
+# --- Auto-detect fuzz binary ---
+if [[ -z "$FUZZ_BIN" ]]; then
+    for candidate in \
+        "${HOME}/dash/src/test/fuzz/fuzz" \
+        "${HOME}/dash/build_fuzz/src/test/fuzz/fuzz" \
+        "$(command -v fuzz 2>/dev/null || true)"; do
+        if [[ -x "$candidate" ]]; then
+            FUZZ_BIN="$candidate"
+            break
+        fi
+    done
+    if [[ -z "$FUZZ_BIN" ]]; then
+        echo "ERROR: Could not find fuzz binary. Use --fuzz-bin to specify." >&2
+        exit 1
+    fi
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    TIMEOUT_BIN="gtimeout"
+else
+    echo "WARNING: timeout command not found; external hang protection disabled" >&2
+fi
+
+# --- Setup directories ---
+mkdir -p "$CORPUS_DIR" "$CRASHES_DIR" "$LOG_DIR"
+
+# --- Discover targets ---
+get_all_targets() {
+    PRINT_ALL_FUZZ_TARGETS_AND_ABORT=1 "$FUZZ_BIN" 2>/dev/null || true
+}
+
+filter_targets() {
+    local all_targets="$1"
+    local result=()
+
+    if [[ -n "$TARGET_LIST" ]]; then
+        # Use only specified targets
+        IFS=',' read -ra wanted <<< "$TARGET_LIST"
+        for t in "${wanted[@]}"; do
+            if echo "$all_targets" | grep -qx "$t"; then
+                result+=("$t")
+            else
+                echo "WARNING: Target '$t' not found in fuzz binary" >&2
+            fi
+        done
+    else
+        # Use all targets
+        while IFS= read -r t; do
+            [[ -n "$t" ]] && result+=("$t")
+        done <<< "$all_targets"
+    fi
+
+    # Apply exclusions
+    if [[ -n "$EXCLUDE_LIST" ]]; then
+        IFS=',' read -ra excluded <<< "$EXCLUDE_LIST"
+        local filtered=()
+        for t in "${result[@]}"; do
+            local skip=false
+            for ex in "${excluded[@]}"; do
+                [[ "$t" == "$ex" ]] && skip=true && break
+            done
+            $skip || filtered+=("$t")
+        done
+        result=("${filtered[@]}")
+    fi
+
+    printf '%s\n' "${result[@]}"
+}
+
+# --- Logging ---
+log() {
+    local level="$1"; shift
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$level] $*" | tee -a "${LOG_DIR}/daemon.log"
+}
+
+trap 'log "INFO" "Caught signal — shutting down"; exit 0' SIGTERM SIGINT
+
+# --- Run one fuzz target ---
+run_target() {
+    local target="$1"
+    local target_corpus="${CORPUS_DIR}/${target}"
+    local target_crashes="${CRASHES_DIR}/${target}"
+    local target_log="${LOG_DIR}/${target}.log"
+
+    mkdir -p "$target_corpus" "$target_crashes"
+
+    log "INFO" "Fuzzing target: ${target} for ${TIME_PER_TARGET}s"
+
+    local exit_code=0
+    if [[ -n "$TIMEOUT_BIN" ]]; then
+        FUZZ="$target" \
+        ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=0" \
+        UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" \
+        "$TIMEOUT_BIN" $((TIME_PER_TARGET + 30)) "$FUZZ_BIN" \
+            -rss_limit_mb="$RSS_LIMIT_MB" \
+            -max_total_time="$TIME_PER_TARGET" \
+            -reload=0 \
+            -print_final_stats=1 \
+            -artifact_prefix="${target_crashes}/" \
+            "$target_corpus" \
+            > "$target_log" 2>&1 || exit_code=$?
+    else
+        FUZZ="$target" \
+        ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=0" \
+        UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" \
+        "$FUZZ_BIN" \
+            -rss_limit_mb="$RSS_LIMIT_MB" \
+            -max_total_time="$TIME_PER_TARGET" \
+            -reload=0 \
+            -print_final_stats=1 \
+            -artifact_prefix="${target_crashes}/" \
+            "$target_corpus" \
+            > "$target_log" 2>&1 || exit_code=$?
+    fi
+
+    # Check for crashes
+    local crash_count
+    crash_count=$(find "$target_crashes" -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' 2>/dev/null | wc -l)
+
+    if [[ "$crash_count" -gt 0 ]]; then
+        log "CRASH" "Target '${target}' produced ${crash_count} crash artifact(s)!"
+        log "CRASH" "Artifacts saved to: ${target_crashes}/"
+
+        # Extract crash details from log
+        grep -E "SUMMARY|ERROR|BINGO|crash-|timeout-|oom-" "$target_log" 2>/dev/null | while IFS= read -r line; do
+            log "CRASH" "  $line"
+        done
+    fi
+
+    # Log stats
+    local corpus_size
+    corpus_size=$(find "$target_corpus" -type f | wc -l)
+    local corpus_bytes
+    corpus_bytes=$(du -sh "$target_corpus" 2>/dev/null | cut -f1)
+
+    if [[ $exit_code -eq 0 ]]; then
+        log "INFO" "Target '${target}' completed: corpus=${corpus_size} files (${corpus_bytes}), exit=${exit_code}"
+    else
+        log "WARN" "Target '${target}' exited with code ${exit_code}: corpus=${corpus_size} files (${corpus_bytes})"
+    fi
+
+    return 0  # Don't fail the daemon on individual target failures
+}
+
+# --- Main loop ---
+main() {
+    log "INFO" "=== Continuous Fuzzing Daemon Starting ==="
+    log "INFO" "Fuzz binary: ${FUZZ_BIN}"
+    log "INFO" "Corpus dir: ${CORPUS_DIR}"
+    log "INFO" "Crashes dir: ${CRASHES_DIR}"
+    log "INFO" "Time per target: ${TIME_PER_TARGET}s"
+    log "INFO" "RSS limit: ${RSS_LIMIT_MB}MB"
+
+    local all_targets
+    all_targets=$(get_all_targets)
+    local targets
+    targets=$(filter_targets "$all_targets")
+    if [[ -z "$targets" ]]; then
+        log "ERROR" "No matching fuzz targets found"
+        exit 1
+    fi
+    local target_count
+    target_count=$(echo "$targets" | wc -l)
+
+    log "INFO" "Found ${target_count} fuzz target(s)"
+
+    if $DRY_RUN; then
+        log "INFO" "DRY RUN — targets that would be fuzzed:"
+        echo "$targets"
+        exit 0
+    fi
+
+    local cycle=0
+    while true; do
+        cycle=$((cycle + 1))
+        log "INFO" "=== Starting cycle ${cycle} (${target_count} targets × ${TIME_PER_TARGET}s) ==="
+
+        # Snapshot crash count before this cycle
+        local crashes_before
+        crashes_before=$(find "$CRASHES_DIR" -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' 2>/dev/null | wc -l)
+
+        # Shuffle targets each cycle for variety
+        local shuffled
+        shuffled=$(echo "$targets" | shuffle_lines)
+
+        while IFS= read -r target; do
+            [[ -z "$target" ]] && continue
+            run_target "$target"
+        done <<< "$shuffled"
+
+        # Cycle summary
+        local total_corpus
+        total_corpus=$(du -sh "$CORPUS_DIR" 2>/dev/null | cut -f1)
+        local total_crashes
+        total_crashes=$(find "$CRASHES_DIR" -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' 2>/dev/null | wc -l)
+        local new_crashes=$((total_crashes - crashes_before))
+        log "INFO" "=== Cycle ${cycle} complete: total corpus=${total_corpus}, new crashes=${new_crashes}, total crashes=${total_crashes} ==="
+
+        if $SINGLE_CYCLE; then
+            if [[ "$new_crashes" -gt 0 ]]; then
+                log "WARN" "Single-cycle mode — exiting with ${new_crashes} new crash(es) found"
+                exit 1
+            fi
+            log "INFO" "Single-cycle mode — exiting"
+            break
+        fi
+
+        # Brief pause between cycles
+        log "INFO" "Sleeping 60s before next cycle..."
+        sleep 60
+    done
+}
+
+main

--- a/contrib/fuzz/continuous_fuzz_daemon.sh
+++ b/contrib/fuzz/continuous_fuzz_daemon.sh
@@ -85,7 +85,7 @@ if ! [[ "$TIME_PER_TARGET" =~ ^[0-9]+$ ]] || (( TIME_PER_TARGET < 1 )); then
     echo "ERROR: --time-per-target must be a positive integer, got '$TIME_PER_TARGET'" >&2
     exit 1
 fi
-if ! [[ "$RSS_LIMIT_MB" =~ ^[0-9]+$ ]]; then
+if ! [[ "$RSS_LIMIT_MB" =~ ^[0-9]+$ ]] || (( RSS_LIMIT_MB < 1 )); then
     echo "ERROR: --rss-limit must be a positive integer, got '$RSS_LIMIT_MB'" >&2
     exit 1
 fi

--- a/contrib/fuzz/continuous_fuzz_daemon.sh
+++ b/contrib/fuzz/continuous_fuzz_daemon.sh
@@ -24,6 +24,10 @@
 export LC_ALL=C
 set -euo pipefail
 
+# Resolve repo root from the script location so defaults work from any cwd.
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+
 # --- Configuration defaults ---
 FUZZ_BIN=""
 TIMEOUT_BIN=""
@@ -36,7 +40,11 @@ TARGET_LIST=""
 EXCLUDE_LIST=""
 SINGLE_CYCLE=false
 DRY_RUN=false
-DAEMON_ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=0"
+# Keep leak detection enabled so the daemon surfaces leak findings the same way
+# .github/workflows/test-fuzz.yml does; noisy dependency leaks are filtered via the
+# LSAN suppressions file rather than globally disabled.
+DAEMON_ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
+DAEMON_LSAN_OPTIONS="suppressions=${REPO_ROOT}/test/sanitizer_suppressions/lsan"
 
 shuffle_lines() {
     if command -v shuf >/dev/null 2>&1; then
@@ -48,7 +56,7 @@ shuffle_lines() {
 
 count_crash_artifacts() {
     local crash_dir="$1"
-    find "$crash_dir" -type f \( -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' \) 2>/dev/null | wc -l | tr -d '[:space:]'
+    find "$crash_dir" -type f \( -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' -o -name 'leak-*' \) 2>/dev/null | wc -l | tr -d '[:space:]'
 }
 
 # --- Parse arguments ---
@@ -73,7 +81,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # --- Validate numeric arguments ---
-if ! [[ "$TIME_PER_TARGET" =~ ^[0-9]+$ ]]; then
+if ! [[ "$TIME_PER_TARGET" =~ ^[0-9]+$ ]] || (( TIME_PER_TARGET < 1 )); then
     echo "ERROR: --time-per-target must be a positive integer, got '$TIME_PER_TARGET'" >&2
     exit 1
 fi
@@ -179,6 +187,7 @@ run_target() {
     if [[ -n "$TIMEOUT_BIN" ]]; then
         FUZZ="$target" \
         ASAN_OPTIONS="${ASAN_OPTIONS:+${ASAN_OPTIONS}:}${DAEMON_ASAN_OPTIONS}" \
+        LSAN_OPTIONS="${LSAN_OPTIONS:+${LSAN_OPTIONS}:}${DAEMON_LSAN_OPTIONS}" \
         UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" \
         "$TIMEOUT_BIN" $((TIME_PER_TARGET + 30)) "$FUZZ_BIN" \
             -rss_limit_mb="$RSS_LIMIT_MB" \
@@ -191,6 +200,7 @@ run_target() {
     else
         FUZZ="$target" \
         ASAN_OPTIONS="${ASAN_OPTIONS:+${ASAN_OPTIONS}:}${DAEMON_ASAN_OPTIONS}" \
+        LSAN_OPTIONS="${LSAN_OPTIONS:+${LSAN_OPTIONS}:}${DAEMON_LSAN_OPTIONS}" \
         UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" \
         "$FUZZ_BIN" \
             -rss_limit_mb="$RSS_LIMIT_MB" \
@@ -213,7 +223,7 @@ run_target() {
         # Extract crash details from log
         while IFS= read -r line; do
             log "CRASH" "  $line"
-        done < <(grep -E "SUMMARY|ERROR|BINGO|crash-|timeout-|oom-" "$target_log" 2>/dev/null || true)
+        done < <(grep -E "SUMMARY|ERROR|BINGO|LeakSanitizer|crash-|timeout-|oom-|leak-" "$target_log" 2>/dev/null || true)
     fi
 
     # Log stats

--- a/contrib/fuzz/continuous_fuzz_daemon.sh
+++ b/contrib/fuzz/continuous_fuzz_daemon.sh
@@ -36,6 +36,7 @@ TARGET_LIST=""
 EXCLUDE_LIST=""
 SINGLE_CYCLE=false
 DRY_RUN=false
+DAEMON_ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=0"
 
 shuffle_lines() {
     if command -v shuf >/dev/null 2>&1; then
@@ -169,7 +170,7 @@ run_target() {
     local exit_code=0
     if [[ -n "$TIMEOUT_BIN" ]]; then
         FUZZ="$target" \
-        ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=0" \
+        ASAN_OPTIONS="${ASAN_OPTIONS:+${ASAN_OPTIONS}:}${DAEMON_ASAN_OPTIONS}" \
         UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" \
         "$TIMEOUT_BIN" $((TIME_PER_TARGET + 30)) "$FUZZ_BIN" \
             -rss_limit_mb="$RSS_LIMIT_MB" \
@@ -181,7 +182,7 @@ run_target() {
             > "$target_log" 2>&1 || exit_code=$?
     else
         FUZZ="$target" \
-        ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1:detect_leaks=0" \
+        ASAN_OPTIONS="${ASAN_OPTIONS:+${ASAN_OPTIONS}:}${DAEMON_ASAN_OPTIONS}" \
         UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1:report_error_type=1" \
         "$FUZZ_BIN" \
             -rss_limit_mb="$RSS_LIMIT_MB" \
@@ -202,9 +203,9 @@ run_target() {
         log "CRASH" "Artifacts saved to: ${target_crashes}/"
 
         # Extract crash details from log
-        grep -E "SUMMARY|ERROR|BINGO|crash-|timeout-|oom-" "$target_log" 2>/dev/null | while IFS= read -r line; do
+        while IFS= read -r line; do
             log "CRASH" "  $line"
-        done
+        done < <(grep -E "SUMMARY|ERROR|BINGO|crash-|timeout-|oom-" "$target_log" 2>/dev/null || true)
     fi
 
     # Log stats

--- a/contrib/fuzz/continuous_fuzz_daemon.sh
+++ b/contrib/fuzz/continuous_fuzz_daemon.sh
@@ -46,6 +46,11 @@ shuffle_lines() {
     fi
 }
 
+count_crash_artifacts() {
+    local crash_dir="$1"
+    find "$crash_dir" -type f \( -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' \) 2>/dev/null | wc -l | tr -d '[:space:]'
+}
+
 # --- Parse arguments ---
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -167,6 +172,9 @@ run_target() {
 
     log "INFO" "Fuzzing target: ${target} for ${TIME_PER_TARGET}s"
 
+    local artifacts_before
+    artifacts_before=$(count_crash_artifacts "$target_crashes")
+
     local exit_code=0
     if [[ -n "$TIMEOUT_BIN" ]]; then
         FUZZ="$target" \
@@ -194,12 +202,12 @@ run_target() {
             > "$target_log" 2>&1 || exit_code=$?
     fi
 
-    # Check for crashes
-    local crash_count
-    crash_count=$(find "$target_crashes" -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' 2>/dev/null | wc -l)
+    local artifacts_after
+    artifacts_after=$(count_crash_artifacts "$target_crashes")
+    local new_artifacts=$((artifacts_after - artifacts_before))
 
-    if [[ "$crash_count" -gt 0 ]]; then
-        log "CRASH" "Target '${target}' produced ${crash_count} crash artifact(s)!"
+    if [[ "$new_artifacts" -gt 0 ]]; then
+        log "CRASH" "Target '${target}' produced ${new_artifacts} new crash artifact(s)!"
         log "CRASH" "Artifacts saved to: ${target_crashes}/"
 
         # Extract crash details from log
@@ -220,7 +228,7 @@ run_target() {
         log "WARN" "Target '${target}' exited with code ${exit_code}: corpus=${corpus_size} files (${corpus_bytes})"
     fi
 
-    return 0  # Don't fail the daemon on individual target failures
+    [[ "$new_artifacts" -eq 0 && "$exit_code" -eq 0 ]]
 }
 
 # --- Main loop ---
@@ -258,7 +266,8 @@ main() {
 
         # Snapshot crash count before this cycle
         local crashes_before
-        crashes_before=$(find "$CRASHES_DIR" -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' 2>/dev/null | wc -l)
+        crashes_before=$(count_crash_artifacts "$CRASHES_DIR")
+        local cycle_failures=0
 
         # Shuffle targets each cycle for variety
         local shuffled
@@ -266,20 +275,22 @@ main() {
 
         while IFS= read -r target; do
             [[ -z "$target" ]] && continue
-            run_target "$target"
+            if ! run_target "$target"; then
+                cycle_failures=$((cycle_failures + 1))
+            fi
         done <<< "$shuffled"
 
         # Cycle summary
         local total_corpus
         total_corpus=$(du -sh "$CORPUS_DIR" 2>/dev/null | cut -f1)
         local total_crashes
-        total_crashes=$(find "$CRASHES_DIR" -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' 2>/dev/null | wc -l)
+        total_crashes=$(count_crash_artifacts "$CRASHES_DIR")
         local new_crashes=$((total_crashes - crashes_before))
-        log "INFO" "=== Cycle ${cycle} complete: total corpus=${total_corpus}, new crashes=${new_crashes}, total crashes=${total_crashes} ==="
+        log "INFO" "=== Cycle ${cycle} complete: total corpus=${total_corpus}, new crashes=${new_crashes}, total crashes=${total_crashes}, failed targets=${cycle_failures} ==="
 
         if $SINGLE_CYCLE; then
-            if [[ "$new_crashes" -gt 0 ]]; then
-                log "WARN" "Single-cycle mode — exiting with ${new_crashes} new crash(es) found"
+            if [[ "$cycle_failures" -gt 0 ]]; then
+                log "WARN" "Single-cycle mode — exiting with ${cycle_failures} failed target(s)"
                 exit 1
             fi
             log "INFO" "Single-cycle mode — exiting"

--- a/contrib/fuzz/seed_corpus_from_chain.py
+++ b/contrib/fuzz/seed_corpus_from_chain.py
@@ -38,24 +38,40 @@ def dash_cli(*args, datadir=None):
         return None
 
 
-# Must match src/version.h PROTOCOL_VERSION. The Dash-specific deserialize/
-# roundtrip fuzz harnesses (src/test/fuzz/deserialize_dash.cpp,
-# src/test/fuzz/roundtrip_dash.cpp) read a 4-byte little-endian int from the
-# start of the buffer and use it as the stream version before deserializing
-# the object. Chain data we extract is serialized at PROTOCOL_VERSION, so we
-# prepend that value to seeds for those targets.
-DASH_STREAM_VERSION = 70240
-DASH_STREAM_VERSION_PREFIX = DASH_STREAM_VERSION.to_bytes(4, byteorder="little", signed=False)
+# Must match src/version.h PROTOCOL_VERSION. Several fuzz harnesses read a
+# 4-byte little-endian int from the start of the buffer and use it as the
+# stream version before deserializing the object:
+#   * The Dash-specific helpers DashDeserializeFromFuzzingInput /
+#     DashRoundtripFromFuzzingInput (src/test/fuzz/deserialize_dash.cpp,
+#     src/test/fuzz/roundtrip_dash.cpp), used by dash_*_deserialize and
+#     dash_*_roundtrip targets.
+#   * The upstream block target (src/test/fuzz/block.cpp), which reads the
+#     version int inline before deserializing CBlock.
+#   * The upstream block_deserialize target (src/test/fuzz/deserialize.cpp),
+#     via DeserializeFromFuzzingInput when no explicit protocol_version is
+#     passed.
+# Chain data we extract is serialized at PROTOCOL_VERSION, so we prepend
+# that value to seeds for those targets.
+STREAM_VERSION = 70240
+STREAM_VERSION_PREFIX = STREAM_VERSION.to_bytes(4, byteorder="little", signed=False)
+
+# Non-Dash targets (outside the dash_* naming convention) whose harnesses
+# also consume the 4-byte stream version prefix described above.
+_NON_DASH_STREAM_VERSION_TARGETS = frozenset({"block", "block_deserialize"})
 
 
 def _needs_stream_version_prefix(target_name):
     """Return True if this target's harness consumes a 4-byte stream version prefix.
 
     Matches the DashDeserializeFromFuzzingInput / DashRoundtripFromFuzzingInput
-    helpers used by every dash_*_deserialize and dash_*_roundtrip target. Non-Dash
-    targets (block_deserialize, block, decode_tx, ...) don't use that helper and
-    must be left untouched.
+    helpers used by every dash_*_deserialize and dash_*_roundtrip target, plus
+    the upstream ``block`` and ``block_deserialize`` targets which do the same
+    (see src/test/fuzz/block.cpp and src/test/fuzz/deserialize.cpp). Other
+    non-Dash targets (decode_tx, ...) don't consume such a prefix and must be
+    left untouched.
     """
+    if target_name in _NON_DASH_STREAM_VERSION_TARGETS:
+        return True
     return target_name.startswith("dash_") and (
         target_name.endswith("_deserialize") or target_name.endswith("_roundtrip")
     )
@@ -73,7 +89,7 @@ def save_corpus_input(output_dir, target_name, data_hex):
         return False
 
     if _needs_stream_version_prefix(target_name):
-        raw_bytes = DASH_STREAM_VERSION_PREFIX + raw_bytes
+        raw_bytes = STREAM_VERSION_PREFIX + raw_bytes
 
     filename = hashlib.sha256(raw_bytes).hexdigest()[:16]
     filepath = target_dir / filename
@@ -315,7 +331,42 @@ def extract_masternode_list(output_dir, datadir=None):
             if not protx_hash:
                 continue
 
-            raw_tx = dash_cli("getrawtransaction", protx_hash, datadir=datadir)
+            state = mn.get("state")
+            if not isinstance(state, dict):
+                print(f"WARNING: Missing state for protx {protx_hash}, skipping", file=sys.stderr)
+                continue
+
+            registered_height = state.get("registeredHeight")
+            try:
+                registered_height = int(registered_height)
+            except (TypeError, ValueError):
+                print(
+                    f"WARNING: Invalid registeredHeight for protx {protx_hash}: {registered_height!r}",
+                    file=sys.stderr,
+                )
+                continue
+
+            block_hash = dash_cli("getblockhash", str(registered_height), datadir=datadir)
+            if not block_hash:
+                continue
+
+            block_json = dash_cli("getblock", block_hash, "1", datadir=datadir)
+            if not block_json:
+                continue
+
+            try:
+                block = json.loads(block_json)
+            except json.JSONDecodeError:
+                continue
+
+            if protx_hash not in block.get("tx", []):
+                print(
+                    f"WARNING: ProRegTx {protx_hash} not found in registeredHeight block {registered_height} ({block_hash}), skipping",
+                    file=sys.stderr,
+                )
+                continue
+
+            raw_tx = dash_cli("getrawtransaction", protx_hash, "false", block_hash, datadir=datadir)
             if not raw_tx:
                 continue
 
@@ -325,7 +376,7 @@ def extract_masternode_list(output_dir, datadir=None):
 
             # Extract the special payload for payload-specific targets
             # ProRegTx type is 1, get extraPayloadSize from verbose tx
-            verbose_tx = dash_cli("getrawtransaction", protx_hash, "true", datadir=datadir)
+            verbose_tx = dash_cli("getrawtransaction", protx_hash, "true", block_hash, datadir=datadir)
             if not verbose_tx:
                 continue
             try:

--- a/contrib/fuzz/seed_corpus_from_chain.py
+++ b/contrib/fuzz/seed_corpus_from_chain.py
@@ -79,6 +79,7 @@ _DESERIALIZE_ONLY_DASH_TARGETS = frozenset(
         "dash_vote_instance_deserialize",
         "dash_vote_rec_deserialize",
         "dash_governance_vote_file_deserialize",
+        "dash_mnhf_tx_deserialize",
     }
 )
 
@@ -1184,8 +1185,27 @@ def create_synthetic_seeds(output_dir):
         "dash_dkg_complaint_deserialize": [
             "64" + "00" * 32 + "00" * 32 + "0000" + "00",  # minimal
         ],
+        "dash_dkg_justification_deserialize": [
+            # llmqType (uint8) + quorumHash (32) + proTxHash (32) +
+            # CompactSize(0) for contributions vector + CBLSSignature (96)
+            ("64" + "00" * 32 + "00" * 32 + "00" + "00" * 96),
+        ],
         "dash_dkg_premature_commitment_deserialize": [
             minimal_premature_commitment.hex(),
+        ],
+        # Sig-share inventory / batched messages
+        "dash_sig_shares_inv_deserialize": [
+            # VARINT(sessionId=0) + CompactSize(invSize=0) + AUTOBITSET selector=0
+            "000000",
+        ],
+        "dash_batched_sig_shares_deserialize": [
+            # VARINT(sessionId=0) + CompactSize(0) for empty sigShares vector
+            "0000",
+        ],
+        # MN HF signal
+        "dash_mnhf_tx_deserialize": [
+            # versionBit (uint8) + quorumHash (32) + CBLSSignature non-legacy (96)
+            ("00" + "00" * 32 + "00" * 96),
         ],
         # Governance
         "dash_governance_vote_deserialize": [
@@ -1215,7 +1235,9 @@ def create_synthetic_seeds(output_dir):
                 saved += 1
             # Also save roundtrip variant
             roundtrip_target = target.replace("_deserialize", "_roundtrip")
-            if target not in _DESERIALIZE_ONLY_DASH_TARGETS and save_corpus_input(output_dir, roundtrip_target, seed_hex):
+            if target not in _DESERIALIZE_ONLY_DASH_TARGETS and save_corpus_input(
+                output_dir, roundtrip_target, seed_hex
+            ):
                 saved += 1
 
     print(f"  Created {saved} synthetic seed inputs")
@@ -1261,6 +1283,13 @@ def _run_helper_self_checks():
             "dash_bls_ies_multi_recipient_blobs_roundtrip",
             "dash_coinjoin_entry_deserialize",
             "dash_coinjoin_entry_roundtrip",
+            "dash_dkg_justification_deserialize",
+            "dash_dkg_justification_roundtrip",
+            "dash_sig_shares_inv_deserialize",
+            "dash_sig_shares_inv_roundtrip",
+            "dash_batched_sig_shares_deserialize",
+            "dash_batched_sig_shares_roundtrip",
+            "dash_mnhf_tx_deserialize",
         ]
         missing = [target for target in required_targets if not any((tmp_path / target).iterdir())]
         assert not missing, f"missing synthetic seeds for: {', '.join(missing)}"

--- a/contrib/fuzz/seed_corpus_from_chain.py
+++ b/contrib/fuzz/seed_corpus_from_chain.py
@@ -38,6 +38,29 @@ def dash_cli(*args, datadir=None):
         return None
 
 
+# Must match src/version.h PROTOCOL_VERSION. The Dash-specific deserialize/
+# roundtrip fuzz harnesses (src/test/fuzz/deserialize_dash.cpp,
+# src/test/fuzz/roundtrip_dash.cpp) read a 4-byte little-endian int from the
+# start of the buffer and use it as the stream version before deserializing
+# the object. Chain data we extract is serialized at PROTOCOL_VERSION, so we
+# prepend that value to seeds for those targets.
+DASH_STREAM_VERSION = 70240
+DASH_STREAM_VERSION_PREFIX = DASH_STREAM_VERSION.to_bytes(4, byteorder="little", signed=False)
+
+
+def _needs_stream_version_prefix(target_name):
+    """Return True if this target's harness consumes a 4-byte stream version prefix.
+
+    Matches the DashDeserializeFromFuzzingInput / DashRoundtripFromFuzzingInput
+    helpers used by every dash_*_deserialize and dash_*_roundtrip target. Non-Dash
+    targets (block_deserialize, block, decode_tx, ...) don't use that helper and
+    must be left untouched.
+    """
+    return target_name.startswith("dash_") and (
+        target_name.endswith("_deserialize") or target_name.endswith("_roundtrip")
+    )
+
+
 def save_corpus_input(output_dir, target_name, data_hex):
     """Save a hex-encoded blob as a corpus input file."""
     target_dir = output_dir / target_name
@@ -48,6 +71,9 @@ def save_corpus_input(output_dir, target_name, data_hex):
     except ValueError:
         print(f"WARNING: Invalid hex data for target {target_name}, skipping", file=sys.stderr)
         return False
+
+    if _needs_stream_version_prefix(target_name):
+        raw_bytes = DASH_STREAM_VERSION_PREFIX + raw_bytes
 
     filename = hashlib.sha256(raw_bytes).hexdigest()[:16]
     filepath = target_dir / filename
@@ -218,7 +244,7 @@ def extract_special_txs(output_dir, count=100, datadir=None):
 
             # Get raw transaction
             txid = tx.get("txid", "")
-            raw_tx = dash_cli("getrawtransaction", txid, datadir=datadir)
+            raw_tx = dash_cli("getrawtransaction", txid, "false", block_hash, datadir=datadir)
             if not raw_tx:
                 continue
 
@@ -265,9 +291,7 @@ def extract_governance_objects(output_dir, datadir=None):
         for _obj_hash, obj_data in objects.items():
             data_hex = obj_data.get("DataHex", "")
             if data_hex:
-                if save_corpus_input(output_dir, "dash_governance_object_deserialize", data_hex):
-                    saved += 1
-                if save_corpus_input(output_dir, "dash_governance_object_roundtrip", data_hex):
+                if save_corpus_input(output_dir, "dash_governance_object_common_deserialize", data_hex):
                     saved += 1
     except (json.JSONDecodeError, AttributeError):
         pass

--- a/contrib/fuzz/seed_corpus_from_chain.py
+++ b/contrib/fuzz/seed_corpus_from_chain.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Extract seed corpus inputs from a running Dash node for fuzz testing.
+
+Connects to a local dashd via RPC and extracts real-world serialized data
+(transactions, blocks, special transactions, governance objects, etc.)
+into fuzzer-consumable corpus files.
+
+Usage:
+    ./seed_corpus_from_chain.py --output-dir /path/to/corpus [options]
+
+Requirements:
+    - Running dashd with RPC enabled
+    - python-bitcoinrpc or compatible RPC library (or uses subprocess + dash-cli)
+"""
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def dash_cli(*args, datadir=None):
+    """Call dash-cli and return the result."""
+    cmd = ["dash-cli"]
+    if datadir:
+        cmd.append(f"-datadir={datadir}")
+    cmd.extend(args)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired) as e:
+        print(f"WARNING: dash-cli {' '.join(args)} failed: {e}", file=sys.stderr)
+        return None
+
+
+def save_corpus_input(output_dir, target_name, data_hex):
+    """Save a hex-encoded blob as a corpus input file."""
+    target_dir = output_dir / target_name
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        raw_bytes = bytes.fromhex(data_hex)
+    except ValueError:
+        print(f"WARNING: Invalid hex data for target {target_name}, skipping", file=sys.stderr)
+        return False
+
+    filename = hashlib.sha256(raw_bytes).hexdigest()[:16]
+    filepath = target_dir / filename
+
+    if not filepath.exists():
+        filepath.write_bytes(raw_bytes)
+        return True
+    return False
+
+
+def read_compact_size(raw, offset):
+    """Decode a CompactSize integer from raw bytes at offset."""
+    if offset >= len(raw):
+        raise ValueError("truncated CompactSize")
+
+    first = raw[offset]
+    offset += 1
+    if first < 253:
+        return first, offset
+    if first == 253:
+        if offset + 2 > len(raw):
+            raise ValueError("truncated CompactSize (uint16)")
+        return int.from_bytes(raw[offset:offset + 2], byteorder="little"), offset + 2
+    if first == 254:
+        if offset + 4 > len(raw):
+            raise ValueError("truncated CompactSize (uint32)")
+        return int.from_bytes(raw[offset:offset + 4], byteorder="little"), offset + 4
+    if offset + 8 > len(raw):
+        raise ValueError("truncated CompactSize (uint64)")
+    return int.from_bytes(raw[offset:offset + 8], byteorder="little"), offset + 8
+
+
+def extract_extra_payload_hex(raw_tx_hex, extra_payload_size):
+    """Extract extra payload bytes by parsing a raw special transaction."""
+    try:
+        raw_tx = bytes.fromhex(raw_tx_hex)
+    except ValueError:
+        return None, "raw transaction is not valid hex"
+
+    if extra_payload_size <= 0:
+        return None, "extraPayloadSize must be > 0"
+
+    try:
+        offset = 0
+        if len(raw_tx) < 4:
+            return None, "raw transaction too short for nVersion/nType"
+
+        n32bit_version = int.from_bytes(raw_tx[offset:offset + 4], byteorder="little")
+        n_version = n32bit_version & 0xFFFF
+        n_type = (n32bit_version >> 16) & 0xFFFF
+        offset += 4
+
+        if n_version < 3 or n_type == 0:
+            return None, f"transaction is not a special tx (version={n_version}, type={n_type})"
+
+        vin_count, offset = read_compact_size(raw_tx, offset)
+        for _ in range(vin_count):
+            # CTxIn: prevout hash (32), prevout index (4), scriptSig, sequence (4)
+            if offset + 36 > len(raw_tx):
+                return None, "truncated tx input prevout"
+            offset += 36
+
+            script_len, offset = read_compact_size(raw_tx, offset)
+            if offset + script_len + 4 > len(raw_tx):
+                return None, "truncated tx input scriptSig/sequence"
+            offset += script_len + 4
+
+        vout_count, offset = read_compact_size(raw_tx, offset)
+        for _ in range(vout_count):
+            # CTxOut: amount (8), scriptPubKey
+            if offset + 8 > len(raw_tx):
+                return None, "truncated tx output amount"
+            offset += 8
+
+            script_len, offset = read_compact_size(raw_tx, offset)
+            if offset + script_len > len(raw_tx):
+                return None, "truncated tx output scriptPubKey"
+            offset += script_len
+
+        if offset + 4 > len(raw_tx):
+            return None, "truncated nLockTime"
+        offset += 4
+
+        payload_len, offset = read_compact_size(raw_tx, offset)
+        if payload_len != extra_payload_size:
+            return None, f"extra payload size mismatch (expected {extra_payload_size}, parsed {payload_len})"
+        if offset + payload_len > len(raw_tx):
+            return None, "truncated extra payload"
+
+        payload = raw_tx[offset:offset + payload_len]
+        offset += payload_len
+        if offset != len(raw_tx):
+            return None, f"unexpected trailing bytes after payload ({len(raw_tx) - offset} bytes)"
+
+        return payload.hex(), None
+    except ValueError as e:
+        return None, str(e)
+
+
+def extract_blocks(output_dir, count=20, datadir=None):
+    """Extract recent blocks as corpus inputs."""
+    print(f"Extracting {count} recent blocks...")
+    height_str = dash_cli("getblockcount", datadir=datadir)
+    if not height_str:
+        return 0
+
+    height = int(height_str)
+    saved = 0
+
+    for h in range(max(0, height - count), height + 1):
+        block_hash = dash_cli("getblockhash", str(h), datadir=datadir)
+        if not block_hash:
+            continue
+
+        # Get serialized block
+        block_hex = dash_cli("getblock", block_hash, "0", datadir=datadir)
+        if block_hex:
+            if save_corpus_input(output_dir, "block_deserialize", block_hex):
+                saved += 1
+            if save_corpus_input(output_dir, "block", block_hex):
+                saved += 1
+
+    print(f"  Saved {saved} block corpus inputs")
+    return saved
+
+
+def extract_special_txs(output_dir, count=100, datadir=None):
+    """Extract special transactions (ProTx, etc.) from recent blocks."""
+    print(f"Scanning {count} recent blocks for special transactions...")
+    height_str = dash_cli("getblockcount", datadir=datadir)
+    if not height_str:
+        return 0
+
+    height = int(height_str)
+    saved = 0
+
+    # Map special tx types to fuzz target names
+    type_map = {
+        1: "dash_proreg_tx",           # ProRegTx
+        2: "dash_proupserv_tx",        # ProUpServTx
+        3: "dash_proupreg_tx",         # ProUpRegTx
+        4: "dash_prouprev_tx",         # ProUpRevTx
+        5: "dash_cbtx",               # CbTx (coinbase)
+        6: "dash_final_commitment_tx_payload",  # Quorum commitment
+        7: "dash_mnhf_tx_payload",     # MN HF signal
+        8: "dash_asset_lock_payload",  # Asset Lock
+        9: "dash_asset_unlock_payload", # Asset Unlock
+    }
+
+    for h in range(max(0, height - count), height + 1):
+        block_hash = dash_cli("getblockhash", str(h), datadir=datadir)
+        if not block_hash:
+            continue
+
+        block_json = dash_cli("getblock", block_hash, "2", datadir=datadir)
+        if not block_json:
+            continue
+
+        try:
+            block = json.loads(block_json)
+        except json.JSONDecodeError:
+            continue
+
+        for tx in block.get("tx", []):
+            tx_type = tx.get("type", 0)
+            if tx_type == 0:
+                continue
+
+            # Get raw transaction
+            txid = tx.get("txid", "")
+            raw_tx = dash_cli("getrawtransaction", txid, datadir=datadir)
+            if not raw_tx:
+                continue
+
+            # Save full transaction
+            if save_corpus_input(output_dir, "decode_tx", raw_tx):
+                saved += 1
+
+            # Extract special payload if we know the target
+            extra_payload_size = tx.get("extraPayloadSize", 0)
+            try:
+                extra_payload_size = int(extra_payload_size)
+            except (TypeError, ValueError):
+                extra_payload_size = 0
+
+            if extra_payload_size > 0 and tx_type in type_map:
+                payload_hex, err = extract_extra_payload_hex(raw_tx, extra_payload_size)
+                if not payload_hex:
+                    print(
+                        f"WARNING: Skipping special payload for tx {txid}: {err}",
+                        file=sys.stderr,
+                    )
+                    continue
+
+                target = type_map[tx_type]
+                # Save payload bytes for both deserialize and roundtrip variants.
+                for suffix in ["_deserialize", "_roundtrip"]:
+                    if save_corpus_input(output_dir, f"{target}{suffix}", payload_hex):
+                        saved += 1
+
+    print(f"  Saved {saved} special transaction corpus inputs")
+    return saved
+
+
+def extract_governance_objects(output_dir, datadir=None):
+    """Extract governance objects (proposals, triggers)."""
+    print("Extracting governance objects...")
+    result = dash_cli("gobject", "list", "all", datadir=datadir)
+    if not result:
+        return 0
+
+    saved = 0
+    try:
+        objects = json.loads(result)
+        for _obj_hash, obj_data in objects.items():
+            data_hex = obj_data.get("DataHex", "")
+            if data_hex:
+                if save_corpus_input(output_dir, "dash_governance_object_deserialize", data_hex):
+                    saved += 1
+                if save_corpus_input(output_dir, "dash_governance_object_roundtrip", data_hex):
+                    saved += 1
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    print(f"  Saved {saved} governance corpus inputs")
+    return saved
+
+
+def extract_masternode_list(output_dir, datadir=None):
+    """Extract masternode list entries."""
+    print("Extracting masternode list data...")
+    result = dash_cli("protx", "list", "registered", "true", datadir=datadir)
+    if not result:
+        return 0
+
+    saved = 0
+    try:
+        mn_list = json.loads(result)
+        for mn in mn_list:
+            protx_hash = mn.get("proTxHash", "")
+            if not protx_hash:
+                continue
+
+            raw_tx = dash_cli("getrawtransaction", protx_hash, datadir=datadir)
+            if not raw_tx:
+                continue
+
+            # Save full raw tx for full-transaction targets
+            if save_corpus_input(output_dir, "decode_tx", raw_tx):
+                saved += 1
+
+            # Extract the special payload for payload-specific targets
+            # ProRegTx type is 1, get extraPayloadSize from verbose tx
+            verbose_tx = dash_cli("getrawtransaction", protx_hash, "true", datadir=datadir)
+            if not verbose_tx:
+                continue
+            try:
+                tx_info = json.loads(verbose_tx)
+            except json.JSONDecodeError:
+                continue
+
+            extra_payload_size = tx_info.get("extraPayloadSize", 0)
+            try:
+                extra_payload_size = int(extra_payload_size)
+            except (TypeError, ValueError):
+                extra_payload_size = 0
+
+            if extra_payload_size > 0:
+                payload_hex, err = extract_extra_payload_hex(raw_tx, extra_payload_size)
+                if payload_hex:
+                    for target in ["dash_proreg_tx_deserialize", "dash_proreg_tx_roundtrip"]:
+                        if save_corpus_input(output_dir, target, payload_hex):
+                            saved += 1
+                else:
+                    print(f"WARNING: Could not extract payload from protx {protx_hash}: {err}", file=sys.stderr)
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    print(f"  Saved {saved} masternode corpus inputs")
+    return saved
+
+
+def extract_quorum_info(output_dir, datadir=None):
+    """Extract quorum-related data from the chain.
+
+    Note: quorum snapshot deserialize targets expect binary-serialized
+    CQuorumSnapshot data, not JSON. We extract final commitment transactions
+    from blocks instead, which are already captured by extract_special_txs()
+    for type 6 (TRANSACTION_QUORUM_COMMITMENT). This function focuses on
+    extracting quorum memberof data as raw bytes for other quorum targets.
+    """
+    print("Extracting quorum data...")
+    result = dash_cli("quorum", "list", datadir=datadir)
+    if not result:
+        return 0
+
+    # quorum info expects a numeric llmqType, but quorum list returns string keys
+    llmq_type_map = {
+        "llmq_50_60": "1",
+        "llmq_400_60": "2",
+        "llmq_400_85": "3",
+        "llmq_100_67": "4",
+        "llmq_60_75": "5",
+        "llmq_25_67": "6",
+        "llmq_test": "100",
+        "llmq_devnet": "101",
+        "llmq_test_v17": "102",
+        "llmq_test_dip0024": "103",
+        "llmq_test_instantsend": "104",
+        "llmq_devnet_dip0024": "105",
+        "llmq_test_platform": "106",
+        "llmq_devnet_platform": "107",
+    }
+
+    saved = 0
+    try:
+        quorum_list = json.loads(result)
+        for qtype, hashes in quorum_list.items():
+            numeric_type = llmq_type_map.get(qtype)
+            if numeric_type is None:
+                print(f"WARNING: Unknown quorum type '{qtype}', skipping", file=sys.stderr)
+                continue
+            for qhash in hashes[:5]:  # Limit per type
+                # Get the quorum commitment transaction via selectquorum
+                # which gives us the quorumHash we can look up in blocks
+                qinfo_str = dash_cli("quorum", "info", numeric_type, qhash, datadir=datadir)
+                if not qinfo_str:
+                    continue
+                try:
+                    qinfo = json.loads(qinfo_str)
+                except json.JSONDecodeError:
+                    continue
+                # Extract the commitment tx if available
+                mining_hash = qinfo.get("minedBlock", "")
+                if mining_hash:
+                    block_hex = dash_cli("getblock", mining_hash, "0", datadir=datadir)
+                    if block_hex and save_corpus_input(output_dir, "block_deserialize", block_hex):
+                        saved += 1
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+    print(f"  Saved {saved} quorum corpus inputs")
+    return saved
+
+
+#
+# These Dash-specific target names are forward-looking: corresponding fuzz targets
+# are planned for a future PR. We pre-generate seeds now so coverage is ready as
+# soon as those targets land.
+def create_synthetic_seeds(output_dir):
+    """Create minimal synthetic seed inputs for targets without chain data."""
+    print("Creating synthetic seed inputs...")
+    saved = 0
+
+    # Targets that need synthetic seeds (serialized structs with known formats)
+    synthetic_seeds = {
+        # CoinJoin messages — minimal valid-ish payloads
+        "dash_coinjoin_accept_deserialize": [
+            "00000000" + "00" * 4,  # nDenom(4) + txCollateral
+        ],
+        "dash_coinjoin_queue_deserialize": [
+            "00000000" + "00" * 48 + "00" * 96 + "0000000000000000",  # nDenom + proTxHash + vchSig + nTime
+        ],
+        "dash_coinjoin_status_update_deserialize": [
+            "00000000" + "00000000" + "00000000",  # nSessionID + nState + nStatusUpdate
+        ],
+        # LLMQ messages
+        "dash_recovered_sig_deserialize": [
+            "64" + "00" * 32 + "00" * 32 + "00" * 96,  # llmqType + quorumHash + id + sig
+        ],
+        "dash_sig_ses_ann_deserialize": [
+            "64" + "00" * 32 + "00000000" + "00" * 32,  # llmqType + quorumHash + nSessionId + id
+        ],
+        "dash_sig_share_deserialize": [
+            "64" + "00" * 32 + "00000000" + "00" * 32 + "0000" + "00" * 96,
+        ],
+        # MNAuth
+        "dash_mnauth_deserialize": [
+            "00" * 32 + "00" * 32 + "00" * 96,  # proRegTxHash + signChallenge + sig
+        ],
+        # DKG messages
+        "dash_dkg_complaint_deserialize": [
+            "64" + "00" * 32 + "00" * 32 + "0000" + "00",  # minimal
+        ],
+    }
+
+    for target, seeds in synthetic_seeds.items():
+        for seed_hex in seeds:
+            if save_corpus_input(output_dir, target, seed_hex):
+                saved += 1
+            # Also save roundtrip variant
+            roundtrip_target = target.replace("_deserialize", "_roundtrip")
+            if save_corpus_input(output_dir, roundtrip_target, seed_hex):
+                saved += 1
+
+    print(f"  Created {saved} synthetic seed inputs")
+    return saved
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract seed corpus from a running Dash node for fuzz testing"
+    )
+    parser.add_argument(
+        "--output-dir", "-o",
+        required=True,
+        help="Output directory for corpus files"
+    )
+    parser.add_argument(
+        "--datadir",
+        help="Dash data directory (passed to dash-cli)"
+    )
+    parser.add_argument(
+        "--blocks", type=int, default=100,
+        help="Number of recent blocks to scan (default: 100)"
+    )
+    parser.add_argument(
+        "--synthetic-only",
+        action="store_true",
+        help="Only generate synthetic seeds (no RPC required)"
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    total = 0
+
+    if not args.synthetic_only:
+        total += extract_blocks(output_dir, count=args.blocks, datadir=args.datadir)
+        total += extract_special_txs(output_dir, count=args.blocks, datadir=args.datadir)
+        total += extract_governance_objects(output_dir, datadir=args.datadir)
+        total += extract_masternode_list(output_dir, datadir=args.datadir)
+        total += extract_quorum_info(output_dir, datadir=args.datadir)
+
+    total += create_synthetic_seeds(output_dir)
+
+    print(f"\nTotal: {total} corpus inputs saved to {output_dir}")
+
+    # Print summary
+    print("\nCorpus directory summary:")
+    for target_dir in sorted(output_dir.iterdir()):
+        if target_dir.is_dir():
+            file_count = len(list(target_dir.iterdir()))
+            print(f"  {target_dir.name}: {file_count} files")
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/fuzz/seed_corpus_from_chain.py
+++ b/contrib/fuzz/seed_corpus_from_chain.py
@@ -19,6 +19,7 @@ Requirements:
 import argparse
 import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -52,9 +53,9 @@ def _read_protocol_version():
     return int(match.group(1))
 
 
-# Must match src/version.h PROTOCOL_VERSION. Several fuzz harnesses read a
-# 4-byte little-endian int from the start of the buffer and use it as the
-# stream version before deserializing the object:
+# The stream version is needed by several fuzz harnesses that read a 4-byte
+# little-endian int from the start of the buffer and use it as the stream
+# version before deserializing the object:
 #   * The Dash-specific helpers DashDeserializeFromFuzzingInput /
 #     DashRoundtripFromFuzzingInput (src/test/fuzz/deserialize_dash.cpp,
 #     src/test/fuzz/roundtrip_dash.cpp), used by dash_*_deserialize and
@@ -65,10 +66,37 @@ def _read_protocol_version():
 #     via DeserializeFromFuzzingInput when no explicit protocol_version is
 #     passed.
 # Chain data we extract is serialized at PROTOCOL_VERSION, so we prepend
-# that value to seeds for those targets.
-PROTOCOL_VERSION = _read_protocol_version()
-STREAM_VERSION = PROTOCOL_VERSION
-STREAM_VERSION_PREFIX = STREAM_VERSION.to_bytes(4, byteorder="little", signed=False)
+# that value to seeds for those targets. The lookup is deferred to first use
+# so `--help` and callers that supply --stream-version / DASH_FUZZ_STREAM_VERSION
+# don't require an in-tree src/version.h.
+_STREAM_VERSION_OVERRIDE = None
+_STREAM_VERSION_CACHE = None
+
+
+def _resolve_stream_version():
+    """Return the stream version, preferring an explicit override and falling back
+    to parsing src/version.h. Cached after first successful resolution."""
+    global _STREAM_VERSION_CACHE
+    if _STREAM_VERSION_CACHE is not None:
+        return _STREAM_VERSION_CACHE
+    if _STREAM_VERSION_OVERRIDE is not None:
+        _STREAM_VERSION_CACHE = _STREAM_VERSION_OVERRIDE
+        return _STREAM_VERSION_CACHE
+    env_override = os.environ.get("DASH_FUZZ_STREAM_VERSION")
+    if env_override:
+        try:
+            _STREAM_VERSION_CACHE = int(env_override)
+        except ValueError as e:
+            raise RuntimeError(
+                f"DASH_FUZZ_STREAM_VERSION must be an integer, got {env_override!r}"
+            ) from e
+        return _STREAM_VERSION_CACHE
+    _STREAM_VERSION_CACHE = _read_protocol_version()
+    return _STREAM_VERSION_CACHE
+
+
+def _stream_version_prefix():
+    return _resolve_stream_version().to_bytes(4, byteorder="little", signed=False)
 
 # Non-Dash targets (outside the dash_* naming convention) whose harnesses
 # also consume the 4-byte stream version prefix described above.
@@ -113,7 +141,7 @@ def save_corpus_input(output_dir, target_name, data_hex):
         return False
 
     if _needs_stream_version_prefix(target_name):
-        raw_bytes = STREAM_VERSION_PREFIX + raw_bytes
+        raw_bytes = _stream_version_prefix() + raw_bytes
 
     filename = hashlib.sha256(raw_bytes).hexdigest()[:16]
     filepath = target_dir / filename
@@ -1137,6 +1165,134 @@ def create_synthetic_seeds(output_dir):
         + b"\x00" * 96
     )
 
+    # CCreditPool (src/evo/creditpool.h):
+    #   locked (int64) + currentLimit (int64) + latelyUnlocked (int64) + ranges (set<Range>)
+    # An empty CRangesSet is just CompactSize(0) = 1 byte.
+    minimal_credit_pool = (
+        _serialize_int64(0)
+        + _serialize_int64(0)
+        + _serialize_int64(0)
+        + _compact_size(0)
+    )
+
+    # CDeterministicMNState (src/evo/dmnstate.h) at nVersion=LegacyBLS=1:
+    #   * pubKeyOperator is wrapped with legacy=true (48 bytes)
+    #   * NetInfoSerWrapper(is_extended=false): MnNetInfo unserializes a CService
+    #     whose wire format without ADDRV2_FORMAT is V1 (16-byte IPv6 addr + 2-byte BE port).
+    #   * platformP2PPort/HTTPPort are emitted only when nVersion < ExtAddr=3.
+    minimal_dmn_state = (
+        _serialize_int32(1)         # nVersion = LegacyBLS
+        + _serialize_int32(0)       # nRegisteredHeight
+        + _serialize_int32(0)       # nLastPaidHeight
+        + _serialize_int32(0)       # nConsecutivePayments
+        + _serialize_int32(0)       # nPoSePenalty
+        + _serialize_int32(0)       # nPoSeRevivedHeight
+        + _serialize_int32(0)       # nPoSeBanHeight
+        + b"\x00\x00"               # nRevocationReason (uint16)
+        + b"\x00" * 32              # confirmedHash
+        + b"\x00" * 32              # confirmedHashWithProRegTxHash
+        + b"\x00" * 20              # keyIDOwner (uint160)
+        + b"\x00" * 48              # pubKeyOperator (legacy CBLSLazyPublicKey)
+        + b"\x00" * 20              # keyIDVoting (uint160)
+        + b"\x00" * 18              # MnNetInfo: CService V1 (16-byte addr + 2-byte port)
+        + _compact_size(0)          # scriptPayout (empty CScript)
+        + _compact_size(0)          # scriptOperatorPayout
+        + b"\x00" * 20              # platformNodeID (uint160)
+        + b"\x00\x00"               # platformP2PPort
+        + b"\x00\x00"               # platformHTTPPort
+    )
+
+    # CDeterministicMN (src/evo/deterministicmns.h) at PROTOCOL_VERSION:
+    #   proTxHash + VARINT(internalId) + collateralOutpoint + nOperatorReward
+    #   + pdmnState (shared_ptr inlines the pointed-to object) + nType (uint16, only present
+    #   when stream version >= DMN_TYPE_PROTO_VERSION which holds for our PROTOCOL_VERSION prefix).
+    minimal_deterministic_mn = (
+        b"\x00" * 32                       # proTxHash
+        + b"\x00"                          # VARINT(internalId=0)
+        + _serialize_outpoint("", 0)       # collateralOutpoint (32 + 4)
+        + b"\x00\x00"                      # nOperatorReward (uint16)
+        + minimal_dmn_state                # pdmnState
+        + b"\x00\x00"                      # nType (MnType, uint16)
+    )
+
+    # CSimplifiedMNListEntry (src/evo/simplifiedmns.h) with nVersion=LegacyBLS=1:
+    #   PROTOCOL_VERSION >= SMNLE_VERSIONED_PROTO_VERSION so nVersion is always read first.
+    #   Because nVersion < BasicBLS, no nType / platform fields are emitted.
+    minimal_smn_list_entry = (
+        b"\x01\x00"                 # nVersion = LegacyBLS (uint16 LE)
+        + b"\x00" * 32              # proRegTxHash
+        + b"\x00" * 32              # confirmedHash
+        + b"\x00" * 18              # MnNetInfo: V1 CService
+        + b"\x00" * 48              # pubKeyOperator (legacy)
+        + b"\x00" * 20              # keyIDVoting
+        + b"\x00"                   # isValid = false
+    )
+
+    # CProUpRegTx (src/evo/providertx.h) at nVersion=LegacyBLS=1:
+    #   nVersion(2) + proTxHash(32) + nMode(2) + pubKeyOperator(legacy CBLSLazyPublicKey, 48)
+    #   + keyIDVoting(20) + scriptPayout(empty CScript -> CompactSize(0)) + inputsHash(32) + vchSig(empty -> CompactSize(0)).
+    minimal_proupreg_tx = (
+        b"\x01\x00"                 # nVersion = LegacyBLS
+        + b"\x00" * 32              # proTxHash
+        + b"\x00\x00"               # nMode (uint16)
+        + b"\x00" * 48              # pubKeyOperator (legacy)
+        + b"\x00" * 20              # keyIDVoting
+        + _compact_size(0)          # scriptPayout (empty)
+        + b"\x00" * 32              # inputsHash
+        + _compact_size(0)          # vchSig (empty)
+    )
+
+    # CProUpRevTx (src/evo/providertx.h) at nVersion=LegacyBLS=1:
+    #   nVersion(2) + proTxHash(32) + nReason(2) + inputsHash(32) + sig(legacy CBLSSignature, 96).
+    minimal_prouprev_tx = (
+        b"\x01\x00"                 # nVersion = LegacyBLS
+        + b"\x00" * 32              # proTxHash
+        + b"\x00\x00"               # nReason (uint16)
+        + b"\x00" * 32              # inputsHash
+        + b"\x00" * 96              # sig (legacy CBLSSignature)
+    )
+
+    # CGetSimplifiedMNListDiff (src/evo/smldiff.h): just baseBlockHash + blockHash.
+    minimal_get_smn_list_diff = b"\x00" * 32 + b"\x00" * 32
+
+    # An empty CPartialMerkleTree (src/merkleblock.h):
+    #   nTransactions(uint32=0) + vHash(CompactSize(0)) + bytes(CompactSize(0))
+    minimal_partial_merkle_tree = (
+        _serialize_uint32(0)
+        + _compact_size(0)
+        + _compact_size(0)
+    )
+
+    # CSimplifiedMNListDiff (src/evo/smldiff.h) at PROTOCOL_VERSION >= MNLISTDIFF_CHAINLOCKS_PROTO_VERSION:
+    #   nVersion(uint16) + baseBlockHash(32) + blockHash(32) + cbTxMerkleTree(CPartialMerkleTree)
+    #   + cbTx(CMutableTransaction) + deletedMNs(CompactSize(0)) + mnList(CompactSize(0))
+    #   + deletedQuorums(CompactSize(0)) + newQuorums(CompactSize(0)) + quorumsCLSigs(CompactSize(0)).
+    # nVersion is read first because PROTOCOL_VERSION >= MNLISTDIFF_VERSION_ORDER.
+    minimal_smn_list_diff = (
+        b"\x01\x00"                          # nVersion
+        + b"\x00" * 32                       # baseBlockHash
+        + b"\x00" * 32                       # blockHash
+        + minimal_partial_merkle_tree        # cbTxMerkleTree
+        + minimal_tx                         # cbTx (n_version=2, type=0, empty vin/vout)
+        + _compact_size(0)                   # deletedMNs
+        + _compact_size(0)                   # mnList
+        + _compact_size(0)                   # deletedQuorums
+        + _compact_size(0)                   # newQuorums
+        + _compact_size(0)                   # quorumsCLSigs
+    )
+
+    # llmq P2P / message types — reuse the shared serializers so the synthetic
+    # form stays in lockstep with what extract_quorum_info() emits from chain data.
+    minimal_quorum_data_request = serialize_quorum_data_request(
+        llmq_type=1, quorum_hash_hex="00" * 32, pro_tx_hash_hex="", n_data_mask=1
+    )
+    minimal_get_quorum_rotation_info = serialize_get_quorum_rotation_info(
+        block_request_hash_hex="00" * 32, base_block_hashes_hex=[], extra_share=False
+    )
+    minimal_quorum_snapshot = serialize_quorum_snapshot(
+        active_quorum_members=[], skip_list=[], mn_skip_list_mode=0
+    )
+
     # Targets that need synthetic seeds (serialized structs with known formats)
     synthetic_seeds = {
         # CoinJoin messages — minimal valid-ish payloads
@@ -1169,13 +1325,17 @@ def create_synthetic_seeds(output_dir):
             ((1).to_bytes(2, "little") + _serialize_uint32(0) + minimal_final_commitment).hex(),
         ],
         "dash_recovered_sig_deserialize": [
-            "64" + "00" * 32 + "00" * 32 + "00" * 96,  # llmqType + quorumHash + id + sig
+            # CRecoveredSig: llmqType (uint8) + quorumHash (32) + id (32) + msgHash (32) + sig (96)
+            "64" + "00" * 32 + "00" * 32 + "00" * 32 + "00" * 96,
         ],
         "dash_sig_ses_ann_deserialize": [
-            "64" + "00" * 32 + "00000000" + "00" * 32,  # llmqType + quorumHash + nSessionId + id
+            # CSigSesAnn: VARINT(sessionId=0) + llmqType (uint8) + quorumHash (32) + id (32) + msgHash (32)
+            "00" + "64" + "00" * 32 + "00" * 32 + "00" * 32,
         ],
         "dash_sig_share_deserialize": [
-            "64" + "00" * 32 + "00000000" + "00" * 32 + "0000" + "00" * 96,
+            # CSigShare: llmqType (uint8) + quorumHash (32) + quorumMember (uint16 LE)
+            #          + id (32) + msgHash (32) + sigShare (96, BLS lazy)
+            "64" + "00" * 32 + "0000" + "00" * 32 + "00" * 32 + "00" * 96,
         ],
         # MNAuth
         "dash_mnauth_deserialize": [
@@ -1183,7 +1343,9 @@ def create_synthetic_seeds(output_dir):
         ],
         # DKG messages
         "dash_dkg_complaint_deserialize": [
-            "64" + "00" * 32 + "00" * 32 + "0000" + "00",  # minimal
+            # CDKGComplaint: llmqType + quorumHash + proTxHash + DYNBITSET(badMembers)
+            #              + DYNBITSET(complainForMembers) + sig (96 bytes)
+            "64" + "00" * 32 + "00" * 32 + "00" + "00" + "00" * 96,
         ],
         "dash_dkg_justification_deserialize": [
             # llmqType (uint8) + quorumHash (32) + proTxHash (32) +
@@ -1226,6 +1388,41 @@ def create_synthetic_seeds(output_dir):
         ],
         "dash_bls_ies_multi_recipient_blobs_deserialize": [
             minimal_bls_ies_multi.hex(),
+        ],
+        # evo/ types — minimal valid serializations matching the C++ layouts above.
+        "dash_credit_pool_deserialize": [
+            minimal_credit_pool.hex(),
+        ],
+        "dash_dmn_state_deserialize": [
+            minimal_dmn_state.hex(),
+        ],
+        "dash_deterministic_mn_deserialize": [
+            minimal_deterministic_mn.hex(),
+        ],
+        "dash_smn_list_entry_deserialize": [
+            minimal_smn_list_entry.hex(),
+        ],
+        "dash_proupreg_tx_deserialize": [
+            minimal_proupreg_tx.hex(),
+        ],
+        "dash_prouprev_tx_deserialize": [
+            minimal_prouprev_tx.hex(),
+        ],
+        "dash_get_smn_list_diff_deserialize": [
+            minimal_get_smn_list_diff.hex(),
+        ],
+        "dash_smn_list_diff_deserialize": [
+            minimal_smn_list_diff.hex(),
+        ],
+        # llmq P2P/message types — keep in sync with extract_quorum_info().
+        "dash_quorum_data_request_deserialize": [
+            minimal_quorum_data_request.hex(),
+        ],
+        "dash_get_quorum_rotation_info_deserialize": [
+            minimal_get_quorum_rotation_info.hex(),
+        ],
+        "dash_quorum_snapshot_deserialize": [
+            minimal_quorum_snapshot.hex(),
         ],
     }
 
@@ -1283,26 +1480,118 @@ def _run_helper_self_checks():
             "dash_bls_ies_multi_recipient_blobs_roundtrip",
             "dash_coinjoin_entry_deserialize",
             "dash_coinjoin_entry_roundtrip",
+            "dash_dkg_complaint_deserialize",
+            "dash_dkg_complaint_roundtrip",
             "dash_dkg_justification_deserialize",
             "dash_dkg_justification_roundtrip",
             "dash_sig_shares_inv_deserialize",
             "dash_sig_shares_inv_roundtrip",
             "dash_batched_sig_shares_deserialize",
             "dash_batched_sig_shares_roundtrip",
+            "dash_recovered_sig_deserialize",
+            "dash_recovered_sig_roundtrip",
+            "dash_sig_ses_ann_deserialize",
+            "dash_sig_ses_ann_roundtrip",
+            "dash_sig_share_deserialize",
+            "dash_sig_share_roundtrip",
+            "dash_mnauth_deserialize",
+            "dash_mnauth_roundtrip",
             "dash_mnhf_tx_deserialize",
+            "dash_credit_pool_deserialize",
+            "dash_credit_pool_roundtrip",
+            "dash_dmn_state_deserialize",
+            "dash_dmn_state_roundtrip",
+            "dash_deterministic_mn_deserialize",
+            "dash_deterministic_mn_roundtrip",
+            "dash_smn_list_entry_deserialize",
+            "dash_smn_list_entry_roundtrip",
+            "dash_proupreg_tx_deserialize",
+            "dash_proupreg_tx_roundtrip",
+            "dash_prouprev_tx_deserialize",
+            "dash_prouprev_tx_roundtrip",
+            "dash_get_smn_list_diff_deserialize",
+            "dash_get_smn_list_diff_roundtrip",
+            "dash_smn_list_diff_deserialize",
+            "dash_smn_list_diff_roundtrip",
+            "dash_quorum_data_request_deserialize",
+            "dash_quorum_data_request_roundtrip",
+            "dash_get_quorum_rotation_info_deserialize",
+            "dash_get_quorum_rotation_info_roundtrip",
+            "dash_quorum_snapshot_deserialize",
+            "dash_quorum_snapshot_roundtrip",
         ]
         missing = [target for target in required_targets if not any((tmp_path / target).iterdir())]
         assert not missing, f"missing synthetic seeds for: {', '.join(missing)}"
+
+        # Assert the LLMQ seed sizes match the C++ serialization layouts so the
+        # synthetic seeds aren't silently truncated again (regression guard).
+        def _seed_bytes(target):
+            files = list((tmp_path / target).iterdir())
+            assert len(files) == 1, f"{target}: expected one synthetic seed, got {len(files)}"
+            return files[0].read_bytes()
+
+        # The Dash deserialize/roundtrip wrappers prepend a 4-byte stream version.
+        prefix = len(_stream_version_prefix())
+        # CRecoveredSig: 1 + 32 + 32 + 32 + 96 = 193
+        assert len(_seed_bytes("dash_recovered_sig_deserialize")) == prefix + 193
+        # CSigSesAnn (VARINT(0)=1 byte): 1 + 1 + 32 + 32 + 32 = 98
+        assert len(_seed_bytes("dash_sig_ses_ann_deserialize")) == prefix + 98
+        # CSigShare: 1 + 32 + 2 + 32 + 32 + 96 = 195
+        assert len(_seed_bytes("dash_sig_share_deserialize")) == prefix + 195
+        # CDKGComplaint with empty bitsets: 1 + 32 + 32 + 1 + 1 + 96 = 163
+        assert len(_seed_bytes("dash_dkg_complaint_deserialize")) == prefix + 163
+        # CCreditPool: int64*3 + CompactSize(0) = 8*3 + 1 = 25
+        assert len(_seed_bytes("dash_credit_pool_deserialize")) == prefix + 25
+        # CDeterministicMNState (LegacyBLS layout): see minimal_dmn_state above.
+        # 4*7 + 2 + 32 + 32 + 20 + 48 + 20 + 18 + 1 + 1 + 20 + 2 + 2 = 226
+        assert len(_seed_bytes("dash_dmn_state_deserialize")) == prefix + 226
+        # CDeterministicMN: 32 + 1 + 36 + 2 + 226 + 2 = 299
+        assert len(_seed_bytes("dash_deterministic_mn_deserialize")) == prefix + 299
+        # CSimplifiedMNListEntry (LegacyBLS): 2 + 32 + 32 + 18 + 48 + 20 + 1 = 153
+        assert len(_seed_bytes("dash_smn_list_entry_deserialize")) == prefix + 153
+        # CProUpRegTx (LegacyBLS): 2 + 32 + 2 + 48 + 20 + 1 + 32 + 1 = 138
+        assert len(_seed_bytes("dash_proupreg_tx_deserialize")) == prefix + 138
+        # CProUpRevTx (LegacyBLS): 2 + 32 + 2 + 32 + 96 = 164
+        assert len(_seed_bytes("dash_prouprev_tx_deserialize")) == prefix + 164
+        # CGetSimplifiedMNListDiff: 32 + 32 = 64
+        assert len(_seed_bytes("dash_get_smn_list_diff_deserialize")) == prefix + 64
+        # CSimplifiedMNListDiff at PROTOCOL_VERSION (>= MNLISTDIFF_CHAINLOCKS_PROTO_VERSION):
+        # nVersion(2) + baseBlockHash(32) + blockHash(32)
+        # + cbTxMerkleTree(uint32+CompactSize(0)+CompactSize(0)=6)
+        # + cbTx(n32bitVersion(4)+CompactSize(0)+CompactSize(0)+nLockTime(4)=10)
+        # + 5*CompactSize(0) (deletedMNs/mnList/deletedQuorums/newQuorums/quorumsCLSigs) = 5
+        # = 2 + 64 + 6 + 10 + 5 = 87
+        assert len(_seed_bytes("dash_smn_list_diff_deserialize")) == prefix + 87
+        # CQuorumDataRequest: llmqType(1) + quorumHash(32) + nDataMask(2) + proTxHash(32) + nError(1) = 68
+        assert len(_seed_bytes("dash_quorum_data_request_deserialize")) == prefix + 68
+        # CGetQuorumRotationInfo (empty baseBlockHashes): CompactSize(0)+blockRequestHash(32)+bool(1) = 34
+        assert len(_seed_bytes("dash_get_quorum_rotation_info_deserialize")) == prefix + 34
+        # CQuorumSnapshot (empty active members + empty skip list):
+        # mnSkipListMode(int32=4) + CompactSize(0) for active bitset + CompactSize(0) for skip list = 6
+        assert len(_seed_bytes("dash_quorum_snapshot_deserialize")) == prefix + 6
+
+    # --stream-version override path: setting the override must not require
+    # src/version.h, and _stream_version_prefix must round-trip the value.
+    global _STREAM_VERSION_OVERRIDE, _STREAM_VERSION_CACHE
+    saved_override, saved_cache = _STREAM_VERSION_OVERRIDE, _STREAM_VERSION_CACHE
+    try:
+        _STREAM_VERSION_OVERRIDE = 0x12345678
+        _STREAM_VERSION_CACHE = None
+        assert _stream_version_prefix() == b"\x78\x56\x34\x12"
+    finally:
+        _STREAM_VERSION_OVERRIDE = saved_override
+        _STREAM_VERSION_CACHE = saved_cache
 
 
 def main():
     parser = argparse.ArgumentParser(
         description="Extract seed corpus from a running Dash node for fuzz testing"
     )
+    # --output-dir is required for normal/synthetic-only runs but not for --self-check,
+    # so the flag is enforced post-parse rather than via argparse's required=True.
     parser.add_argument(
         "--output-dir", "-o",
-        required=True,
-        help="Output directory for corpus files"
+        help="Output directory for corpus files (required unless --self-check)"
     )
     parser.add_argument(
         "--datadir",
@@ -1317,7 +1606,38 @@ def main():
         action="store_true",
         help="Only generate synthetic seeds (no RPC required)"
     )
+    parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help=(
+            "Run deterministic helper self-checks (governance/final-commitment "
+            "serializers and the synthetic seed generator) and exit. Does not "
+            "require --output-dir."
+        ),
+    )
+    parser.add_argument(
+        "--stream-version",
+        type=int,
+        default=None,
+        help=(
+            "Stream version (4-byte LE prefix) to use for harnesses that consume one. "
+            "Overrides DASH_FUZZ_STREAM_VERSION and the src/version.h fallback. "
+            "Useful when running outside an in-tree source checkout."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.stream_version is not None:
+        global _STREAM_VERSION_OVERRIDE
+        _STREAM_VERSION_OVERRIDE = args.stream_version
+
+    if args.self_check:
+        _run_helper_self_checks()
+        print("seed_corpus_from_chain.py: self-check passed")
+        return
+
+    if not args.output_dir:
+        parser.error("--output-dir/-o is required unless --self-check is passed")
 
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/contrib/fuzz/seed_corpus_from_chain.py
+++ b/contrib/fuzz/seed_corpus_from_chain.py
@@ -100,6 +100,163 @@ def save_corpus_input(output_dir, target_name, data_hex):
     return False
 
 
+def _compact_size(n):
+    """Encode an unsigned integer as a Bitcoin/Dash CompactSize (aka VarInt)."""
+    if n < 253:
+        return bytes([n])
+    if n < 0x10000:
+        return b"\xfd" + n.to_bytes(2, "little")
+    if n < 0x100000000:
+        return b"\xfe" + n.to_bytes(4, "little")
+    return b"\xff" + n.to_bytes(8, "little")
+
+
+def _var_bytes(b):
+    """CompactSize length prefix + the bytes themselves (vector<unsigned char>)."""
+    return _compact_size(len(b)) + b
+
+
+def _uint256_from_hex(h):
+    """Convert an RPC-form uint256 hex string (big-endian display) to its 32-byte
+    wire representation (little-endian internal). Empty/missing input -> zero hash.
+    """
+    if not h:
+        return b"\x00" * 32
+    raw = bytes.fromhex(h)
+    if len(raw) != 32:
+        raise ValueError(f"uint256 hex must be 32 bytes, got {len(raw)}")
+    return raw[::-1]
+
+
+def _parse_outpoint_short(s):
+    """Parse a masternode-outpoint short form 'txid-n' into wire bytes
+    (uint256 hash + uint32 n). Returns zeroed outpoint on missing/invalid input.
+    RPC exposes the signing masternode outpoint as "txid-n" (COutPoint::ToStringShort)."""
+    if not s or "-" not in s:
+        return b"\x00" * 32 + (0).to_bytes(4, "little")
+    txid, _, idx = s.rpartition("-")
+    try:
+        n = int(idx)
+    except ValueError:
+        return b"\x00" * 32 + (0).to_bytes(4, "little")
+    try:
+        return _uint256_from_hex(txid) + n.to_bytes(4, "little")
+    except ValueError:
+        return b"\x00" * 32 + (0).to_bytes(4, "little")
+
+
+def serialize_governance_object(obj_data):
+    """Serialize a structurally valid Governance::Object from a `gobject list` RPC entry.
+
+    The fuzz target ``dash_governance_object_common_deserialize`` reads a full
+    Governance::Object (see src/governance/common.h SERIALIZE_METHODS). The RPC
+    exposes only a subset of the fields; the rest are filled with documented
+    best-effort defaults so the seed is structurally sound rather than random bytes.
+
+    Field sources:
+      * ``hashParent``      — not exposed by RPC (root-object semantics); zeroed.
+      * ``revision``        — not exposed by RPC; defaulted to 1.
+      * ``time``            — from ``CreationTime`` (int64 seconds).
+      * ``collateralHash``  — from ``CollateralHash`` (hex, RPC display order).
+      * ``vchData``         — from ``DataHex`` (raw payload bytes).
+      * ``type``            — from ``ObjectType`` (int: UNKNOWN=0, PROPOSAL=1, TRIGGER=2).
+      * ``masternodeOutpoint`` — from ``SigningMasternode`` ("txid-n"), if present.
+      * ``vchSig``          — not exposed by RPC; left empty.
+    """
+    hash_parent = b"\x00" * 32
+    revision = 1
+    try:
+        time_ = int(obj_data.get("CreationTime", 0))
+    except (TypeError, ValueError):
+        time_ = 0
+    try:
+        collateral_hash = _uint256_from_hex(obj_data.get("CollateralHash", ""))
+    except ValueError:
+        collateral_hash = b"\x00" * 32
+
+    data_hex = obj_data.get("DataHex", "") or ""
+    try:
+        vch_data = bytes.fromhex(data_hex)
+    except ValueError:
+        vch_data = b""
+
+    try:
+        obj_type = int(obj_data.get("ObjectType", 0))
+    except (TypeError, ValueError):
+        obj_type = 0
+
+    outpoint = _parse_outpoint_short(obj_data.get("SigningMasternode", ""))
+    vch_sig = b""
+
+    return (
+        hash_parent
+        + revision.to_bytes(4, "little", signed=True)
+        + time_.to_bytes(8, "little", signed=True)
+        + collateral_hash
+        + _var_bytes(vch_data)
+        + obj_type.to_bytes(4, "little", signed=True)
+        + outpoint
+        + _var_bytes(vch_sig)
+    )
+
+
+def serialize_quorum_data_request(llmq_type, quorum_hash_hex, pro_tx_hash_hex="", n_data_mask=3):
+    """Serialize a llmq::CQuorumDataRequest (src/llmq/quorums.h).
+
+    Wire layout: llmqType (uint8) + quorumHash (uint256) + nDataMask (uint16 LE)
+    + proTxHash (uint256) + nError (uint8, NONE=0). nError is optional per the
+    SERIALIZE_METHODS (try/catch on read, conditional on write) — we include it
+    with NONE so the seed round-trips cleanly.
+
+    nDataMask defaults to QUORUM_VERIFICATION_VECTOR|ENCRYPTED_CONTRIBUTIONS (0x3)
+    for maximal coverage; RPC doesn't expose a concrete in-flight request.
+    """
+    return (
+        bytes([llmq_type & 0xFF])
+        + _uint256_from_hex(quorum_hash_hex)
+        + (n_data_mask & 0xFFFF).to_bytes(2, "little")
+        + _uint256_from_hex(pro_tx_hash_hex)
+        + bytes([0])  # nError = NONE
+    )
+
+
+def serialize_get_quorum_rotation_info(block_request_hash_hex, base_block_hashes_hex, extra_share=False):
+    """Serialize a llmq::CGetQuorumRotationInfo (src/llmq/snapshot.h).
+
+    Wire layout: vector<uint256> baseBlockHashes + uint256 blockRequestHash + bool extraShare.
+    """
+    out = _compact_size(len(base_block_hashes_hex))
+    for h in base_block_hashes_hex:
+        out += _uint256_from_hex(h)
+    out += _uint256_from_hex(block_request_hash_hex)
+    out += bytes([1 if extra_share else 0])
+    return out
+
+
+def serialize_quorum_snapshot(active_quorum_members, skip_list, mn_skip_list_mode=0):
+    """Serialize a llmq::CQuorumSnapshot (src/llmq/snapshot.h).
+
+    Wire layout: mnSkipListMode (int, 4 bytes LE — SnapshotSkipMode enum underlying type is int)
+    + CompactSize(len(activeQuorumMembers)) + WriteFixedBitSet(activeQuorumMembers)
+    + CompactSize(len(mnSkipList)) + int32 LE for each skip-list entry.
+    """
+    count = len(active_quorum_members)
+    out = mn_skip_list_mode.to_bytes(4, "little", signed=True)
+    out += _compact_size(count)
+
+    nbytes = (count + 7) // 8
+    buf = bytearray(nbytes)
+    for i, v in enumerate(active_quorum_members):
+        if v:
+            buf[i // 8] |= 1 << (i % 8)
+    out += bytes(buf)
+
+    out += _compact_size(len(skip_list))
+    for x in skip_list:
+        out += int(x).to_bytes(4, "little", signed=True)
+    return out
+
+
 def read_compact_size(raw, offset):
     """Decode a CompactSize integer from raw bytes at offset."""
     if offset >= len(raw):
@@ -297,7 +454,15 @@ def extract_special_txs(output_dir, count=100, datadir=None):
 
 
 def extract_governance_objects(output_dir, datadir=None):
-    """Extract governance objects (proposals, triggers)."""
+    """Extract governance objects (proposals, triggers) into structurally valid seeds.
+
+    The fuzz target deserializes a full Governance::Object, not raw payload bytes,
+    so we reconstruct the object from the RPC fields (CollateralHash, CreationTime,
+    ObjectType, SigningMasternode, DataHex) and synthesize best-effort defaults for
+    fields the RPC doesn't expose (hashParent, revision, vchSig). CGovernanceObject's
+    non-disk serialization is just ``m_obj`` (see src/governance/object.h:248) so the
+    same bytes are valid seeds for dash_governance_object_{deserialize,roundtrip}.
+    """
     print("Extracting governance objects...")
     result = dash_cli("gobject", "list", "all", datadir=datadir)
     if not result:
@@ -306,13 +471,30 @@ def extract_governance_objects(output_dir, datadir=None):
     saved = 0
     try:
         objects = json.loads(result)
-        for _obj_hash, obj_data in objects.items():
-            data_hex = obj_data.get("DataHex", "")
-            if data_hex:
-                if save_corpus_input(output_dir, "dash_governance_object_common_deserialize", data_hex):
-                    saved += 1
     except (json.JSONDecodeError, AttributeError):
-        pass
+        return 0
+
+    if not isinstance(objects, dict):
+        return 0
+
+    targets = [
+        "dash_governance_object_common_deserialize",
+        "dash_governance_object_deserialize",
+        "dash_governance_object_roundtrip",
+    ]
+
+    for obj_hash, obj_data in objects.items():
+        if not isinstance(obj_data, dict):
+            continue
+        try:
+            serialized = serialize_governance_object(obj_data)
+        except (ValueError, OverflowError) as e:
+            print(f"WARNING: Skipping governance object {obj_hash}: {e}", file=sys.stderr)
+            continue
+        seed_hex = serialized.hex()
+        for target in targets:
+            if save_corpus_input(output_dir, target, seed_hex):
+                saved += 1
 
     print(f"  Saved {saved} governance corpus inputs")
     return saved
@@ -408,13 +590,29 @@ def extract_masternode_list(output_dir, datadir=None):
 
 
 def extract_quorum_info(output_dir, datadir=None):
-    """Extract quorum-related data from the chain.
+    """Seed the quorum-specific P2P/message fuzz targets from live chain data.
 
-    Note: quorum snapshot deserialize targets expect binary-serialized
-    CQuorumSnapshot data, not JSON. We extract final commitment transactions
-    from blocks instead, which are already captured by extract_special_txs()
-    for type 6 (TRANSACTION_QUORUM_COMMITMENT). This function focuses on
-    extracting quorum memberof data as raw bytes for other quorum targets.
+    Drives three fuzz-target families (each with _deserialize and _roundtrip):
+      * dash_quorum_data_request_*        — CQuorumDataRequest (QGETDATA message)
+      * dash_get_quorum_rotation_info_*   — CGetQuorumRotationInfo (QGETRTINFO message)
+      * dash_quorum_snapshot_*            — CQuorumSnapshot (QRINFO payload piece)
+
+    We derive inputs from ``quorum list`` + ``quorum info`` + ``quorum rotationinfo``:
+
+      * CQuorumDataRequest: if ``quorum info`` exposes a real member proTxHash we
+        use it with nDataMask=3 (VV|EC); otherwise we fall back to a zero proTxHash
+        with nDataMask=1 (verification-vector only). Both shapes are structurally
+        valid per the protocol.
+      * CQuorumSnapshot: prefer snapshots returned by ``quorum rotationinfo``
+        (``quorumSnapshotAtHMinus{C,2C,3C}`` and ``quorumSnapshotList``), whose
+        ``activeQuorumMembers`` / ``mnSkipListMode`` / ``mnSkipList`` fields are
+        serialized verbatim. Fall back to the ``quorum info`` member-validity
+        bitmap with an empty skip list + MODE_NO_SKIPPING if rotationinfo is
+        unavailable for that quorum.
+      * CGetQuorumRotationInfo: serialize the exact requests that rotationinfo
+        actually answered (blockRequestHash == quorumHash, empty baseBlockHashes,
+        extraShare=false). Only fall back to a tip-hash + quorum-hash composite
+        when no rotationinfo request succeeded.
     """
     print("Extracting quorum data...")
     result = dash_cli("quorum", "list", datadir=datadir)
@@ -423,48 +621,222 @@ def extract_quorum_info(output_dir, datadir=None):
 
     # quorum info expects a numeric llmqType, but quorum list returns string keys
     llmq_type_map = {
-        "llmq_50_60": "1",
-        "llmq_400_60": "2",
-        "llmq_400_85": "3",
-        "llmq_100_67": "4",
-        "llmq_60_75": "5",
-        "llmq_25_67": "6",
-        "llmq_test": "100",
-        "llmq_devnet": "101",
-        "llmq_test_v17": "102",
-        "llmq_test_dip0024": "103",
-        "llmq_test_instantsend": "104",
-        "llmq_devnet_dip0024": "105",
-        "llmq_test_platform": "106",
-        "llmq_devnet_platform": "107",
+        "llmq_50_60": 1,
+        "llmq_400_60": 2,
+        "llmq_400_85": 3,
+        "llmq_100_67": 4,
+        "llmq_60_75": 5,
+        "llmq_25_67": 6,
+        "llmq_test": 100,
+        "llmq_devnet": 101,
+        "llmq_test_v17": 102,
+        "llmq_test_dip0024": 103,
+        "llmq_test_instantsend": 104,
+        "llmq_devnet_dip0024": 105,
+        "llmq_test_platform": 106,
+        "llmq_devnet_platform": 107,
     }
 
     saved = 0
     try:
         quorum_list = json.loads(result)
-        for qtype, hashes in quorum_list.items():
-            numeric_type = llmq_type_map.get(qtype)
-            if numeric_type is None:
-                print(f"WARNING: Unknown quorum type '{qtype}', skipping", file=sys.stderr)
-                continue
-            for qhash in hashes[:5]:  # Limit per type
-                # Get the quorum commitment transaction via selectquorum
-                # which gives us the quorumHash we can look up in blocks
-                qinfo_str = dash_cli("quorum", "info", numeric_type, qhash, datadir=datadir)
-                if not qinfo_str:
-                    continue
-                try:
-                    qinfo = json.loads(qinfo_str)
-                except json.JSONDecodeError:
-                    continue
-                # Extract the commitment tx if available
-                mining_hash = qinfo.get("minedBlock", "")
-                if mining_hash:
-                    block_hex = dash_cli("getblock", mining_hash, "0", datadir=datadir)
-                    if block_hex and save_corpus_input(output_dir, "block_deserialize", block_hex):
-                        saved += 1
     except (json.JSONDecodeError, AttributeError):
-        pass
+        return 0
+
+    if not isinstance(quorum_list, dict):
+        return 0
+
+    # Collect quorum hashes across types (used as a fallback for
+    # CGetQuorumRotationInfo seeds if no rotationinfo request succeeds).
+    all_quorum_hashes = []
+    # Track the exact (blockRequestHash, baseBlockHashes, extraShare) tuples
+    # for which we successfully invoked `quorum rotationinfo` — these become
+    # the preferred CGetQuorumRotationInfo seeds.
+    successful_rotation_requests = []
+
+    for qtype, hashes in quorum_list.items():
+        numeric_type = llmq_type_map.get(qtype)
+        if numeric_type is None:
+            print(f"WARNING: Unknown quorum type '{qtype}', skipping", file=sys.stderr)
+            continue
+        if not isinstance(hashes, list):
+            continue
+
+        for qhash in hashes[:5]:  # Limit per type
+            if not isinstance(qhash, str) or not qhash:
+                continue
+            all_quorum_hashes.append(qhash)
+
+            # Fetch quorum info once up-front so we can both pull a real
+            # member proTxHash for CQuorumDataRequest and use its
+            # member-validity bitmap as a CQuorumSnapshot fallback.
+            qinfo = None
+            qinfo_str = dash_cli("quorum", "info", str(numeric_type), qhash, datadir=datadir)
+            if qinfo_str:
+                try:
+                    parsed = json.loads(qinfo_str)
+                except json.JSONDecodeError:
+                    parsed = None
+                if isinstance(parsed, dict):
+                    qinfo = parsed
+
+            # --- Seed dash_quorum_data_request_{deserialize,roundtrip} ---
+            # If we have a real member proTxHash, emit a VV|EC request (mask=3);
+            # otherwise emit a zero-proTxHash VV-only request (mask=1). Both
+            # match the CQuorumDataRequest protocol surface.
+            member_protx = ""
+            if qinfo:
+                members = qinfo.get("members", [])
+                if isinstance(members, list):
+                    for m in members:
+                        if not isinstance(m, dict):
+                            continue
+                        p = m.get("proTxHash", "")
+                        if isinstance(p, str) and p:
+                            member_protx = p
+                            break
+            n_data_mask = 3 if member_protx else 1
+            try:
+                qdr = serialize_quorum_data_request(
+                    numeric_type, qhash, member_protx, n_data_mask=n_data_mask
+                )
+            except ValueError as e:
+                print(f"WARNING: Skipping CQuorumDataRequest seed for {qhash}: {e}", file=sys.stderr)
+            else:
+                seed_hex = qdr.hex()
+                for target in [
+                    "dash_quorum_data_request_deserialize",
+                    "dash_quorum_data_request_roundtrip",
+                ]:
+                    if save_corpus_input(output_dir, target, seed_hex):
+                        saved += 1
+
+            # --- Seed dash_quorum_snapshot_{deserialize,roundtrip} ---
+            # Prefer real rotationinfo snapshots when available.
+            snapshot_seeded = False
+            rot_str = dash_cli("quorum", "rotationinfo", qhash, "false", datadir=datadir)
+            rot_info = None
+            if rot_str:
+                try:
+                    parsed = json.loads(rot_str)
+                except json.JSONDecodeError:
+                    parsed = None
+                if isinstance(parsed, dict):
+                    rot_info = parsed
+                    successful_rotation_requests.append((qhash, [], False))
+
+            if rot_info is not None:
+                snapshot_candidates = []
+                for key in (
+                    "quorumSnapshotAtHMinusC",
+                    "quorumSnapshotAtHMinus2C",
+                    "quorumSnapshotAtHMinus3C",
+                ):
+                    s = rot_info.get(key)
+                    if isinstance(s, dict):
+                        snapshot_candidates.append(s)
+                snap_list = rot_info.get("quorumSnapshotList", [])
+                if isinstance(snap_list, list):
+                    snapshot_candidates.extend(s for s in snap_list if isinstance(s, dict))
+
+                for snap in snapshot_candidates:
+                    active_raw = snap.get("activeQuorumMembers", [])
+                    skip_list_raw = snap.get("mnSkipList", [])
+                    skip_mode_raw = snap.get("mnSkipListMode", 0)
+                    if not isinstance(active_raw, list):
+                        continue
+                    if not isinstance(skip_list_raw, list):
+                        skip_list_raw = []
+                    try:
+                        skip_mode_int = int(skip_mode_raw)
+                    except (TypeError, ValueError):
+                        skip_mode_int = 0
+                    try:
+                        snap_bytes = serialize_quorum_snapshot(
+                            [bool(x) for x in active_raw],
+                            [int(x) for x in skip_list_raw],
+                            mn_skip_list_mode=skip_mode_int,
+                        )
+                    except (ValueError, OverflowError, TypeError) as e:
+                        print(
+                            f"WARNING: Skipping rotationinfo CQuorumSnapshot seed for {qhash}: {e}",
+                            file=sys.stderr,
+                        )
+                        continue
+                    seed_hex = snap_bytes.hex()
+                    for target in [
+                        "dash_quorum_snapshot_deserialize",
+                        "dash_quorum_snapshot_roundtrip",
+                    ]:
+                        if save_corpus_input(output_dir, target, seed_hex):
+                            saved += 1
+                    snapshot_seeded = True
+
+            # Fall back to the quorum-info-derived approximation only when
+            # rotationinfo didn't yield a usable snapshot.
+            if not snapshot_seeded and qinfo:
+                members = qinfo.get("members", [])
+                if isinstance(members, list) and members:
+                    active = [bool(m.get("valid", False)) for m in members if isinstance(m, dict)]
+                    try:
+                        snap = serialize_quorum_snapshot(active, [])
+                    except (ValueError, OverflowError) as e:
+                        print(
+                            f"WARNING: Skipping CQuorumSnapshot seed for {qhash}: {e}",
+                            file=sys.stderr,
+                        )
+                    else:
+                        seed_hex = snap.hex()
+                        for target in [
+                            "dash_quorum_snapshot_deserialize",
+                            "dash_quorum_snapshot_roundtrip",
+                        ]:
+                            if save_corpus_input(output_dir, target, seed_hex):
+                                saved += 1
+
+    # --- Seed dash_get_quorum_rotation_info_{deserialize,roundtrip} ---
+    # Prefer the exact requests rotationinfo actually answered. Each is a
+    # minimal (blockRequestHash, [], extraShare=false) tuple matching the
+    # CLI call we issued above.
+    variants = []
+    if successful_rotation_requests:
+        for block_request_hash, base_hashes, extra_share in successful_rotation_requests[:8]:
+            try:
+                variants.append(
+                    serialize_get_quorum_rotation_info(
+                        block_request_hash, base_hashes, extra_share=extra_share
+                    )
+                )
+            except ValueError as e:
+                print(f"WARNING: Skipping CGetQuorumRotationInfo seed: {e}", file=sys.stderr)
+    elif all_quorum_hashes:
+        # Fallback when no rotationinfo call succeeded: synthesize tip-hash
+        # + quorum-hash variants so the corpus isn't empty.
+        tip_hash = dash_cli("getbestblockhash", datadir=datadir)
+        if tip_hash:
+            try:
+                variants.append(
+                    serialize_get_quorum_rotation_info(
+                        tip_hash, all_quorum_hashes[:8], extra_share=False
+                    )
+                )
+                variants.append(
+                    serialize_get_quorum_rotation_info(
+                        tip_hash, all_quorum_hashes[:1], extra_share=True
+                    )
+                )
+            except ValueError as e:
+                print(f"WARNING: Skipping CGetQuorumRotationInfo fallback seeds: {e}", file=sys.stderr)
+                variants = []
+
+    for seed in variants:
+        seed_hex = seed.hex()
+        for target in [
+            "dash_get_quorum_rotation_info_deserialize",
+            "dash_get_quorum_rotation_info_roundtrip",
+        ]:
+            if save_corpus_input(output_dir, target, seed_hex):
+                saved += 1
 
     print(f"  Saved {saved} quorum corpus inputs")
     return saved

--- a/contrib/fuzz/seed_corpus_from_chain.py
+++ b/contrib/fuzz/seed_corpus_from_chain.py
@@ -19,8 +19,10 @@ Requirements:
 import argparse
 import hashlib
 import json
+import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -38,6 +40,18 @@ def dash_cli(*args, datadir=None):
         return None
 
 
+def _read_protocol_version():
+    """Read PROTOCOL_VERSION from src/version.h."""
+    version_header = Path(__file__).resolve().parents[2] / "src" / "version.h"
+    match = re.search(
+        r"static\s+const\s+int\s+PROTOCOL_VERSION\s*=\s*(\d+)\s*;",
+        version_header.read_text(encoding="utf-8"),
+    )
+    if not match:
+        raise RuntimeError(f"Could not parse PROTOCOL_VERSION from {version_header}")
+    return int(match.group(1))
+
+
 # Must match src/version.h PROTOCOL_VERSION. Several fuzz harnesses read a
 # 4-byte little-endian int from the start of the buffer and use it as the
 # stream version before deserializing the object:
@@ -52,12 +66,21 @@ def dash_cli(*args, datadir=None):
 #     passed.
 # Chain data we extract is serialized at PROTOCOL_VERSION, so we prepend
 # that value to seeds for those targets.
-STREAM_VERSION = 70240
+PROTOCOL_VERSION = _read_protocol_version()
+STREAM_VERSION = PROTOCOL_VERSION
 STREAM_VERSION_PREFIX = STREAM_VERSION.to_bytes(4, byteorder="little", signed=False)
 
 # Non-Dash targets (outside the dash_* naming convention) whose harnesses
 # also consume the 4-byte stream version prefix described above.
 _NON_DASH_STREAM_VERSION_TARGETS = frozenset({"block", "block_deserialize", "blockmerkleroot"})
+_DESERIALIZE_ONLY_DASH_TARGETS = frozenset(
+    {
+        "dash_governance_vote_deserialize",
+        "dash_vote_instance_deserialize",
+        "dash_vote_rec_deserialize",
+        "dash_governance_vote_file_deserialize",
+    }
+)
 
 
 def _needs_stream_version_prefix(target_name):
@@ -116,6 +139,31 @@ def _var_bytes(b):
     return _compact_size(len(b)) + b
 
 
+def _var_list(items):
+    """CompactSize length prefix + concatenated serialized entries."""
+    return _compact_size(len(items)) + b"".join(items)
+
+
+def _serialize_int32(value):
+    return int(value).to_bytes(4, "little", signed=True)
+
+
+def _serialize_uint32(value):
+    return int(value).to_bytes(4, "little", signed=False)
+
+
+def _serialize_int64(value):
+    return int(value).to_bytes(8, "little", signed=True)
+
+
+def _serialize_uint64(value):
+    return int(value).to_bytes(8, "little", signed=False)
+
+
+def _serialize_bool(value):
+    return bytes([1 if value else 0])
+
+
 def _uint256_from_hex(h):
     """Convert an RPC-form uint256 hex string (big-endian display) to its 32-byte
     wire representation (little-endian internal). Empty/missing input -> zero hash.
@@ -143,6 +191,134 @@ def _parse_outpoint_short(s):
         return _uint256_from_hex(txid) + n.to_bytes(4, "little")
     except ValueError:
         return b"\x00" * 32 + (0).to_bytes(4, "little")
+
+
+def _serialize_outpoint(txid_hex="", n=0):
+    return _uint256_from_hex(txid_hex) + _serialize_uint32(n)
+
+
+def _serialize_dynbitset(bits):
+    count = len(bits)
+    nbytes = (count + 7) // 8
+    buf = bytearray(nbytes)
+    for i, value in enumerate(bits):
+        if value:
+            buf[i // 8] |= 1 << (i % 8)
+    return _compact_size(count) + bytes(buf)
+
+
+def _serialize_string(value):
+    return _var_bytes(value.encode("utf-8"))
+
+
+def _serialize_txin(prev_txid_hex="", prev_n=0, script_sig=b"", sequence=0xFFFFFFFF):
+    return _serialize_outpoint(prev_txid_hex, prev_n) + _var_bytes(script_sig) + _serialize_uint32(sequence)
+
+
+def _serialize_txout(value=0, script_pubkey=b""):
+    return int(value).to_bytes(8, "little", signed=True) + _var_bytes(script_pubkey)
+
+
+def _serialize_transaction(vin=None, vout=None, n_version=2, n_type=0, n_lock_time=0, extra_payload=b""):
+    vin = list(vin or [])
+    vout = list(vout or [])
+    n32bit_version = (int(n_version) & 0xFFFF) | ((int(n_type) & 0xFFFF) << 16)
+    out = _serialize_uint32(n32bit_version)
+    out += _var_list(vin)
+    out += _var_list(vout)
+    out += _serialize_uint32(n_lock_time)
+    if n_version >= 3 and n_type != 0:
+        out += _var_bytes(extra_payload)
+    return out
+
+
+def _final_commitment_from_tx_payload(payload_hex):
+    """Extract the embedded CFinalCommitment from a CFinalCommitmentTxPayload."""
+    try:
+        payload = bytes.fromhex(payload_hex)
+    except ValueError as e:
+        raise ValueError("payload is not valid hex") from e
+    if len(payload) < 6:
+        raise ValueError("payload too short for CFinalCommitmentTxPayload header")
+    return payload[6:]
+
+
+_GOVERNANCE_OUTCOME_NAME_TO_INT = {
+    "none": 0,
+    "yes": 1,
+    "no": 2,
+    "abstain": 3,
+}
+
+_GOVERNANCE_SIGNAL_NAME_TO_INT = {
+    "none": 0,
+    "funding": 1,
+    "valid": 2,
+    "delete": 3,
+    "endorsed": 4,
+}
+
+
+def parse_governance_vote_record(vote_record, parent_hash_hex):
+    """Parse one `gobject getcurrentvotes` string into CGovernanceVote fields."""
+    if not isinstance(vote_record, str):
+        raise ValueError("vote record must be a string")
+    parts = vote_record.split(":")
+    if len(parts) != 5:
+        raise ValueError(f"unexpected governance vote format: {vote_record!r}")
+    outpoint_text, timestamp_text, outcome_text, signal_text, _vote_weight = parts
+    if "-" not in outpoint_text:
+        raise ValueError(f"unexpected masternode outpoint format: {outpoint_text!r}")
+    txid_text, _, n_text = outpoint_text.rpartition("-")
+    try:
+        timestamp = int(timestamp_text)
+    except ValueError as e:
+        raise ValueError(f"invalid governance vote timestamp: {timestamp_text!r}") from e
+    outcome = _GOVERNANCE_OUTCOME_NAME_TO_INT.get(outcome_text.lower())
+    if outcome is None:
+        raise ValueError(f"unknown governance vote outcome: {outcome_text!r}")
+    signal = _GOVERNANCE_SIGNAL_NAME_TO_INT.get(signal_text.lower())
+    if signal is None:
+        raise ValueError(f"unknown governance vote signal: {signal_text!r}")
+    return {
+        "masternode_txid": txid_text,
+        "masternode_n": int(n_text),
+        "parent_hash": parent_hash_hex,
+        "outcome": outcome,
+        "signal": signal,
+        "timestamp": timestamp,
+        "signature": b"",
+    }
+
+
+def serialize_governance_vote(parsed_vote):
+    """Serialize CGovernanceVote exactly as in src/governance/vote.h."""
+    return (
+        _serialize_outpoint(parsed_vote["masternode_txid"], parsed_vote["masternode_n"])
+        + _uint256_from_hex(parsed_vote["parent_hash"])
+        + _serialize_int32(parsed_vote["outcome"])
+        + _serialize_int32(parsed_vote["signal"])
+        + _serialize_int64(parsed_vote["timestamp"])
+        + _var_bytes(parsed_vote.get("signature", b""))
+    )
+
+
+def serialize_vote_instance(outcome, updated_time, creation_time):
+    """Serialize vote_instance_t exactly as in src/governance/object.h."""
+    return _serialize_int32(outcome) + _serialize_int64(updated_time) + _serialize_int64(creation_time)
+
+
+def serialize_vote_rec(signal_to_instance):
+    """Serialize vote_rec_t (std::map<int, vote_instance_t>)."""
+    items = []
+    for signal, instance in sorted(signal_to_instance.items()):
+        items.append(_serialize_int32(signal) + instance)
+    return _var_list(items)
+
+
+def serialize_governance_vote_file(votes):
+    """Serialize CGovernanceObjectVoteFile from a list of serialized CGovernanceVote entries."""
+    return _serialize_int32(len(votes)) + _var_list(votes)
 
 
 def serialize_governance_object(obj_data):
@@ -449,6 +625,19 @@ def extract_special_txs(output_dir, count=100, datadir=None):
                     if save_corpus_input(output_dir, f"{target}{suffix}", payload_hex):
                         saved += 1
 
+                if tx_type == 6:
+                    try:
+                        commitment_hex = _final_commitment_from_tx_payload(payload_hex).hex()
+                    except ValueError as e:
+                        print(
+                            f"WARNING: Skipping final commitment seed for tx {txid}: {e}",
+                            file=sys.stderr,
+                        )
+                    else:
+                        for suffix in ["_deserialize", "_roundtrip"]:
+                            if save_corpus_input(output_dir, f"dash_final_commitment{suffix}", commitment_hex):
+                                saved += 1
+
     print(f"  Saved {saved} special transaction corpus inputs")
     return saved
 
@@ -482,6 +671,10 @@ def extract_governance_objects(output_dir, datadir=None):
         "dash_governance_object_deserialize",
         "dash_governance_object_roundtrip",
     ]
+    vote_targets = ["dash_governance_vote_deserialize"]
+    vote_instance_targets = ["dash_vote_instance_deserialize"]
+    vote_rec_targets = ["dash_vote_rec_deserialize"]
+    vote_file_targets = ["dash_governance_vote_file_deserialize"]
 
     for obj_hash, obj_data in objects.items():
         if not isinstance(obj_data, dict):
@@ -495,6 +688,55 @@ def extract_governance_objects(output_dir, datadir=None):
         for target in targets:
             if save_corpus_input(output_dir, target, seed_hex):
                 saved += 1
+
+        votes_result = dash_cli("gobject", "getcurrentvotes", obj_hash, datadir=datadir)
+        if not votes_result:
+            continue
+        try:
+            votes_map = json.loads(votes_result)
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if not isinstance(votes_map, dict):
+            continue
+
+        serialized_votes = []
+        signal_to_instance = {}
+        for vote_hash, vote_record in votes_map.items():
+            del vote_hash  # Key is informational only; serialized vote recomputes its own hash.
+            try:
+                parsed_vote = parse_governance_vote_record(vote_record, obj_hash)
+                serialized_vote = serialize_governance_vote(parsed_vote)
+            except (ValueError, OverflowError) as e:
+                print(f"WARNING: Skipping governance vote for {obj_hash}: {e}", file=sys.stderr)
+                continue
+
+            serialized_votes.append(serialized_vote)
+            vote_hex = serialized_vote.hex()
+            for target in vote_targets:
+                if save_corpus_input(output_dir, target, vote_hex):
+                    saved += 1
+
+            updated_time = parsed_vote["timestamp"]
+            instance = serialize_vote_instance(
+                parsed_vote["outcome"], updated_time, updated_time
+            )
+            signal_to_instance[parsed_vote["signal"]] = instance
+            instance_hex = instance.hex()
+            for target in vote_instance_targets:
+                if save_corpus_input(output_dir, target, instance_hex):
+                    saved += 1
+
+        if signal_to_instance:
+            vote_rec_hex = serialize_vote_rec(signal_to_instance).hex()
+            for target in vote_rec_targets:
+                if save_corpus_input(output_dir, target, vote_rec_hex):
+                    saved += 1
+
+        if serialized_votes:
+            vote_file_hex = serialize_governance_vote_file(serialized_votes).hex()
+            for target in vote_file_targets:
+                if save_corpus_input(output_dir, target, vote_file_hex):
+                    saved += 1
 
     print(f"  Saved {saved} governance corpus inputs")
     return saved
@@ -851,19 +1093,80 @@ def create_synthetic_seeds(output_dir):
     print("Creating synthetic seed inputs...")
     saved = 0
 
+    minimal_tx = _serialize_transaction()
+    minimal_txin = _serialize_txin()
+    minimal_txout = _serialize_txout()
+    minimal_final_commitment = (
+        (3).to_bytes(2, "little")
+        + bytes([1])
+        + b"\x00" * 32
+        + _serialize_dynbitset([])
+        + _serialize_dynbitset([])
+        + b"\x00" * 48
+        + b"\x00" * 32
+        + b"\x00" * 96
+        + b"\x00" * 96
+    )
+    minimal_governance_vote = serialize_governance_vote(
+        {
+            "masternode_txid": "00" * 32,
+            "masternode_n": 0,
+            "parent_hash": "00" * 32,
+            "outcome": 1,
+            "signal": 1,
+            "timestamp": 0,
+            "signature": b"",
+        }
+    )
+    minimal_vote_instance = serialize_vote_instance(1, 0, 0)
+    minimal_vote_rec = serialize_vote_rec({1: minimal_vote_instance})
+    minimal_vote_file = serialize_governance_vote_file([minimal_governance_vote])
+    minimal_bls_ies_blob = b"\x00" * 48 + b"\x00" * 32 + _var_bytes(b"seed")
+    minimal_bls_ies_multi = b"\x00" * 48 + b"\x00" * 32 + _var_list([_var_bytes(b"seed0"), _var_bytes(b"seed1")])
+    minimal_coinjoin_entry = _var_list([minimal_txin]) + minimal_tx + _var_list([minimal_txout])
+    minimal_coinjoin_broadcast_tx = minimal_tx + b"\x00" * 32 + _var_bytes(b"") + _serialize_int64(0)
+    minimal_premature_commitment = (
+        bytes([1])
+        + b"\x00" * 32
+        + b"\x00" * 32
+        + _serialize_dynbitset([True])
+        + b"\x00" * 48
+        + b"\x00" * 32
+        + b"\x00" * 96
+        + b"\x00" * 96
+    )
+
     # Targets that need synthetic seeds (serialized structs with known formats)
     synthetic_seeds = {
         # CoinJoin messages — minimal valid-ish payloads
         "dash_coinjoin_accept_deserialize": [
-            "00000000" + "00" * 4,  # nDenom(4) + txCollateral
+            (_serialize_int32(0) + minimal_tx).hex(),  # nDenom + txCollateral
+        ],
+        "dash_coinjoin_entry_deserialize": [
+            minimal_coinjoin_entry.hex(),
         ],
         "dash_coinjoin_queue_deserialize": [
-            "00000000" + "00" * 48 + "00" * 96 + "0000000000000000",  # nDenom + proTxHash + vchSig + nTime
+            (
+                _serialize_int32(0)
+                + b"\x00" * 32
+                + _serialize_int64(0)
+                + _serialize_bool(False)
+                + _var_bytes(b"")
+            ).hex(),
         ],
         "dash_coinjoin_status_update_deserialize": [
-            "00000000" + "00000000" + "00000000",  # nSessionID + nState + nStatusUpdate
+            (_serialize_int32(0) + _serialize_int32(0) + _serialize_int32(0) + _serialize_int32(0)).hex(),
+        ],
+        "dash_coinjoin_broadcast_tx_deserialize": [
+            minimal_coinjoin_broadcast_tx.hex(),
         ],
         # LLMQ messages
+        "dash_final_commitment_deserialize": [
+            minimal_final_commitment.hex(),
+        ],
+        "dash_final_commitment_tx_payload_deserialize": [
+            ((1).to_bytes(2, "little") + _serialize_uint32(0) + minimal_final_commitment).hex(),
+        ],
         "dash_recovered_sig_deserialize": [
             "64" + "00" * 32 + "00" * 32 + "00" * 96,  # llmqType + quorumHash + id + sig
         ],
@@ -881,6 +1184,29 @@ def create_synthetic_seeds(output_dir):
         "dash_dkg_complaint_deserialize": [
             "64" + "00" * 32 + "00" * 32 + "0000" + "00",  # minimal
         ],
+        "dash_dkg_premature_commitment_deserialize": [
+            minimal_premature_commitment.hex(),
+        ],
+        # Governance
+        "dash_governance_vote_deserialize": [
+            minimal_governance_vote.hex(),
+        ],
+        "dash_vote_instance_deserialize": [
+            minimal_vote_instance.hex(),
+        ],
+        "dash_vote_rec_deserialize": [
+            minimal_vote_rec.hex(),
+        ],
+        "dash_governance_vote_file_deserialize": [
+            minimal_vote_file.hex(),
+        ],
+        # BLS IES
+        "dash_bls_ies_encrypted_blob_deserialize": [
+            minimal_bls_ies_blob.hex(),
+        ],
+        "dash_bls_ies_multi_recipient_blobs_deserialize": [
+            minimal_bls_ies_multi.hex(),
+        ],
     }
 
     for target, seeds in synthetic_seeds.items():
@@ -889,11 +1215,55 @@ def create_synthetic_seeds(output_dir):
                 saved += 1
             # Also save roundtrip variant
             roundtrip_target = target.replace("_deserialize", "_roundtrip")
-            if save_corpus_input(output_dir, roundtrip_target, seed_hex):
+            if target not in _DESERIALIZE_ONLY_DASH_TARGETS and save_corpus_input(output_dir, roundtrip_target, seed_hex):
                 saved += 1
 
     print(f"  Created {saved} synthetic seed inputs")
     return saved
+
+
+def _run_helper_self_checks():
+    """Deterministic checks for new governance/final-commitment helpers."""
+    parsed_vote = parse_governance_vote_record(
+        "11" * 32 + "-2:1700000000:yes:funding:1",
+        "22" * 32,
+    )
+    assert parsed_vote["masternode_txid"] == "11" * 32
+    assert parsed_vote["masternode_n"] == 2
+    assert parsed_vote["signal"] == 1
+    assert parsed_vote["outcome"] == 1
+    vote_bytes = serialize_governance_vote(parsed_vote)
+    assert len(vote_bytes) == 32 + 4 + 32 + 4 + 4 + 8 + 1
+
+    vote_instance = serialize_vote_instance(1, 1700000000, 1690000000)
+    assert len(vote_instance) == 20
+    vote_rec = serialize_vote_rec({1: vote_instance, 2: serialize_vote_instance(2, 1700000100, 1690000000)})
+    assert vote_rec.startswith(b"\x02")
+    vote_file = serialize_governance_vote_file([vote_bytes])
+    assert vote_file[:4] == _serialize_int32(1)
+
+    payload = bytes.fromhex("0100") + _serialize_uint32(42) + b"\xaa\xbb\xcc"
+    assert _final_commitment_from_tx_payload(payload.hex()) == b"\xaa\xbb\xcc"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
+        create_synthetic_seeds(tmp_path)
+        required_targets = [
+            "dash_final_commitment_deserialize",
+            "dash_final_commitment_roundtrip",
+            "dash_governance_vote_deserialize",
+            "dash_vote_instance_deserialize",
+            "dash_vote_rec_deserialize",
+            "dash_governance_vote_file_deserialize",
+            "dash_bls_ies_encrypted_blob_deserialize",
+            "dash_bls_ies_encrypted_blob_roundtrip",
+            "dash_bls_ies_multi_recipient_blobs_deserialize",
+            "dash_bls_ies_multi_recipient_blobs_roundtrip",
+            "dash_coinjoin_entry_deserialize",
+            "dash_coinjoin_entry_roundtrip",
+        ]
+        missing = [target for target in required_targets if not any((tmp_path / target).iterdir())]
+        assert not missing, f"missing synthetic seeds for: {', '.join(missing)}"
 
 
 def main():

--- a/contrib/fuzz/seed_corpus_from_chain.py
+++ b/contrib/fuzz/seed_corpus_from_chain.py
@@ -57,7 +57,7 @@ STREAM_VERSION_PREFIX = STREAM_VERSION.to_bytes(4, byteorder="little", signed=Fa
 
 # Non-Dash targets (outside the dash_* naming convention) whose harnesses
 # also consume the 4-byte stream version prefix described above.
-_NON_DASH_STREAM_VERSION_TARGETS = frozenset({"block", "block_deserialize"})
+_NON_DASH_STREAM_VERSION_TARGETS = frozenset({"block", "block_deserialize", "blockmerkleroot"})
 
 
 def _needs_stream_version_prefix(target_name):
@@ -210,6 +210,8 @@ def extract_blocks(output_dir, count=20, datadir=None):
             if save_corpus_input(output_dir, "block_deserialize", block_hex):
                 saved += 1
             if save_corpus_input(output_dir, "block", block_hex):
+                saved += 1
+            if save_corpus_input(output_dir, "blockmerkleroot", block_hex):
                 saved += 1
 
     print(f"  Saved {saved} block corpus inputs")

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -278,11 +278,13 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/addrman.cpp \
  test/fuzz/asmap.cpp \
  test/fuzz/asmap_direct.cpp \
+ test/fuzz/asset_lock_unlock.cpp \
  test/fuzz/autofile.cpp \
  test/fuzz/banman.cpp \
  test/fuzz/base_encode_decode.cpp \
  test/fuzz/bech32.cpp \
  test/fuzz/bip324.cpp \
+ test/fuzz/bls_operations.cpp \
  test/fuzz/block.cpp \
  test/fuzz/block_header.cpp \
  test/fuzz/blockfilter.cpp \
@@ -290,6 +292,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/buffered_file.cpp \
  test/fuzz/chain.cpp \
  test/fuzz/checkqueue.cpp \
+ test/fuzz/coinjoin.cpp \
  test/fuzz/coins_view.cpp \
  test/fuzz/coinscache_sim.cpp \
  test/fuzz/connman.cpp \
@@ -305,18 +308,23 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/decode_tx.cpp \
  test/fuzz/descriptor_parse.cpp \
  test/fuzz/deserialize.cpp \
+ test/fuzz/deserialize_dash.cpp \
+ test/fuzz/deterministic_mn_list_diff.cpp \
+ test/fuzz/simplified_mn_list_diff.cpp \
  test/fuzz/eval_script.cpp \
  test/fuzz/fee_rate.cpp \
  test/fuzz/fees.cpp \
  test/fuzz/flatfile.cpp \
  test/fuzz/float.cpp \
  test/fuzz/golomb_rice.cpp \
+ test/fuzz/governance_proposal_validator.cpp \
  test/fuzz/hex.cpp \
  test/fuzz/http_request.cpp \
  test/fuzz/integer.cpp \
  test/fuzz/key.cpp \
  test/fuzz/key_io.cpp \
  test/fuzz/kitchen_sink.cpp \
+ test/fuzz/llmq_messages.cpp \
  test/fuzz/load_external_block_file.cpp \
  test/fuzz/locale.cpp \
  test/fuzz/merkleblock.cpp \
@@ -342,11 +350,13 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/prevector.cpp \
  test/fuzz/primitives_transaction.cpp \
  test/fuzz/process_message.cpp \
+ test/fuzz/process_message_dash.cpp \
  test/fuzz/process_messages.cpp \
  test/fuzz/protocol.cpp \
  test/fuzz/psbt.cpp \
  test/fuzz/random.cpp \
  test/fuzz/rolling_bloom_filter.cpp \
+ test/fuzz/roundtrip_dash.cpp \
  test/fuzz/rpc.cpp \
  test/fuzz/script.cpp \
  test/fuzz/script_bitcoin_consensus.cpp \
@@ -361,6 +371,7 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/secp256k1_ec_seckey_import_export_der.cpp \
  test/fuzz/secp256k1_ecdsa_signature_parse_der_lax.cpp \
  test/fuzz/signature_checker.cpp \
+ test/fuzz/special_tx_validation.cpp \
  test/fuzz/socks5.cpp \
  test/fuzz/span.cpp \
  test/fuzz/spanparsing.cpp \

--- a/src/Makefile.test_fuzz.include
+++ b/src/Makefile.test_fuzz.include
@@ -11,6 +11,7 @@ TEST_FUZZ_H = \
     test/fuzz/fuzz.h \
     test/fuzz/FuzzedDataProvider.h \
     test/fuzz/util.h \
+    test/fuzz/util_dash.h \
     test/util/mining.h \
     test/fuzz/util/net.h
 

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -57,10 +57,10 @@ bool CCoinJoinQueue::CheckSignature(const CBLSPublicKey& blsPubKey) const
 
 bool CCoinJoinQueue::IsTimeOutOfBounds(int64_t current_time) const
 {
+    // Both operands are gated to be non-negative, so the differences cannot overflow int64_t.
     if (current_time < 0 || nTime < 0) return true;
-    const uint64_t diff = (current_time > nTime) ? static_cast<uint64_t>(current_time) - static_cast<uint64_t>(nTime)
-                                                 : static_cast<uint64_t>(nTime) - static_cast<uint64_t>(current_time);
-    return diff > static_cast<uint64_t>(COINJOIN_QUEUE_TIMEOUT);
+    return current_time - nTime > COINJOIN_QUEUE_TIMEOUT ||
+           nTime - current_time > COINJOIN_QUEUE_TIMEOUT;
 }
 
 [[nodiscard]] std::string CCoinJoinQueue::ToString() const

--- a/src/coinjoin/coinjoin.cpp
+++ b/src/coinjoin/coinjoin.cpp
@@ -58,8 +58,9 @@ bool CCoinJoinQueue::CheckSignature(const CBLSPublicKey& blsPubKey) const
 bool CCoinJoinQueue::IsTimeOutOfBounds(int64_t current_time) const
 {
     if (current_time < 0 || nTime < 0) return true;
-    return current_time - nTime > COINJOIN_QUEUE_TIMEOUT ||
-           nTime - current_time > COINJOIN_QUEUE_TIMEOUT;
+    const uint64_t diff = (current_time > nTime) ? static_cast<uint64_t>(current_time) - static_cast<uint64_t>(nTime)
+                                                 : static_cast<uint64_t>(nTime) - static_cast<uint64_t>(current_time);
+    return diff > static_cast<uint64_t>(COINJOIN_QUEUE_TIMEOUT);
 }
 
 [[nodiscard]] std::string CCoinJoinQueue::ToString() const

--- a/src/coinjoin/common.h
+++ b/src/coinjoin/common.h
@@ -10,7 +10,9 @@
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
 
+#include <algorithm>
 #include <array>
+#include <limits>
 #include <string>
 
 /** Holds a mixing input
@@ -128,7 +130,8 @@ constexpr int CalculateAmountPriority(CAmount nInputAmount)
     }
 
     //nondenom return largest first
-    return -1 * (nInputAmount / COIN);
+    const int64_t val = -(nInputAmount / COIN);
+    return int(std::clamp<int64_t>(val, std::numeric_limits<int>::min(), std::numeric_limits<int>::max()));
 }
 
 } // namespace CoinJoin

--- a/src/coinjoin/common.h
+++ b/src/coinjoin/common.h
@@ -10,9 +10,7 @@
 #include <consensus/amount.h>
 #include <primitives/transaction.h>
 
-#include <algorithm>
 #include <array>
-#include <limits>
 #include <string>
 
 /** Holds a mixing input
@@ -130,8 +128,9 @@ constexpr int CalculateAmountPriority(CAmount nInputAmount)
     }
 
     //nondenom return largest first
-    const int64_t val = -(nInputAmount / COIN);
-    return int(std::clamp<int64_t>(val, std::numeric_limits<int>::min(), std::numeric_limits<int>::max()));
+    // nInputAmount is bounded to [0, MAX_MONEY] by the guard at the top of this function,
+    // so (nInputAmount / COIN) fits comfortably in int.
+    return -1 * (nInputAmount / COIN);
 }
 
 } // namespace CoinJoin

--- a/src/llmq/snapshot.h
+++ b/src/llmq/snapshot.h
@@ -78,6 +78,8 @@ public:
         size_t cnt = ReadCompactSize(s);
         ReadFixedBitSet(s, activeQuorumMembers, cnt);
         cnt = ReadCompactSize(s);
+        mnSkipList.clear();
+        mnSkipList.reserve(cnt);
         for ([[maybe_unused]] const auto _ : util::irange(cnt)) {
             int obj;
             s >> obj;

--- a/src/llmq/snapshot.h
+++ b/src/llmq/snapshot.h
@@ -78,8 +78,12 @@ public:
         size_t cnt = ReadCompactSize(s);
         ReadFixedBitSet(s, activeQuorumMembers, cnt);
         cnt = ReadCompactSize(s);
+        // Reset the destination so in-place re-deserialization (e.g. via CDBWrapper::Read
+        // reusing an existing snapshot object) doesn't append onto stale entries.
+        // Note: intentionally no reserve(cnt) — cnt comes from an unbounded ReadCompactSize
+        // on a P2P-reachable path (QRINFO), and eager reservation would let a peer force
+        // large allocations from a tiny message.
         mnSkipList.clear();
-        mnSkipList.reserve(cnt);
         for ([[maybe_unused]] const auto _ : util::irange(cnt)) {
             int obj;
             s >> obj;

--- a/src/test/fuzz/addrman.cpp
+++ b/src/test/fuzz/addrman.cpp
@@ -247,6 +247,8 @@ FUZZ_TARGET(addrman, .init = initialize_addrman)
             ds >> *addr_man_ptr;
         } catch (const std::ios_base::failure&) {
             addr_man_ptr = std::make_unique<AddrManDeterministic>(netgroupman, fuzzed_data_provider);
+        } catch (const DbInconsistentError&) {
+            addr_man_ptr = std::make_unique<AddrManDeterministic>(netgroupman, fuzzed_data_provider);
         }
     }
     AddrManDeterministic& addr_man = *addr_man_ptr;

--- a/src/test/fuzz/asset_lock_unlock.cpp
+++ b/src/test/fuzz/asset_lock_unlock.cpp
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <consensus/validation.h>
+#include <evo/assetlocktx.h>
+#include <evo/specialtx.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <version.h>
+
+#include <cassert>
+#include <cstdint>
+#include <exception>
+#include <limits>
+#include <vector>
+
+namespace {
+CScript ConsumeRandomScript(FuzzedDataProvider& fuzzed_data_provider, size_t max_size = 64)
+{
+    const std::vector<uint8_t> raw_script = fuzzed_data_provider.ConsumeBytes<uint8_t>(
+        fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, max_size));
+    return CScript(raw_script.begin(), raw_script.end());
+}
+
+CScript ConsumeP2PKHScript(FuzzedDataProvider& fuzzed_data_provider)
+{
+    const std::vector<uint8_t> key_hash = fuzzed_data_provider.ConsumeBytes<uint8_t>(20);
+    return CScript() << OP_DUP << OP_HASH160 << key_hash << OP_EQUALVERIFY << OP_CHECKSIG;
+}
+
+CAmount ConsumeAmount(FuzzedDataProvider& fuzzed_data_provider)
+{
+    return fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(-1, static_cast<CAmount>(MAX_MONEY) + 1);
+}
+
+std::vector<uint8_t> BuildAssetLockPayload(const uint8_t version, const std::vector<CTxOut>& credit_outputs)
+{
+    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+    ds << version;
+    ds << credit_outputs;
+    return {UCharCast(ds.data()), UCharCast(ds.data() + ds.size())};
+}
+
+CBLSSignature ConsumeBLSSignature(FuzzedDataProvider& fuzzed_data_provider)
+{
+    CBLSSignature sig;
+    auto bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(CBLSSignature::SerSize);
+    bytes.resize(CBLSSignature::SerSize);
+    sig.SetBytes(bytes, fuzzed_data_provider.ConsumeBool());
+    return sig;
+}
+
+void initialize_asset_lock_unlock() { SelectParams(CBaseChainParams::REGTEST); }
+} // namespace
+
+FUZZ_TARGET(asset_lock_tx, .init = initialize_asset_lock_unlock)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    CMutableTransaction tx;
+    tx.nVersion = CTransaction::SPECIAL_VERSION;
+    tx.nType = TRANSACTION_ASSET_LOCK;
+
+    std::vector<CTxOut> credit_outputs;
+    const size_t num_credit_outputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4);
+    CAmount credit_outputs_total{0};
+    for (size_t i = 0; i < num_credit_outputs; ++i) {
+        const CAmount amount = fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(1, 10 * COIN);
+        assert(MoneyRange(amount));
+        assert(MoneyRange(credit_outputs_total + amount));
+        credit_outputs_total += amount;
+        credit_outputs.emplace_back(amount, ConsumeP2PKHScript(fuzzed_data_provider));
+    }
+
+    SetTxPayload(tx, CAssetLockPayload(credit_outputs));
+
+    tx.vout.emplace_back(credit_outputs_total, CScript() << OP_RETURN << std::vector<uint8_t>{});
+
+    const size_t num_regular_outputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4);
+    for (size_t i = 0; i < num_regular_outputs; ++i) {
+        tx.vout.emplace_back(ConsumeAmount(fuzzed_data_provider), ConsumeRandomScript(fuzzed_data_provider));
+    }
+
+    const uint8_t scenario = fuzzed_data_provider.ConsumeIntegralInRange<uint8_t>(0, 11);
+    switch (scenario) {
+    case 0: // bad-assetlocktx-type
+        tx.nType = fuzzed_data_provider.ConsumeBool() ? TRANSACTION_ASSET_UNLOCK : TRANSACTION_NORMAL;
+        break;
+    case 1: // bad-assetlocktx-non-empty-return
+        tx.vout[0].scriptPubKey = CScript() << OP_RETURN
+                                            << fuzzed_data_provider.ConsumeBytes<uint8_t>(
+                                                   fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 16));
+        break;
+    case 2: // bad-assetlocktx-opreturn-outofrange
+        tx.vout[0].nValue = fuzzed_data_provider.ConsumeBool() ? 0 : static_cast<CAmount>(MAX_MONEY) + 1;
+        break;
+    case 3: // bad-assetlocktx-multiple-return
+        tx.vout.emplace_back(1, CScript() << OP_RETURN << std::vector<uint8_t>{});
+        break;
+    case 4: // bad-assetlocktx-no-return
+        tx.vout[0].scriptPubKey = ConsumeRandomScript(fuzzed_data_provider);
+        if (!tx.vout[0].scriptPubKey.empty() && tx.vout[0].scriptPubKey[0] == OP_RETURN) {
+            tx.vout[0].scriptPubKey = CScript() << OP_1;
+        }
+        break;
+    case 5: // bad-assetlocktx-payload
+        tx.vExtraPayload = fuzzed_data_provider.ConsumeBytes<uint8_t>(
+            fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 8));
+        break;
+    case 6: // bad-assetlocktx-version
+        tx.vExtraPayload = BuildAssetLockPayload(fuzzed_data_provider.ConsumeBool() ? uint8_t{0}
+                                                                                    : std::numeric_limits<uint8_t>::max(),
+                                                 credit_outputs);
+        break;
+    case 7: // bad-assetlocktx-emptycreditoutputs
+        tx.vExtraPayload = BuildAssetLockPayload(CAssetLockPayload::CURRENT_VERSION, {});
+        break;
+    case 8: { // bad-assetlocktx-credit-outofrange
+        auto bad_credit_outputs = credit_outputs;
+        bad_credit_outputs[0].nValue = fuzzed_data_provider.ConsumeBool() ? 0 : static_cast<CAmount>(MAX_MONEY) + 1;
+        tx.vExtraPayload = BuildAssetLockPayload(CAssetLockPayload::CURRENT_VERSION, bad_credit_outputs);
+        break;
+    }
+    case 9: { // bad-assetlocktx-pubKeyHash
+        auto bad_credit_outputs = credit_outputs;
+        bad_credit_outputs[0].scriptPubKey = ConsumeRandomScript(fuzzed_data_provider);
+        if (bad_credit_outputs[0].scriptPubKey.IsPayToPublicKeyHash()) {
+            bad_credit_outputs[0].scriptPubKey = CScript() << OP_1;
+        }
+        tx.vExtraPayload = BuildAssetLockPayload(CAssetLockPayload::CURRENT_VERSION, bad_credit_outputs);
+        break;
+    }
+    case 10: { // bad-assetlocktx-creditamount
+        auto bad_credit_outputs = credit_outputs;
+        bad_credit_outputs[0].nValue += fuzzed_data_provider.ConsumeBool() ? 1 : -1;
+        tx.vExtraPayload = BuildAssetLockPayload(CAssetLockPayload::CURRENT_VERSION, bad_credit_outputs);
+        break;
+    }
+    case 11: // Valid path
+        break;
+    }
+
+    TxValidationState state;
+    const bool result = CheckAssetLockTx(CTransaction(tx), state);
+    assert(result == state.IsValid());
+}
+
+FUZZ_TARGET(asset_lock_tx_raw, .init = initialize_asset_lock_unlock)
+{
+    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    try {
+        const CTransaction tx(deserialize, ds);
+        TxValidationState state;
+        const bool result = CheckAssetLockTx(tx, state);
+        assert(result == state.IsValid());
+    } catch (const std::exception&) {
+    }
+}
+
+FUZZ_TARGET(asset_unlock_fee, .init = initialize_asset_lock_unlock)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    CMutableTransaction tx;
+    tx.nVersion = CTransaction::SPECIAL_VERSION;
+    tx.nType = TRANSACTION_ASSET_UNLOCK;
+
+    const uint8_t payload_version = fuzzed_data_provider.ConsumeIntegral<uint8_t>();
+    const uint64_t index = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+    const uint32_t fee = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+    const uint32_t requested_height = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+    const uint256 quorum_hash = ConsumeUInt256(fuzzed_data_provider);
+    const CBLSSignature quorum_sig = ConsumeBLSSignature(fuzzed_data_provider);
+    SetTxPayload(tx, CAssetUnlockPayload(payload_version, index, fee, requested_height, quorum_hash, quorum_sig));
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        // Trigger payload deserialization failures with short/truncated random bytes.
+        tx.vExtraPayload = fuzzed_data_provider.ConsumeBytes<uint8_t>(
+            fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 16));
+    } else if (fuzzed_data_provider.ConsumeBool()) {
+        // Trigger bad-txns-assetunlock-fee-outofrange.
+        SetTxPayload(tx, CAssetUnlockPayload(payload_version, index, 0, requested_height, quorum_hash, quorum_sig));
+    }
+
+    CAmount txfee{0};
+    TxValidationState state;
+    const bool result = GetAssetUnlockFee(CTransaction(tx), txfee, state);
+    assert(result == state.IsValid());
+}

--- a/src/test/fuzz/bls_operations.cpp
+++ b/src/test/fuzz/bls_operations.cpp
@@ -1,0 +1,297 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bls/bls.h>
+#include <bls/bls_ies.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <uint256.h>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+//! Build a CBLSSecretKey from fuzzed bytes. Returns invalid key on bad input.
+CBLSSecretKey MakeSecretKey(FuzzedDataProvider& fuzzed_data_provider)
+{
+    auto bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(CBLSSecretKey::SerSize);
+    bytes.resize(CBLSSecretKey::SerSize);
+    return CBLSSecretKey(bytes);
+}
+
+//! Build a CBLSPublicKey from fuzzed bytes via deserialization.
+CBLSPublicKey MakePublicKey(FuzzedDataProvider& fuzzed_data_provider)
+{
+    auto bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(CBLSPublicKey::SerSize);
+    bytes.resize(CBLSPublicKey::SerSize);
+    CBLSPublicKey pk;
+    pk.SetBytes(bytes, fuzzed_data_provider.ConsumeBool());
+    return pk;
+}
+
+//! Build a CBLSSignature from fuzzed bytes via deserialization.
+CBLSSignature MakeSignature(FuzzedDataProvider& fuzzed_data_provider)
+{
+    auto bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(CBLSSignature::SerSize);
+    bytes.resize(CBLSSignature::SerSize);
+    CBLSSignature sig;
+    sig.SetBytes(bytes, fuzzed_data_provider.ConsumeBool());
+    return sig;
+}
+
+uint256 MakeHash(FuzzedDataProvider& fuzzed_data_provider)
+{
+    auto bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(32);
+    bytes.resize(32);
+    uint256 h;
+    memcpy(h.begin(), bytes.data(), 32);
+    return h;
+}
+
+} // namespace
+
+void initialize_bls_operations() { BLSInit(); }
+
+FUZZ_TARGET(bls_operations, .init = initialize_bls_operations)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    // Test both legacy and basic BLS schemes.
+    // Intentionally mutating this global: each fuzz run is an isolated process,
+    // so there is no cross-run state leakage.
+    const bool use_legacy = fuzzed_data_provider.ConsumeBool();
+    bls::bls_legacy_scheme.store(use_legacy);
+
+    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes() > 0, 32)
+    {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 10)) {
+        case 0: {
+            // Key generation from fuzzed bytes + public key derivation
+            CBLSSecretKey sk = MakeSecretKey(fuzzed_data_provider);
+            if (sk.IsValid()) {
+                CBLSPublicKey pk = sk.GetPublicKey();
+                (void)pk.IsValid();
+                (void)pk.GetHash();
+                (void)pk.ToString();
+            }
+            break;
+        }
+        case 1: {
+            // Signing + verification with fuzzed data
+            CBLSSecretKey sk = MakeSecretKey(fuzzed_data_provider);
+            uint256 hash = MakeHash(fuzzed_data_provider);
+            const bool legacy_sign = fuzzed_data_provider.ConsumeBool();
+
+            if (sk.IsValid()) {
+                CBLSSignature sig = sk.Sign(hash, legacy_sign);
+                if (sig.IsValid()) {
+                    CBLSPublicKey pk = sk.GetPublicKey();
+                    // Should verify with matching scheme
+                    (void)sig.VerifyInsecure(pk, hash, legacy_sign);
+                    // May or may not verify with opposite scheme
+                    (void)sig.VerifyInsecure(pk, hash, !legacy_sign);
+                }
+            }
+            break;
+        }
+        case 2: {
+            // Verification with completely fuzzed key/sig/hash
+            CBLSPublicKey pk = MakePublicKey(fuzzed_data_provider);
+            CBLSSignature sig = MakeSignature(fuzzed_data_provider);
+            uint256 hash = MakeHash(fuzzed_data_provider);
+            const bool legacy_verify = fuzzed_data_provider.ConsumeBool();
+
+            (void)sig.VerifyInsecure(pk, hash, legacy_verify);
+            break;
+        }
+        case 3: {
+            // Public key aggregation (filter to valid keys — impl access on invalid is UB)
+            const size_t count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 5);
+            std::vector<CBLSPublicKey> pks;
+            for (size_t i = 0; i < count; i++) {
+                auto pk = MakePublicKey(fuzzed_data_provider);
+                if (pk.IsValid()) pks.push_back(pk);
+            }
+            (void)CBLSPublicKey::AggregateInsecure(pks);
+            break;
+        }
+        case 4: {
+            // Signature aggregation (filter to valid sigs)
+            const size_t count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 5);
+            std::vector<CBLSSignature> sigs;
+            for (size_t i = 0; i < count; i++) {
+                auto sig = MakeSignature(fuzzed_data_provider);
+                if (sig.IsValid()) sigs.push_back(sig);
+            }
+            (void)CBLSSignature::AggregateInsecure(sigs);
+            break;
+        }
+        case 5: {
+            // Secret key aggregation (filter to valid keys)
+            const size_t count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 5);
+            std::vector<CBLSSecretKey> sks;
+            for (size_t i = 0; i < count; i++) {
+                auto sk = MakeSecretKey(fuzzed_data_provider);
+                if (sk.IsValid()) sks.push_back(sk);
+            }
+            (void)CBLSSecretKey::AggregateInsecure(sks);
+            break;
+        }
+        case 6: {
+            // Threshold secret key share — SecretKeyShare validates inputs internally
+            const size_t threshold = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4);
+            std::vector<CBLSSecretKey> msk;
+            for (size_t i = 0; i < threshold; i++) {
+                msk.push_back(MakeSecretKey(fuzzed_data_provider));
+            }
+            CBLSId id(MakeHash(fuzzed_data_provider));
+            CBLSSecretKey share;
+            (void)share.SecretKeyShare(msk, id);
+            break;
+        }
+        case 7: {
+            // Threshold public key share — PublicKeyShare validates inputs internally
+            const size_t threshold = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4);
+            std::vector<CBLSPublicKey> mpk;
+            for (size_t i = 0; i < threshold; i++) {
+                mpk.push_back(MakePublicKey(fuzzed_data_provider));
+            }
+            CBLSId id(MakeHash(fuzzed_data_provider));
+            CBLSPublicKey share;
+            (void)share.PublicKeyShare(mpk, id);
+            break;
+        }
+        case 8: {
+            // Signature recovery from shares — Recover validates inputs internally
+            const size_t count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4);
+            std::vector<CBLSSignature> sigs;
+            std::vector<CBLSId> ids;
+            for (size_t i = 0; i < count; i++) {
+                sigs.push_back(MakeSignature(fuzzed_data_provider));
+                ids.emplace_back(MakeHash(fuzzed_data_provider));
+            }
+            CBLSSignature recovered;
+            (void)recovered.Recover(sigs, ids);
+            break;
+        }
+        case 9: {
+            // DH key exchange
+            CBLSSecretKey sk = MakeSecretKey(fuzzed_data_provider);
+            CBLSPublicKey pk = MakePublicKey(fuzzed_data_provider);
+            CBLSPublicKey result;
+            (void)result.DHKeyExchange(sk, pk);
+            break;
+        }
+        case 10: {
+            // Aggregated signature verification
+            const size_t count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 4);
+            std::vector<CBLSPublicKey> pks;
+            std::vector<uint256> hashes;
+            for (size_t i = 0; i < count; i++) {
+                auto pk = MakePublicKey(fuzzed_data_provider);
+                uint256 h = MakeHash(fuzzed_data_provider);
+                if (pk.IsValid()) {
+                    pks.push_back(pk);
+                    hashes.push_back(h);
+                }
+            }
+            if (!pks.empty()) {
+                CBLSSignature sig = MakeSignature(fuzzed_data_provider);
+                // VerifyInsecureAggregated asserts non-empty + equal sizes
+                (void)sig.VerifyInsecureAggregated(pks, hashes);
+                // VerifySecureAggregated accesses pk.impl directly
+                uint256 single_hash = MakeHash(fuzzed_data_provider);
+                (void)sig.VerifySecureAggregated(pks, single_hash);
+            }
+            break;
+        }
+        } // switch
+    } // while
+}
+
+FUZZ_TARGET(bls_ies, .init = initialize_bls_operations)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    // Intentionally mutating global; see bls_operations target comment.
+    bls::bls_legacy_scheme.store(fuzzed_data_provider.ConsumeBool());
+
+    switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 2)) {
+    case 0: {
+        // CBLSIESEncryptedBlob deserialization + decrypt with fuzzed key
+        CBLSIESEncryptedBlob blob;
+
+        // Build blob from fuzzed data
+        blob.ephemeralPubKey = MakePublicKey(fuzzed_data_provider);
+        auto iv_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(32);
+        iv_bytes.resize(32);
+        memcpy(blob.ivSeed.begin(), iv_bytes.data(), 32);
+        blob.data = fuzzed_data_provider.ConsumeBytes<uint8_t>(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 256));
+
+        (void)blob.IsValid();
+
+        size_t idx = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 16);
+        (void)blob.GetIV(idx);
+
+        CBLSSecretKey sk = MakeSecretKey(fuzzed_data_provider);
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        (void)blob.Decrypt(idx, sk, ds);
+        break;
+    }
+    case 1: {
+        // CBLSIESMultiRecipientBlobs decrypt with fuzzed data
+        CBLSIESMultiRecipientBlobs multi;
+        multi.ephemeralPubKey = MakePublicKey(fuzzed_data_provider);
+
+        auto iv_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(32);
+        iv_bytes.resize(32);
+        memcpy(multi.ivSeed.begin(), iv_bytes.data(), 32);
+
+        const size_t blob_count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 8);
+        multi.blobs.resize(blob_count);
+        for (size_t i = 0; i < blob_count; i++) {
+            multi.blobs[i] = fuzzed_data_provider.ConsumeBytes<uint8_t>(
+                fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 128));
+        }
+
+        // Try to decrypt each blob
+        CBLSSecretKey sk = MakeSecretKey(fuzzed_data_provider);
+        for (size_t i = 0; i < blob_count; i++) {
+            CBLSIESMultiRecipientBlobs::Blob result;
+            (void)multi.Decrypt(i, sk, result);
+        }
+        break;
+    }
+    case 2: {
+        // Roundtrip: encrypt then decrypt with matching keys
+        CBLSSecretKey recipient_sk = MakeSecretKey(fuzzed_data_provider);
+        if (!recipient_sk.IsValid()) break;
+
+        CBLSPublicKey recipient_pk = recipient_sk.GetPublicKey();
+        if (!recipient_pk.IsValid()) break;
+
+        const size_t data_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 128);
+        auto plaintext = fuzzed_data_provider.ConsumeBytes<uint8_t>(data_size);
+        plaintext.resize(data_size);
+
+        // Encrypt
+        CBLSIESMultiRecipientBlobs multi;
+        multi.InitEncrypt(1);
+        bool encrypted = multi.Encrypt(0, recipient_pk, plaintext);
+        if (encrypted) {
+            // Decrypt
+            CBLSIESMultiRecipientBlobs::Blob decrypted;
+            bool decrypted_ok = multi.Decrypt(0, recipient_sk, decrypted);
+            if (decrypted_ok) {
+                assert(decrypted == plaintext);
+            }
+        }
+        break;
+    }
+    } // switch
+}

--- a/src/test/fuzz/bls_operations.cpp
+++ b/src/test/fuzz/bls_operations.cpp
@@ -268,23 +268,37 @@ FUZZ_TARGET(bls_ies, .init = initialize_bls_operations)
         break;
     }
     case 2: {
-        // Roundtrip: encrypt then decrypt with matching keys
+        // Roundtrip: encrypt then decrypt with matching keys.
+        //
+        // We deliberately do NOT call CBLSIESMultiRecipientBlobs::InitEncrypt(): it pulls the
+        // ephemeral secret key and ivSeed from external randomness (MakeNewKey() and
+        // GetStrongRandBytes), which makes the same fuzz input non-deterministic across runs
+        // and breaks libFuzzer crash reproduction. Instead, fill the public ephemeralSecretKey,
+        // ephemeralPubKey, ivSeed, ivVector, and blobs fields directly from the fuzz buffer,
+        // mirroring InitEncrypt's behavior. The production BLS IES API is not modified.
         CBLSSecretKey recipient_sk = MakeSecretKey(fuzzed_data_provider);
         if (!recipient_sk.IsValid()) break;
 
         CBLSPublicKey recipient_pk = recipient_sk.GetPublicKey();
         if (!recipient_pk.IsValid()) break;
 
+        CBLSSecretKey ephemeral_sk = MakeSecretKey(fuzzed_data_provider);
+        if (!ephemeral_sk.IsValid()) break;
+
         const size_t data_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 128);
         auto plaintext = fuzzed_data_provider.ConsumeBytes<uint8_t>(data_size);
         plaintext.resize(data_size);
 
-        // Encrypt
         CBLSIESMultiRecipientBlobs multi;
-        multi.InitEncrypt(1);
+        multi.ephemeralSecretKey = ephemeral_sk;
+        multi.ephemeralPubKey = ephemeral_sk.GetPublicKey();
+        multi.ivSeed = MakeHash(fuzzed_data_provider);
+        // Replicate InitEncrypt's per-recipient IV chain so Decrypt's IV walk matches.
+        multi.ivVector.assign(1, multi.ivSeed);
+        multi.blobs.resize(1);
+
         bool encrypted = multi.Encrypt(0, recipient_pk, plaintext);
         if (encrypted) {
-            // Decrypt
             CBLSIESMultiRecipientBlobs::Blob decrypted;
             bool decrypted_ok = multi.Decrypt(0, recipient_sk, decrypted);
             if (decrypted_ok) {

--- a/src/test/fuzz/bls_operations.cpp
+++ b/src/test/fuzz/bls_operations.cpp
@@ -62,8 +62,8 @@ FUZZ_TARGET(bls_operations, .init = initialize_bls_operations)
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
 
     // Test both legacy and basic BLS schemes.
-    // Intentionally mutating this global: each fuzz run is an isolated process,
-    // so there is no cross-run state leakage.
+    // Intentionally mutating this global: each invocation overwrites it before use,
+    // so later iterations do not inherit stale scheme state from earlier ones.
     const bool use_legacy = fuzzed_data_provider.ConsumeBool();
     bls::bls_legacy_scheme.store(use_legacy);
 

--- a/src/test/fuzz/coinjoin.cpp
+++ b/src/test/fuzz/coinjoin.cpp
@@ -1,0 +1,176 @@
+// Copyright (c) 2026-present The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <coinjoin/coinjoin.h>
+#include <coinjoin/common.h>
+#include <primitives/transaction.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace {
+void initialize_coinjoin() { SelectParams(CBaseChainParams::REGTEST); }
+} // namespace
+
+// Fuzz the CoinJoin denomination helper functions with arbitrary amounts
+FUZZ_TARGET(coinjoin_denominations)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    // Test AmountToDenomination / DenominationToAmount roundtrip
+    const CAmount amount = fuzzed_data_provider.ConsumeIntegral<CAmount>();
+    const int denom = CoinJoin::AmountToDenomination(amount);
+    if (denom > 0) {
+        // Valid denomination — roundtrip must be consistent
+        assert(CoinJoin::DenominationToAmount(denom) == amount);
+        assert(CoinJoin::IsDenominatedAmount(amount));
+        assert(CoinJoin::IsValidDenomination(denom));
+    }
+
+    // Test DenominationToAmount with fuzzed denom values
+    const int fuzzed_denom = fuzzed_data_provider.ConsumeIntegral<int>();
+    const CAmount denom_amount = CoinJoin::DenominationToAmount(fuzzed_denom);
+    if (denom_amount > 0) {
+        assert(CoinJoin::IsDenominatedAmount(denom_amount));
+        assert(CoinJoin::AmountToDenomination(denom_amount) == fuzzed_denom);
+    }
+
+    // Test collateral amount checks
+    const CAmount collateral_amount = fuzzed_data_provider.ConsumeIntegral<CAmount>();
+    (void)CoinJoin::IsCollateralAmount(collateral_amount);
+
+    // Test priority calculation
+    (void)CoinJoin::CalculateAmountPriority(amount);
+    (void)CoinJoin::CalculateAmountPriority(collateral_amount);
+}
+
+// Fuzz CCoinJoinQueue — deserialization + method exercising
+FUZZ_TARGET(coinjoin_queue)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    CCoinJoinQueue queue;
+    {
+        CDataStream ds(fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>(), SER_NETWORK, PROTOCOL_VERSION);
+        try {
+            ds >> queue;
+        } catch (const std::ios_base::failure&) {
+            return;
+        }
+    }
+
+    // Exercise methods on successfully deserialized queue — must not crash
+    (void)queue.GetHash();
+    (void)queue.GetSignatureHash();
+    (void)queue.ToString();
+
+    // Test time bounds with various times
+    (void)queue.IsTimeOutOfBounds();
+    (void)queue.IsTimeOutOfBounds(0);
+    (void)queue.IsTimeOutOfBounds(queue.nTime);
+    // Use saturating arithmetic to avoid signed overflow UB in the test driver
+    const int64_t kTimeout = COINJOIN_QUEUE_TIMEOUT;
+    const int64_t time_plus = (queue.nTime <= std::numeric_limits<int64_t>::max() - kTimeout)
+                                  ? queue.nTime + kTimeout
+                                  : std::numeric_limits<int64_t>::max();
+    const int64_t time_minus = (queue.nTime >= std::numeric_limits<int64_t>::min() + kTimeout)
+                                   ? queue.nTime - kTimeout
+                                   : std::numeric_limits<int64_t>::min();
+    (void)queue.IsTimeOutOfBounds(time_plus);
+    (void)queue.IsTimeOutOfBounds(time_minus);
+    (void)queue.IsTimeOutOfBounds(std::numeric_limits<int64_t>::max());
+    (void)queue.IsTimeOutOfBounds(std::numeric_limits<int64_t>::min());
+}
+
+// Fuzz CCoinJoinBroadcastTx — deserialization + IsValidStructure
+FUZZ_TARGET(coinjoin_broadcasttx, .init = initialize_coinjoin)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    CCoinJoinBroadcastTx dstx;
+    {
+        CDataStream ds(fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>(), SER_NETWORK, PROTOCOL_VERSION);
+        try {
+            ds >> dstx;
+        } catch (const std::ios_base::failure&) {
+            return;
+        }
+    }
+
+    // Exercise methods — must not crash
+    (void)dstx.IsValidStructure();
+    (void)dstx.GetSignatureHash();
+    (void)static_cast<bool>(dstx);
+}
+
+// Fuzz CCoinJoinEntry::AddScriptSig with fuzzed inputs
+FUZZ_TARGET(coinjoin_entry_addscriptsig)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    // Build a CCoinJoinEntry with fuzzed DSIn entries
+    CCoinJoinEntry entry;
+    const size_t num_inputs = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 20);
+    for (size_t i = 0; i < num_inputs; ++i) {
+        CTxDSIn dsin;
+        // Fuzz the outpoint
+        uint256 hash;
+        auto hash_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(32);
+        if (hash_bytes.size() == 32) {
+            memcpy(hash.begin(), hash_bytes.data(), 32);
+        }
+        dsin.prevout = COutPoint(hash, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+        dsin.nSequence = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+        dsin.fHasSig = fuzzed_data_provider.ConsumeBool();
+        entry.vecTxDSIn.push_back(dsin);
+    }
+
+    // Now try to AddScriptSig with fuzzed CTxIn
+    LIMITED_WHILE(fuzzed_data_provider.remaining_bytes() > 0, 50)
+    {
+        CTxIn txin;
+        uint256 hash;
+        auto hash_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(32);
+        if (hash_bytes.size() == 32) {
+            memcpy(hash.begin(), hash_bytes.data(), 32);
+        }
+        txin.prevout = COutPoint(hash, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+        txin.nSequence = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+        auto script_bytes = fuzzed_data_provider.ConsumeBytes<uint8_t>(
+            fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 100));
+        txin.scriptSig = CScript(script_bytes.begin(), script_bytes.end());
+
+        (void)entry.AddScriptSig(txin);
+    }
+}
+
+// Fuzz CCoinJoinStatusUpdate — deserialization + GetMessageByID
+FUZZ_TARGET(coinjoin_status_update)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    // Test with arbitrary PoolMessage values first (doesn't consume much data)
+    const auto raw_msg = fuzzed_data_provider.ConsumeIntegral<int32_t>();
+    (void)CoinJoin::GetMessageByID(static_cast<PoolMessage>(raw_msg));
+
+    CCoinJoinStatusUpdate status;
+    {
+        CDataStream ds(fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>(), SER_NETWORK, PROTOCOL_VERSION);
+        try {
+            ds >> status;
+        } catch (const std::ios_base::failure&) {
+            return;
+        }
+    }
+
+    // Exercise GetMessageByID with deserialized message ID — must not crash
+    (void)CoinJoin::GetMessageByID(status.nMessageID);
+}

--- a/src/test/fuzz/decode_tx.cpp
+++ b/src/test/fuzz/decode_tx.cpp
@@ -16,6 +16,5 @@ FUZZ_TARGET(decode_tx)
 {
     const std::string tx_hex = HexStr(std::string{buffer.begin(), buffer.end()});
     CMutableTransaction mtx;
-    const bool result_none = DecodeHexTx(mtx, tx_hex);
-    assert(!result_none);
+    (void)DecodeHexTx(mtx, tx_hex);
 }

--- a/src/test/fuzz/decode_tx.cpp
+++ b/src/test/fuzz/decode_tx.cpp
@@ -14,6 +14,9 @@
 
 FUZZ_TARGET(decode_tx)
 {
+    // Dash's DecodeHexTx takes no try_no_witness/try_witness flags (no witness support),
+    // so unlike upstream we can't assert all decode attempts fail — a fuzzer-generated
+    // buffer can coincidentally be a valid serialized transaction.
     const std::string tx_hex = HexStr(std::string{buffer.begin(), buffer.end()});
     CMutableTransaction mtx;
     (void)DecodeHexTx(mtx, tx_hex);

--- a/src/test/fuzz/deserialize_dash.cpp
+++ b/src/test/fuzz/deserialize_dash.cpp
@@ -1,0 +1,309 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Deserialization fuzz targets for Dash-specific types.
+// Follows the same pattern as deserialize.cpp for Bitcoin Core types.
+
+#include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
+
+#include <streams.h>
+#include <version.h>
+
+#include <bls/bls_ies.h>
+#include <coinjoin/coinjoin.h>
+#include <evo/assetlocktx.h>
+#include <evo/cbtx.h>
+#include <evo/creditpool.h>
+#include <evo/deterministicmns.h>
+#include <evo/dmnstate.h>
+#include <evo/mnauth.h>
+#include <evo/mnhftx.h>
+#include <evo/providertx.h>
+#include <evo/simplifiedmns.h>
+#include <evo/smldiff.h>
+#include <governance/common.h>
+#include <governance/object.h>
+#include <governance/vote.h>
+#include <governance/votedb.h>
+#include <llmq/commitment.h>
+#include <llmq/dkgsession.h>
+#include <llmq/quorums.h>
+#include <llmq/signing.h>
+#include <llmq/signing_shares.h>
+#include <llmq/snapshot.h>
+
+#include <cassert>
+#include <exception>
+#include <optional>
+#include <stdexcept>
+#include <stdint.h>
+
+namespace {
+
+const BasicTestingSetup* g_setup;
+
+struct dash_invalid_fuzzing_input_exception : public std::exception {
+};
+
+template <typename T>
+void DashDeserializeFromFuzzingInput(FuzzBufferType buffer, T& obj,
+                                     const std::optional<int> protocol_version = std::nullopt,
+                                     const int ser_type = SER_NETWORK)
+{
+    CDataStream ds(buffer, ser_type, PROTOCOL_VERSION);
+    if (protocol_version) {
+        ds.SetVersion(*protocol_version);
+    } else {
+        try {
+            int version;
+            ds >> version;
+            ds.SetVersion(version);
+        } catch (const std::ios_base::failure&) {
+            throw dash_invalid_fuzzing_input_exception();
+        }
+    }
+    try {
+        ds >> obj;
+    } catch (const std::ios_base::failure&) {
+        throw dash_invalid_fuzzing_input_exception();
+    }
+    CDataStream sink(ser_type, ds.GetVersion());
+    sink << obj;
+    assert(!sink.empty());
+}
+
+} // namespace
+
+void initialize_deserialize_dash()
+{
+    static const auto testing_setup = MakeNoLogFileContext<>();
+    g_setup = testing_setup.get();
+}
+
+#define FUZZ_TARGET_DASH_DESERIALIZE(name, code)                \
+    FUZZ_TARGET(name, .init = initialize_deserialize_dash)      \
+    {                                                           \
+        try {                                                   \
+            code                                                \
+        } catch (const dash_invalid_fuzzing_input_exception&) { \
+        }                                                       \
+    }
+
+// --- evo/ types: Provider transactions ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_proreg_tx_deserialize, {
+    CProRegTx obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_proupserv_tx_deserialize, {
+    CProUpServTx obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_proupreg_tx_deserialize, {
+    CProUpRegTx obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_prouprev_tx_deserialize, {
+    CProUpRevTx obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- evo/ types: Asset Lock/Unlock (L1↔L2 bridge) ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_asset_lock_payload_deserialize, {
+    CAssetLockPayload obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_asset_unlock_payload_deserialize, {
+    CAssetUnlockPayload obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- evo/ types: Coinbase special payload ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_cbtx_deserialize, {
+    CCbTx obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- evo/ types: Credit pool ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_credit_pool_deserialize, {
+    CCreditPool obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- evo/ types: Deterministic masternode ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_deterministic_mn_deserialize, {
+    CDeterministicMN obj(0 /* internalId, will be overwritten by deserialization */);
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- evo/ types: Deterministic masternode state ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_dmn_state_deserialize, {
+    CDeterministicMNState obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_dmn_state_diff_deserialize, {
+    CDeterministicMNStateDiff obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- evo/ types: Simplified MN list ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_smn_list_entry_deserialize, {
+    CSimplifiedMNListEntry obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_get_smn_list_diff_deserialize, {
+    CGetSimplifiedMNListDiff obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_smn_list_diff_deserialize, {
+    CSimplifiedMNListDiff obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- evo/ types: MN auth and hard fork signaling ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_mnauth_deserialize, {
+    CMNAuth obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_mnhf_tx_deserialize, {
+    MNHFTx obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_mnhf_tx_payload_deserialize, {
+    MNHFTxPayload obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- llmq/ types: Quorum commitment ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_final_commitment_deserialize, {
+    llmq::CFinalCommitment obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_final_commitment_tx_payload_deserialize, {
+    llmq::CFinalCommitmentTxPayload obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- llmq/ types: DKG messages ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_dkg_complaint_deserialize, {
+    llmq::CDKGComplaint obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_dkg_justification_deserialize, {
+    llmq::CDKGJustification obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_dkg_premature_commitment_deserialize, {
+    llmq::CDKGPrematureCommitment obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- llmq/ types: Signing ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_recovered_sig_deserialize, {
+    llmq::CRecoveredSig obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_sig_share_deserialize, {
+    llmq::CSigShare obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_sig_ses_ann_deserialize, {
+    llmq::CSigSesAnn obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_sig_shares_inv_deserialize, {
+    llmq::CSigSharesInv obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_batched_sig_shares_deserialize, {
+    llmq::CBatchedSigShares obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- llmq/ types: Quorum data and rotation ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_quorum_data_request_deserialize, {
+    llmq::CQuorumDataRequest obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_get_quorum_rotation_info_deserialize, {
+    llmq::CGetQuorumRotationInfo obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_quorum_snapshot_deserialize, {
+    llmq::CQuorumSnapshot obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- governance/ types ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_governance_object_common_deserialize, {
+    Governance::Object obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_governance_object_deserialize, {
+    CGovernanceObject obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_governance_vote_deserialize, {
+    CGovernanceVote obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_vote_instance_deserialize, {
+    vote_instance_t obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_vote_rec_deserialize, {
+    vote_rec_t obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_governance_vote_file_deserialize, {
+    CGovernanceObjectVoteFile obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- bls/ types ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_bls_ies_encrypted_blob_deserialize, {
+    CBLSIESEncryptedBlob obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_bls_ies_multi_recipient_blobs_deserialize, {
+    CBLSIESMultiRecipientBlobs obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+
+// --- coinjoin/ types ---
+
+FUZZ_TARGET_DASH_DESERIALIZE(dash_coinjoin_status_update_deserialize, {
+    CCoinJoinStatusUpdate obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_coinjoin_accept_deserialize, {
+    CCoinJoinAccept obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_coinjoin_entry_deserialize, {
+    CCoinJoinEntry obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_coinjoin_queue_deserialize, {
+    CCoinJoinQueue obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_DESERIALIZE(dash_coinjoin_broadcast_tx_deserialize, {
+    CCoinJoinBroadcastTx obj;
+    DashDeserializeFromFuzzingInput(buffer, obj);
+})

--- a/src/test/fuzz/deterministic_mn_list_diff.cpp
+++ b/src/test/fuzz/deterministic_mn_list_diff.cpp
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bls/bls.h>
+#include <chain.h>
+#include <evo/deterministicmns.h>
+#include <evo/netinfo.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <script/standard.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/fuzz/util_dash.h>
+#include <test/util/setup_common.h>
+#include <tinyformat.h>
+#include <version.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+const TestingSetup* g_setup;
+
+std::vector<uint64_t> GetInternalIds(const CDeterministicMNList& mn_list)
+{
+    std::vector<uint64_t> ids;
+    mn_list.ForEachMN(/*onlyValid=*/false, [&](const CDeterministicMN& dmn) { ids.push_back(dmn.GetInternalId()); });
+    return ids;
+}
+
+bool DiffHasRequiredPointers(const CDeterministicMNListDiff& diff)
+{
+    for (const auto& dmn : diff.addedMNs) {
+        if (!dmn || !dmn->pdmnState || !dmn->pdmnState->netInfo) {
+            return false;
+        }
+    }
+    return true;
+}
+
+struct SyntheticBlockIndex {
+    CBlockIndex m_index{};
+    uint256 m_hash;
+
+    SyntheticBlockIndex(const int height, const uint256& hash) :
+        m_hash(hash)
+    {
+        m_index.nHeight = height;
+        m_index.phashBlock = &m_hash;
+    }
+};
+
+} // namespace
+
+void initialize_deterministic_mn_list_diff()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::REGTEST);
+    g_setup = testing_setup.get();
+}
+
+FUZZ_TARGET(deterministic_mn_list_diff, .init = initialize_deterministic_mn_list_diff)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const int source_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 10000);
+    const uint256 source_hash = ConsumeUInt256(fuzzed_data_provider);
+    CDeterministicMNList list_from(source_hash, source_height, 0);
+
+    uint64_t next_internal_id = 1;
+    uint64_t next_unique_tag = 1;
+    const size_t initial_mn_count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 8);
+    for (size_t i = 0; i < initial_mn_count; ++i) {
+        const MnType mn_type = fuzzed_data_provider.ConsumeBool() ? MnType::Evo : MnType::Regular;
+        list_from.AddMN(MakeMasternode(next_internal_id++, next_unique_tag++, source_height, mn_type), /*fBumpTotalCount=*/true);
+    }
+
+    CDeterministicMNList list_to(list_from);
+    const size_t operation_count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 24);
+    for (size_t i = 0; i < operation_count; ++i) {
+        const uint8_t op = fuzzed_data_provider.ConsumeIntegralInRange<uint8_t>(0, 2);
+        if (op == 0) {
+            const MnType mn_type = fuzzed_data_provider.ConsumeBool() ? MnType::Evo : MnType::Regular;
+            list_to.AddMN(MakeMasternode(next_internal_id++, next_unique_tag++, source_height, mn_type), /*fBumpTotalCount=*/true);
+            continue;
+        }
+
+        const auto hashes = GetProTxHashes(list_to);
+        if (hashes.empty()) continue;
+        const auto index = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, hashes.size() - 1);
+
+        if (op == 1) {
+            list_to.RemoveMN(hashes[index]);
+            continue;
+        }
+
+        const auto old_mn = list_to.GetMN(hashes[index]);
+        if (!old_mn) continue;
+        auto new_state = std::make_shared<CDeterministicMNState>(*old_mn->pdmnState);
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<uint8_t>(0, 15)) {
+        case 0:
+            new_state->nPoSePenalty = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 1000);
+            break;
+        case 1:
+            new_state->nConsecutivePayments = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 1000);
+            break;
+        case 2:
+            new_state->nLastPaidHeight = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 100000);
+            break;
+        case 3:
+            new_state->confirmedHash = HashFromTag(next_unique_tag++ ^ 0x33333333ULL);
+            break;
+        case 4: {
+            CBLSSecretKey sk;
+            sk.MakeNewKey();
+            new_state->nVersion = ProTxVersion::BasicBLS;
+            new_state->pubKeyOperator.Set(sk.GetPublicKey(), /*specificLegacyScheme=*/false);
+            break;
+        }
+        case 5:
+            new_state->keyIDVoting = CKeyID(Uint160FromTag(next_unique_tag++ ^ 0x06060606ULL));
+            break;
+        case 6: {
+            auto net_info = NetInfoInterface::MakeNetInfo(new_state->nVersion);
+            if (net_info && net_info->AddEntry(NetInfoPurpose::CORE_P2P, AddressFromTag(next_unique_tag++)) == NetInfoStatus::Success) {
+                new_state->netInfo = std::move(net_info);
+            }
+            break;
+        }
+        case 7:
+            new_state->scriptPayout = CScript() << OP_DUP << OP_HASH160 << ToByteVector(Uint160FromTag(next_unique_tag++)) << OP_EQUALVERIFY << OP_CHECKSIG;
+            break;
+        case 8:
+            new_state->scriptOperatorPayout = CScript() << OP_DUP << OP_HASH160 << ToByteVector(Uint160FromTag(next_unique_tag++ ^ 0x08080808ULL)) << OP_EQUALVERIFY << OP_CHECKSIG;
+            break;
+        case 9:
+            new_state->nRevocationReason = fuzzed_data_provider.ConsumeIntegralInRange<uint16_t>(CProUpRevTx::REASON_NOT_SPECIFIED, CProUpRevTx::REASON_CHANGE_OF_KEYS);
+            break;
+        case 10:
+            new_state->nPoSeRevivedHeight = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 100000);
+            break;
+        case 11:
+            new_state->BanIfNotBanned(fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 100000));
+            break;
+        case 12:
+            new_state->platformNodeID = Uint160FromTag(next_unique_tag++ ^ 0x12121212ULL);
+            break;
+        case 13:
+            new_state->platformP2PPort = fuzzed_data_provider.ConsumeIntegral<uint16_t>();
+            break;
+        case 14:
+            new_state->platformHTTPPort = fuzzed_data_provider.ConsumeIntegral<uint16_t>();
+            break;
+        case 15:
+            new_state->nRegisteredHeight = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 10000);
+            break;
+        }
+        list_to.UpdateMN(*old_mn, new_state);
+    }
+
+    const int target_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 100000);
+    const uint256 target_hash = ConsumeUInt256(fuzzed_data_provider);
+    list_to.SetHeight(target_height);
+    list_to.SetBlockHash(target_hash);
+    const SyntheticBlockIndex target_index(target_height, target_hash);
+
+    const CDeterministicMNListDiff diff = list_from.BuildDiff(list_to);
+    CDeterministicMNList applied(list_from);
+    applied.ApplyDiff(&target_index.m_index, diff);
+    if (!applied.IsEqual(list_to)) {
+        throw std::runtime_error("deterministic_mn_list_diff: BuildDiff/ApplyDiff invariant failed");
+    }
+
+    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+    ds << diff;
+    CDeterministicMNListDiff roundtrip_diff;
+    ds >> roundtrip_diff;
+    CDeterministicMNList applied_roundtrip(list_from);
+    applied_roundtrip.ApplyDiff(&target_index.m_index, roundtrip_diff);
+    if (!applied_roundtrip.IsEqual(list_to)) {
+        throw std::runtime_error("deterministic_mn_list_diff: serialized diff invariant failed");
+    }
+
+    CDeterministicMNListDiff mutated_diff = diff;
+    if (fuzzed_data_provider.ConsumeBool()) {
+        mutated_diff.removedMns.insert(fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        CDeterministicMNState before_state;
+        before_state.nVersion = ProTxVersion::LegacyBLS;
+        before_state.netInfo = NetInfoInterface::MakeNetInfo(before_state.nVersion);
+        if (before_state.netInfo) {
+            (void)before_state.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, AddressFromTag(next_unique_tag++));
+        }
+        before_state.keyIDOwner = CKeyID(Uint160FromTag(next_unique_tag++ ^ 0x05050505ULL));
+        CDeterministicMNState after_state(before_state);
+        after_state.nPoSePenalty += 1;
+        const auto ids = GetInternalIds(list_from);
+        const uint64_t maybe_existing_id = !ids.empty() && fuzzed_data_provider.ConsumeBool()
+                                               ? ids.front()
+                                               : fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+        mutated_diff.updatedMNs.emplace(maybe_existing_id, CDeterministicMNStateDiff(before_state, after_state));
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        mutated_diff.addedMNs.emplace_back(
+            MakeMasternode(fuzzed_data_provider.ConsumeBool() && !mutated_diff.addedMNs.empty()
+                               ? mutated_diff.addedMNs.front()->GetInternalId()
+                               : next_internal_id++,
+                           next_unique_tag++, source_height, fuzzed_data_provider.ConsumeBool() ? MnType::Evo : MnType::Regular));
+    }
+
+    if (DiffHasRequiredPointers(mutated_diff)) {
+        try {
+            CDeterministicMNList applied_mutated(list_from);
+            applied_mutated.ApplyDiff(&target_index.m_index, mutated_diff);
+        } catch (const std::exception&) {
+        }
+    }
+
+    CDeterministicMNListDiff random_diff;
+    CDataStream ds_random(fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>(), SER_NETWORK, PROTOCOL_VERSION);
+    try {
+        ds_random >> random_diff;
+        if (DiffHasRequiredPointers(random_diff)) {
+            try {
+                CDeterministicMNList applied_random(list_from);
+                applied_random.ApplyDiff(&target_index.m_index, random_diff);
+            } catch (const std::exception&) {
+            }
+        }
+    } catch (const std::exception&) {
+    }
+}

--- a/src/test/fuzz/deterministic_mn_list_diff.cpp
+++ b/src/test/fuzz/deterministic_mn_list_diff.cpp
@@ -118,8 +118,8 @@ FUZZ_TARGET(deterministic_mn_list_diff, .init = initialize_deterministic_mn_list
             new_state->confirmedHash = HashFromTag(next_unique_tag++ ^ 0x33333333ULL);
             break;
         case 4: {
-            CBLSSecretKey sk;
-            sk.MakeNewKey();
+            const uint256 operator_seed = HashFromTag(next_unique_tag++ ^ 0x04040404ULL);
+            const CBLSSecretKey sk{Span<const unsigned char>{operator_seed.begin(), operator_seed.size()}};
             new_state->nVersion = ProTxVersion::BasicBLS;
             new_state->pubKeyOperator.Set(sk.GetPublicKey(), /*specificLegacyScheme=*/false);
             break;

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -7,6 +7,7 @@
 #include <fs.h>
 #include <netaddress.h>
 #include <netbase.h>
+#include <stats/client.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
 #include <util/sock.h>
@@ -98,6 +99,12 @@ void ResetCoverageCounters() {}
 
 void initialize()
 {
+    // Initialize a no-op stats client to prevent null dereferences in production
+    // code that unconditionally calls g_stats_client->timing()/inc()/count().
+    if (!::g_stats_client) {
+        ::g_stats_client = std::make_unique<StatsdClient>();
+    }
+
     // Terminate immediately if a fuzzing harness ever tries to create a TCP socket.
     CreateSock = [](const sa_family_t&) -> std::unique_ptr<Sock> { std::terminate(); };
 

--- a/src/test/fuzz/governance_proposal_validator.cpp
+++ b/src/test/fuzz/governance_proposal_validator.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <governance/common.h>
+#include <governance/validators.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <util/std23.h>
+
+#include <array>
+#include <cinttypes>
+#include <cstdint>
+#include <string>
+
+namespace {
+std::string HexEncodeString(const std::string& input)
+{
+    static constexpr char HEX_DIGITS[] = "0123456789abcdef";
+    std::string out;
+    out.reserve(input.size() * 2);
+    for (const unsigned char ch : input) {
+        out.push_back(HEX_DIGITS[ch >> 4]);
+        out.push_back(HEX_DIGITS[ch & 0x0f]);
+    }
+    return out;
+}
+
+std::string SanitizeJsonString(std::string input)
+{
+    for (char& ch : input) {
+        if (ch == '"' || ch == '\\' || static_cast<unsigned char>(ch) < 0x20) {
+            ch = 'x';
+        }
+    }
+    return input;
+}
+
+std::string MakeProposalJson(int64_t type, const std::string& name, int64_t start_epoch, int64_t end_epoch,
+                             double payment_amount, const std::string& payment_address, const std::string& url)
+{
+    return strprintf("{\"type\":%" PRId64 ",\"name\":\"%s\",\"start_epoch\":%" PRId64 ",\"end_epoch\":%" PRId64
+                     ",\"payment_amount\":%.17g,\"payment_address\":\"%s\",\"url\":\"%s\"}",
+                     type, SanitizeJsonString(name), start_epoch, end_epoch, payment_amount,
+                     SanitizeJsonString(payment_address), SanitizeJsonString(url));
+}
+
+void RunValidatorCase(const std::string& hex_data, bool allow_script, bool check_expiration)
+{
+    try {
+        CProposalValidator validator(hex_data, allow_script);
+        (void)validator.Validate(check_expiration);
+        (void)validator.GetErrorMessages();
+    } catch (const std::exception&) {
+    } catch (...) {
+    }
+}
+} // namespace
+
+void initialize_governance_proposal_validator() { SelectParams(CBaseChainParams::MAIN); }
+
+FUZZ_TARGET(governance_proposal_validator, .init = initialize_governance_proposal_validator)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    constexpr std::array<const char*, 2> kPaymentAddresses{
+        "Xs7iEDx8nMwJHdiQnwvCnLBTP2sjmDGTJA", // P2PKH (mainnet)
+        "7XuP9xVGyvkCAfW84QJkGfbiR7dX9TYaPH", // P2SH (mainnet)
+    };
+
+    const int64_t type = fuzzed_data_provider.ConsumeBool() ? std23::to_underlying(GovernanceObject::PROPOSAL)
+                                                            : fuzzed_data_provider.ConsumeIntegral<int64_t>();
+
+    const int64_t start_epoch = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+    const int64_t end_epoch = start_epoch + fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(-4, 1024);
+
+    double payment_amount = fuzzed_data_provider.ConsumeFloatingPointInRange<double>(-1000.0, 1000.0);
+    if (fuzzed_data_provider.ConsumeBool()) {
+        payment_amount = 1.0;
+    }
+
+    std::string random_name = fuzzed_data_provider.ConsumeRandomLengthString(96);
+    std::string random_url = fuzzed_data_provider.ConsumeRandomLengthString(256);
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        random_name = "dash-proposal-" + random_name;
+    }
+
+    constexpr std::array<const char*, 4> kUrls{
+        "https://dash.org/proposals/1",
+        "http://[::1]/path",
+        "http://[broken/path",
+        "http://broken]/path",
+    };
+
+    const std::string payment_address =
+        fuzzed_data_provider.ConsumeBool()
+            ? std::string(
+                  kPaymentAddresses[fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, kPaymentAddresses.size() - 1)])
+            : fuzzed_data_provider.ConsumeRandomLengthString(96);
+    const std::string url = fuzzed_data_provider.ConsumeBool()
+                                ? std::string(
+                                      kUrls[fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, kUrls.size() - 1)])
+                                : random_url;
+
+    const std::string json_hex = HexEncodeString(
+        MakeProposalJson(type, random_name, start_epoch, end_epoch, payment_amount, payment_address, url));
+
+    const std::string malformed_json_hex = HexEncodeString("{" + fuzzed_data_provider.ConsumeRandomLengthString(128));
+    const size_t oversized_payload_size = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(513, 2048);
+    const std::string oversized_hex(oversized_payload_size * 2, 'a');
+    const std::string random_hex = fuzzed_data_provider.ConsumeRandomLengthString(2048);
+
+    for (const bool allow_script : {false, true}) {
+        for (const bool check_expiration : {false, true}) {
+            RunValidatorCase(json_hex, allow_script, check_expiration);
+            RunValidatorCase(malformed_json_hex, allow_script, check_expiration);
+            RunValidatorCase(oversized_hex, allow_script, check_expiration);
+            RunValidatorCase(random_hex, allow_script, check_expiration);
+        }
+    }
+}

--- a/src/test/fuzz/governance_proposal_validator.cpp
+++ b/src/test/fuzz/governance_proposal_validator.cpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <cinttypes>
 #include <cstdint>
+#include <limits>
 #include <string>
 
 namespace {
@@ -73,7 +74,15 @@ FUZZ_TARGET(governance_proposal_validator, .init = initialize_governance_proposa
                                                             : fuzzed_data_provider.ConsumeIntegral<int64_t>();
 
     const int64_t start_epoch = fuzzed_data_provider.ConsumeIntegral<int64_t>();
-    const int64_t end_epoch = start_epoch + fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(-4, 1024);
+    const int64_t offset = fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(-4, 1024);
+    int64_t end_epoch;
+    if (offset > 0 && start_epoch > std::numeric_limits<int64_t>::max() - offset) {
+        end_epoch = std::numeric_limits<int64_t>::max();
+    } else if (offset < 0 && start_epoch < std::numeric_limits<int64_t>::min() - offset) {
+        end_epoch = std::numeric_limits<int64_t>::min();
+    } else {
+        end_epoch = start_epoch + offset;
+    }
 
     double payment_amount = fuzzed_data_provider.ConsumeFloatingPointInRange<double>(-1000.0, 1000.0);
     if (fuzzed_data_provider.ConsumeBool()) {

--- a/src/test/fuzz/governance_proposal_validator.cpp
+++ b/src/test/fuzz/governance_proposal_validator.cpp
@@ -21,7 +21,10 @@ std::string HexEncodeString(const std::string& input)
     static constexpr char HEX_DIGITS[] = "0123456789abcdef";
     std::string out;
     out.reserve(input.size() * 2);
-    for (const unsigned char ch : input) {
+    // std::string holds char, which may be signed. Cast explicitly to avoid UBSan's
+    // implicit-integer-sign-change on the char->unsigned char conversion.
+    for (const char raw : input) {
+        const auto ch = static_cast<unsigned char>(raw);
         out.push_back(HEX_DIGITS[ch >> 4]);
         out.push_back(HEX_DIGITS[ch & 0x0f]);
     }

--- a/src/test/fuzz/llmq_messages.cpp
+++ b/src/test/fuzz/llmq_messages.cpp
@@ -1,0 +1,209 @@
+// Copyright (c) 2026-present The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <active/context.h>
+#include <consensus/consensus.h>
+#include <deploymentstatus.h>
+#include <llmq/blockprocessor.h>
+#include <llmq/commitment.h>
+#include <llmq/context.h>
+#include <llmq/dkgsessionmgr.h>
+#include <llmq/observer/context.h>
+#include <llmq/options.h>
+#include <llmq/quorumsman.h>
+#include <net.h>
+#include <protocol.h>
+#include <sync.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/mining.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+#include <test/util/validation.h>
+#include <validationinterface.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <memory>
+#include <string_view>
+
+namespace {
+const TestingSetup* g_setup;
+std::string_view LIMIT_TO_MESSAGE_TYPE{};
+
+const std::array<const char*, 8> LLMQ_MESSAGE_TYPES{
+    NetMsgType::QFCOMMITMENT, NetMsgType::QCONTRIB, NetMsgType::QCOMPLAINT, NetMsgType::QJUSTIFICATION,
+    NetMsgType::QPCOMMITMENT, NetMsgType::QWATCH,   NetMsgType::QGETDATA,   NetMsgType::QDATA,
+};
+
+const CBlockIndex* ConsumeQuorumBaseIndex(FuzzedDataProvider& fuzzed_data_provider, const CChain& chain)
+{
+    const CBlockIndex* tip = chain.Tip();
+    if (tip == nullptr) return nullptr;
+    const int depth = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, tip->nHeight);
+    return tip->GetAncestor(tip->nHeight - depth);
+}
+
+std::vector<bool> ConsumeFixedSizeBits(FuzzedDataProvider& fuzzed_data_provider, size_t size)
+{
+    std::vector<bool> bits(size);
+    for (size_t i = 0; i < size; ++i) {
+        bits[i] = fuzzed_data_provider.ConsumeBool();
+    }
+    return bits;
+}
+
+CDataStream BuildStructuredDKGMessage(FuzzedDataProvider& fuzzed_data_provider, const CChain& chain)
+{
+    CDataStream vRecv{SER_NETWORK, INIT_PROTO_VERSION};
+    const auto& llmqs = Params().GetConsensus().llmqs;
+    if (llmqs.empty()) {
+        return vRecv;
+    }
+
+    const auto& llmq_params = llmqs.at(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, llmqs.size() - 1));
+    const CBlockIndex* pindex = ConsumeQuorumBaseIndex(fuzzed_data_provider, chain);
+    const uint256 quorum_hash = pindex ? pindex->GetBlockHash() : uint256{};
+
+    vRecv << llmq_params.type;
+    vRecv << quorum_hash;
+
+    const auto payload = ConsumeRandomLengthByteVector(fuzzed_data_provider, 4096);
+    if (!payload.empty()) {
+        vRecv << payload;
+    }
+
+    return vRecv;
+}
+
+CDataStream BuildStructuredFinalCommitment(FuzzedDataProvider& fuzzed_data_provider, const CChain& chain)
+{
+    CDataStream vRecv{SER_NETWORK, INIT_PROTO_VERSION};
+    const auto& llmqs = Params().GetConsensus().llmqs;
+    if (llmqs.empty()) {
+        return vRecv;
+    }
+
+    const auto& llmq_params = llmqs.at(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, llmqs.size() - 1));
+    const CBlockIndex* pindex = ConsumeQuorumBaseIndex(fuzzed_data_provider, chain);
+    if (pindex == nullptr) {
+        return vRecv;
+    }
+
+    llmq::CFinalCommitment qc(llmq_params, pindex->GetBlockHash());
+    qc.nVersion = llmq::CFinalCommitment::GetVersion(llmq::IsQuorumRotationEnabled(llmq_params, pindex),
+                                                     DeploymentActiveAfter(pindex, Params().GetConsensus(),
+                                                                           Consensus::DEPLOYMENT_V19));
+    qc.quorumIndex = pindex->nHeight % llmq_params.dkgInterval;
+
+    if (fuzzed_data_provider.ConsumeBool()) {
+        qc.signers = ConsumeFixedSizeBits(fuzzed_data_provider, llmq_params.size);
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        qc.validMembers = ConsumeFixedSizeBits(fuzzed_data_provider, llmq_params.size);
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        qc.llmqType = static_cast<Consensus::LLMQType>(fuzzed_data_provider.ConsumeIntegral<uint8_t>());
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        qc.quorumHash = ConsumeUInt256(fuzzed_data_provider);
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        qc.quorumIndex = fuzzed_data_provider.ConsumeIntegral<int16_t>();
+    }
+    if (fuzzed_data_provider.ConsumeBool()) {
+        qc.nVersion = fuzzed_data_provider.ConsumeIntegral<uint16_t>();
+    }
+
+    vRecv << qc;
+    return vRecv;
+}
+} // namespace
+
+void initialize_llmq_messages()
+{
+    if (const auto val{std::getenv("LIMIT_TO_MESSAGE_TYPE")}) {
+        LIMIT_TO_MESSAGE_TYPE = val;
+        Assert(std::count(LLMQ_MESSAGE_TYPES.begin(), LLMQ_MESSAGE_TYPES.end(), LIMIT_TO_MESSAGE_TYPE)); // Unknown message type passed
+    }
+
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(
+        /*chain_name=*/CBaseChainParams::REGTEST,
+        /*extra_args=*/{"-txreconciliation", "-watchquorums=1"});
+    g_setup = testing_setup.get();
+    for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
+        MineBlock(g_setup->m_node, CScript() << OP_TRUE);
+    }
+    SyncWithValidationInterfaceQueue();
+}
+
+FUZZ_TARGET(llmq_messages, .init = initialize_llmq_messages)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    ConnmanTestMsg& connman = *static_cast<ConnmanTestMsg*>(g_setup->m_node.connman.get());
+    TestChainState& chainstate = *static_cast<TestChainState*>(&g_setup->m_node.chainman->ActiveChainstate());
+    SetMockTime(4102444800); // Keep SPORK_17_QUORUM_DKG_ENABLED active on test chains.
+    chainstate.ResetIbd();
+
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    CNode& p2p_node = *ConsumeNodeAsUniquePtr(fuzzed_data_provider).release();
+    connman.AddTestNode(p2p_node);
+    FillNode(fuzzed_data_provider, connman, p2p_node);
+
+    auto* dkg_session_manager = g_setup->m_node.active_ctx
+                                    ? g_setup->m_node.active_ctx->qdkgsman.get()
+                                    : (g_setup->m_node.observer_ctx ? g_setup->m_node.observer_ctx->qdkgsman.get()
+                                                                    : nullptr);
+
+    const size_t iterations = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, 64);
+    for (size_t i = 0; i < iterations; ++i) {
+        const std::string msg_type = fuzzed_data_provider.PickValueInArray(LLMQ_MESSAGE_TYPES);
+        if (!LIMIT_TO_MESSAGE_TYPE.empty() && msg_type != LIMIT_TO_MESSAGE_TYPE) {
+            continue;
+        }
+        CDataStream vRecv = [&]() {
+            if (msg_type == NetMsgType::QFCOMMITMENT && fuzzed_data_provider.ConsumeBool()) {
+                return BuildStructuredFinalCommitment(fuzzed_data_provider, chainstate.m_chain);
+            }
+            if ((msg_type == NetMsgType::QCONTRIB || msg_type == NetMsgType::QCOMPLAINT ||
+                 msg_type == NetMsgType::QJUSTIFICATION || msg_type == NetMsgType::QPCOMMITMENT ||
+                 msg_type == NetMsgType::QWATCH) &&
+                fuzzed_data_provider.ConsumeBool()) {
+                return BuildStructuredDKGMessage(fuzzed_data_provider, chainstate.m_chain);
+            }
+            return ConsumeDataStream(fuzzed_data_provider, MAX_PROTOCOL_MESSAGE_LENGTH);
+        }();
+
+        try {
+            if (msg_type == NetMsgType::QFCOMMITMENT) {
+                g_setup->m_node.peerman->PostProcessMessage(
+                    g_setup->m_node.llmq_ctx->quorum_block_processor->ProcessMessage(p2p_node, msg_type, vRecv),
+                    p2p_node.GetId());
+                continue;
+            }
+
+            if (dkg_session_manager != nullptr &&
+                (msg_type == NetMsgType::QCONTRIB || msg_type == NetMsgType::QCOMPLAINT ||
+                 msg_type == NetMsgType::QJUSTIFICATION || msg_type == NetMsgType::QPCOMMITMENT ||
+                 msg_type == NetMsgType::QWATCH)) {
+                g_setup->m_node.peerman->PostProcessMessage(
+                    dkg_session_manager->ProcessMessage(p2p_node, g_setup->m_node.active_ctx != nullptr, msg_type, vRecv),
+                    p2p_node.GetId());
+                continue;
+            }
+
+            g_setup->m_node.peerman->PostProcessMessage(g_setup->m_node.llmq_ctx->qman->ProcessMessage(p2p_node, connman,
+                                                                                                       msg_type, vRecv),
+                                                        p2p_node.GetId());
+        } catch (const std::ios_base::failure&) {
+        }
+    }
+
+    SyncWithValidationInterfaceQueue();
+    g_setup->m_node.connman->StopNodes();
+}

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -59,6 +60,11 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
 
     const std::string random_message_type{fuzzed_data_provider.ConsumeBytesAsString(CMessageHeader::COMMAND_SIZE).c_str()};
     if (!LIMIT_TO_MESSAGE_TYPE.empty() && random_message_type != LIMIT_TO_MESSAGE_TYPE) {
+        return;
+    }
+    // Skip Dash message types that require subsystem initialization not present in the fuzz harness
+    static const std::set<std::string> skip_message_types{"mnauth"};
+    if (skip_message_types.count(random_message_type)) {
         return;
     }
     CNode& p2p_node = *ConsumeNodeAsUniquePtr(fuzzed_data_provider).release();

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -63,9 +63,10 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     if (!LIMIT_TO_MESSAGE_TYPE.empty() && random_message_type != LIMIT_TO_MESSAGE_TYPE) {
         return;
     }
-    // Skip Dash message types that require subsystem initialization not present in the fuzz harness.
-    // TODO: initialize the masternode/LLMQ contexts here (see process_message_dash.cpp) and remove
-    // this list so these handlers get real coverage.
+    // Skip Dash message types that require subsystem initialization not present in
+    // this upstream-style harness. MNAUTH coverage is provided by the Dash-aware
+    // `process_message_dash` harness (src/test/fuzz/process_message_dash.cpp), which
+    // sets up the masternode/LLMQ contexts the handler depends on.
     static constexpr std::array<std::string_view, 1> skip_message_types{"mnauth"};
     if (std::find(skip_message_types.begin(), skip_message_types.end(), random_message_type) != skip_message_types.end()) {
         return;

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -17,10 +17,11 @@
 #include <validationinterface.h>
 #include <version.h>
 
+#include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
-#include <set>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -62,9 +63,11 @@ FUZZ_TARGET(process_message, .init = initialize_process_message)
     if (!LIMIT_TO_MESSAGE_TYPE.empty() && random_message_type != LIMIT_TO_MESSAGE_TYPE) {
         return;
     }
-    // Skip Dash message types that require subsystem initialization not present in the fuzz harness
-    static const std::set<std::string> skip_message_types{"mnauth"};
-    if (skip_message_types.count(random_message_type)) {
+    // Skip Dash message types that require subsystem initialization not present in the fuzz harness.
+    // TODO: initialize the masternode/LLMQ contexts here (see process_message_dash.cpp) and remove
+    // this list so these handlers get real coverage.
+    static constexpr std::array<std::string_view, 1> skip_message_types{"mnauth"};
+    if (std::find(skip_message_types.begin(), skip_message_types.end(), random_message_type) != skip_message_types.end()) {
         return;
     }
     CNode& p2p_node = *ConsumeNodeAsUniquePtr(fuzzed_data_provider).release();

--- a/src/test/fuzz/process_message_dash.cpp
+++ b/src/test/fuzz/process_message_dash.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2026-present The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/consensus.h>
+#include <net.h>
+#include <protocol.h>
+#include <script/script.h>
+#include <sync.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/mining.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+#include <test/util/validation.h>
+#include <validationinterface.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <memory>
+#include <string_view>
+
+namespace {
+const TestingSetup* g_setup;
+std::string_view LIMIT_TO_MESSAGE_TYPE{};
+
+const std::array<const char*, 41> DASH_MESSAGE_TYPES{
+    NetMsgType::SPORK,
+    NetMsgType::GETSPORKS,
+    NetMsgType::DSACCEPT,
+    NetMsgType::DSVIN,
+    NetMsgType::DSFINALTX,
+    NetMsgType::DSSIGNFINALTX,
+    NetMsgType::DSCOMPLETE,
+    NetMsgType::DSSTATUSUPDATE,
+    NetMsgType::DSTX,
+    NetMsgType::DSQUEUE,
+    NetMsgType::SENDDSQUEUE,
+    NetMsgType::SYNCSTATUSCOUNT,
+    NetMsgType::MNGOVERNANCESYNC,
+    NetMsgType::MNGOVERNANCEOBJECT,
+    NetMsgType::MNGOVERNANCEOBJECTVOTE,
+    NetMsgType::GETMNLISTDIFF,
+    NetMsgType::MNLISTDIFF,
+    NetMsgType::QSENDRECSIGS,
+    NetMsgType::QFCOMMITMENT,
+    NetMsgType::QCONTRIB,
+    NetMsgType::QCOMPLAINT,
+    NetMsgType::QJUSTIFICATION,
+    NetMsgType::QPCOMMITMENT,
+    NetMsgType::QWATCH,
+    NetMsgType::QSIGSESANN,
+    NetMsgType::QSIGSHARESINV,
+    NetMsgType::QGETSIGSHARES,
+    NetMsgType::QBSIGSHARES,
+    NetMsgType::QSIGREC,
+    NetMsgType::QSIGSHARE,
+    NetMsgType::QGETDATA,
+    NetMsgType::QDATA,
+    NetMsgType::CLSIG,
+    NetMsgType::ISDLOCK,
+    NetMsgType::MNAUTH,
+    NetMsgType::GETHEADERS2,
+    NetMsgType::SENDHEADERS2,
+    NetMsgType::HEADERS2,
+    NetMsgType::GETQUORUMROTATIONINFO,
+    NetMsgType::QUORUMROTATIONINFO,
+    NetMsgType::PLATFORMBAN,
+};
+} // namespace
+
+void initialize_process_message_dash()
+{
+    if (const auto val{std::getenv("LIMIT_TO_MESSAGE_TYPE")}) {
+        LIMIT_TO_MESSAGE_TYPE = val;
+        Assert(std::count(DASH_MESSAGE_TYPES.begin(), DASH_MESSAGE_TYPES.end(), LIMIT_TO_MESSAGE_TYPE)); // Unknown message type passed
+    }
+
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(
+        /*chain_name=*/CBaseChainParams::REGTEST,
+        /*extra_args=*/{"-txreconciliation"});
+    g_setup = testing_setup.get();
+    for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
+        MineBlock(g_setup->m_node, CScript() << OP_TRUE);
+    }
+    SyncWithValidationInterfaceQueue();
+}
+
+FUZZ_TARGET(process_message_dash, .init = initialize_process_message_dash)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    ConnmanTestMsg& connman = *static_cast<ConnmanTestMsg*>(g_setup->m_node.connman.get());
+    TestChainState& chainstate = *static_cast<TestChainState*>(&g_setup->m_node.chainman->ActiveChainstate());
+    SetMockTime(1610000000); // any time to successfully reset ibd
+    chainstate.ResetIbd();
+
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    CNode& p2p_node = *ConsumeNodeAsUniquePtr(fuzzed_data_provider).release();
+
+    connman.AddTestNode(p2p_node);
+    FillNode(fuzzed_data_provider, connman, p2p_node);
+
+    const auto mock_time = ConsumeTime(fuzzed_data_provider);
+    SetMockTime(mock_time);
+
+    CSerializedNetMsg net_msg;
+    net_msg.m_type = fuzzed_data_provider.PickValueInArray(DASH_MESSAGE_TYPES);
+    if (!LIMIT_TO_MESSAGE_TYPE.empty() && net_msg.m_type != LIMIT_TO_MESSAGE_TYPE) {
+        return;
+    }
+    net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider, MAX_PROTOCOL_MESSAGE_LENGTH);
+
+    connman.FlushSendBuffer(p2p_node);
+    (void)connman.ReceiveMsgFrom(p2p_node, std::move(net_msg));
+
+    bool more_work{true};
+    LIMITED_WHILE(more_work, 10000)
+    {
+        p2p_node.fPauseSend = false;
+        try {
+            more_work = connman.ProcessMessagesOnce(p2p_node);
+        } catch (const std::ios_base::failure&) {
+            more_work = false;
+        }
+        g_setup->m_node.peerman->SendMessages(&p2p_node);
+    }
+    SyncWithValidationInterfaceQueue();
+    g_setup->m_node.connman->StopNodes();
+}

--- a/src/test/fuzz/process_message_dash.cpp
+++ b/src/test/fuzz/process_message_dash.cpp
@@ -110,6 +110,7 @@ FUZZ_TARGET(process_message_dash, .init = initialize_process_message_dash)
     CSerializedNetMsg net_msg;
     net_msg.m_type = fuzzed_data_provider.PickValueInArray(DASH_MESSAGE_TYPES);
     if (!LIMIT_TO_MESSAGE_TYPE.empty() && net_msg.m_type != LIMIT_TO_MESSAGE_TYPE) {
+        g_setup->m_node.connman->StopNodes();
         return;
     }
     net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider, MAX_PROTOCOL_MESSAGE_LENGTH);

--- a/src/test/fuzz/roundtrip_dash.cpp
+++ b/src/test/fuzz/roundtrip_dash.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+// Roundtrip (deserialize -> serialize -> deserialize -> serialize) fuzz targets
+// for Dash-specific types.
+
+#include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
+
+#include <streams.h>
+#include <version.h>
+
+// evo/ types
+#include <evo/assetlocktx.h>
+#include <evo/cbtx.h>
+#include <evo/creditpool.h>
+#include <evo/deterministicmns.h>
+#include <evo/dmnstate.h>
+#include <evo/mnauth.h>
+#include <evo/mnhftx.h>
+#include <evo/providertx.h>
+#include <evo/simplifiedmns.h>
+#include <evo/smldiff.h>
+
+// llmq/ types
+#include <llmq/commitment.h>
+#include <llmq/dkgsession.h>
+#include <llmq/quorums.h>
+#include <llmq/signing.h>
+#include <llmq/signing_shares.h>
+#include <llmq/snapshot.h>
+
+// governance/ types
+#include <governance/object.h>
+
+// bls/ types
+#include <bls/bls_ies.h>
+
+// coinjoin/ types
+#include <coinjoin/coinjoin.h>
+
+#include <cassert>
+#include <exception>
+#include <stdint.h>
+
+namespace {
+
+const BasicTestingSetup* g_setup;
+
+struct dash_invalid_fuzzing_input_exception : public std::exception {
+};
+
+template <typename T>
+void DashRoundtripFromFuzzingInput(FuzzBufferType buffer, T& obj)
+{
+    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    try {
+        int version;
+        ds >> version;
+        ds.SetVersion(version);
+    } catch (const std::ios_base::failure&) {
+        throw dash_invalid_fuzzing_input_exception();
+    }
+
+    try {
+        ds >> obj;
+    } catch (const std::ios_base::failure&) {
+        throw dash_invalid_fuzzing_input_exception();
+    }
+
+    CDataStream sink(SER_NETWORK, ds.GetVersion());
+    sink << obj;
+    assert(!sink.empty());
+
+    CDataStream ds2(SER_NETWORK, ds.GetVersion());
+    ds2 << obj;
+
+    T obj2 = obj;
+    CDataStream ds3(Span<const std::byte>{ds2}, SER_NETWORK, ds.GetVersion());
+    try {
+        ds3 >> obj2;
+    } catch (const std::ios_base::failure&) {
+        assert(false);
+    }
+
+    CDataStream ds4(SER_NETWORK, ds.GetVersion());
+    ds4 << obj2;
+
+    assert(MakeByteSpan(ds2) == MakeByteSpan(ds4));
+}
+
+template <typename T>
+void DashRoundtripFromFuzzingInput(FuzzBufferType buffer)
+{
+    T obj;
+    DashRoundtripFromFuzzingInput(buffer, obj);
+}
+
+} // namespace
+
+void initialize_roundtrip_dash()
+{
+    static const auto testing_setup = MakeNoLogFileContext<>();
+    g_setup = testing_setup.get();
+}
+
+#define FUZZ_TARGET_DASH_ROUNDTRIP(name, code)                  \
+    FUZZ_TARGET(name, .init = initialize_roundtrip_dash)        \
+    {                                                           \
+        try {                                                   \
+            code                                                \
+        } catch (const dash_invalid_fuzzing_input_exception&) { \
+        }                                                       \
+    }
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_proreg_tx_roundtrip, { DashRoundtripFromFuzzingInput<CProRegTx>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_proupserv_tx_roundtrip, { DashRoundtripFromFuzzingInput<CProUpServTx>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_proupreg_tx_roundtrip, { DashRoundtripFromFuzzingInput<CProUpRegTx>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_prouprev_tx_roundtrip, { DashRoundtripFromFuzzingInput<CProUpRevTx>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_asset_lock_payload_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CAssetLockPayload>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_asset_unlock_payload_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CAssetUnlockPayload>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_cbtx_roundtrip, { DashRoundtripFromFuzzingInput<CCbTx>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_credit_pool_roundtrip, { DashRoundtripFromFuzzingInput<CCreditPool>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_deterministic_mn_roundtrip, {
+    CDeterministicMN obj(0 /* internalId, overwritten by deserialization */);
+    DashRoundtripFromFuzzingInput(buffer, obj);
+})
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_dmn_state_roundtrip, { DashRoundtripFromFuzzingInput<CDeterministicMNState>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_dmn_state_diff_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CDeterministicMNStateDiff>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_smn_list_entry_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CSimplifiedMNListEntry>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_get_smn_list_diff_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CGetSimplifiedMNListDiff>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_smn_list_diff_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CSimplifiedMNListDiff>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_mnauth_roundtrip, { DashRoundtripFromFuzzingInput<CMNAuth>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_mnhf_tx_payload_roundtrip, { DashRoundtripFromFuzzingInput<MNHFTxPayload>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_final_commitment_roundtrip,
+                           { DashRoundtripFromFuzzingInput<llmq::CFinalCommitment>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_final_commitment_tx_payload_roundtrip,
+                           { DashRoundtripFromFuzzingInput<llmq::CFinalCommitmentTxPayload>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_dkg_complaint_roundtrip, { DashRoundtripFromFuzzingInput<llmq::CDKGComplaint>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_dkg_justification_roundtrip,
+                           { DashRoundtripFromFuzzingInput<llmq::CDKGJustification>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_dkg_premature_commitment_roundtrip,
+                           { DashRoundtripFromFuzzingInput<llmq::CDKGPrematureCommitment>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_recovered_sig_roundtrip, { DashRoundtripFromFuzzingInput<llmq::CRecoveredSig>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_sig_share_roundtrip, { DashRoundtripFromFuzzingInput<llmq::CSigShare>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_sig_ses_ann_roundtrip, { DashRoundtripFromFuzzingInput<llmq::CSigSesAnn>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_sig_shares_inv_roundtrip, { DashRoundtripFromFuzzingInput<llmq::CSigSharesInv>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_batched_sig_shares_roundtrip,
+                           { DashRoundtripFromFuzzingInput<llmq::CBatchedSigShares>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_quorum_data_request_roundtrip,
+                           { DashRoundtripFromFuzzingInput<llmq::CQuorumDataRequest>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_get_quorum_rotation_info_roundtrip,
+                           { DashRoundtripFromFuzzingInput<llmq::CGetQuorumRotationInfo>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_quorum_snapshot_roundtrip,
+                           { DashRoundtripFromFuzzingInput<llmq::CQuorumSnapshot>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_governance_object_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CGovernanceObject>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_bls_ies_encrypted_blob_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CBLSIESEncryptedBlob>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_bls_ies_multi_recipient_blobs_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CBLSIESMultiRecipientBlobs>(buffer); })
+
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_coinjoin_status_update_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CCoinJoinStatusUpdate>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_coinjoin_accept_roundtrip, { DashRoundtripFromFuzzingInput<CCoinJoinAccept>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_coinjoin_entry_roundtrip, { DashRoundtripFromFuzzingInput<CCoinJoinEntry>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_coinjoin_queue_roundtrip, { DashRoundtripFromFuzzingInput<CCoinJoinQueue>(buffer); })
+FUZZ_TARGET_DASH_ROUNDTRIP(dash_coinjoin_broadcast_tx_roundtrip,
+                           { DashRoundtripFromFuzzingInput<CCoinJoinBroadcastTx>(buffer); })

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -70,17 +70,97 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "addconnection",  // avoid DNS lookups
     "addnode",        // avoid DNS lookups
     "addpeeraddress", // avoid DNS lookups
+    "bls",                   // Dash: requires MN subsystem
+    "bls fromsecret",        // Dash: requires MN subsystem
+    "bls generate",          // Dash: requires MN subsystem
+    "cleardiscouraged",      // avoid modifying ban state
+    "coinjoin",              // Dash: requires wallet/MN subsystem
+    "coinjoin reset",        // Dash: requires wallet/MN subsystem
+    "coinjoin start",        // Dash: requires wallet/MN subsystem
+    "coinjoin status",       // Dash: requires wallet/MN subsystem
+    "coinjoin stop",         // Dash: requires wallet/MN subsystem
+    "coinjoinsalt",          // Dash: requires wallet
+    "coinjoinsalt generate", // Dash: requires wallet
+    "coinjoinsalt get",      // Dash: requires wallet
+    "coinjoinsalt set",      // Dash: requires wallet
+    "debug",                 // Dash: debug command
     "dumptxoutset",   // avoid writing to disk
     "dumpwallet", // avoid writing to disk
     "echoipc",              // avoid assertion failure (Assertion `"EnsureAnyNodeContext(request.context).init" && check' failed.)
+    "enumeratesigners",      // avoid external signer interaction
+    "evodb repair",          // Dash: requires evodb
+    "evodb verify",          // Dash: requires evodb
     "generatetoaddress",    // avoid prohibitively slow execution (when `num_blocks` is large)
     "generatetodescriptor", // avoid prohibitively slow execution (when `nblocks` is large)
+    "getaddressbalance",     // Dash: requires address index
+    "getaddressdeltas",      // Dash: requires address index
+    "getaddressmempool",     // Dash: requires address index
+    "getaddresstxids",       // Dash: requires address index
+    "getaddressutxos",       // Dash: requires address index
+    "getbestchainlock",      // Dash: requires LLMQ subsystem
+    "getblockhashes",        // Dash: requires timestamp index
+    "getblockheaders",       // Dash: requires block index
+    "getcoinjoininfo",       // Dash: requires MN subsystem
+    "getgovernanceinfo",     // Dash: requires governance subsystem
+    "getislocks",            // Dash: requires LLMQ subsystem
+    "getmerkleblocks",       // Dash: requires block index
+    "getspentinfo",          // Dash: requires spent index
+    "getspecialtxes",        // Dash: requires block index
+    "getsuperblockbudget",   // Dash: requires governance subsystem
     "gettxoutproof",        // avoid prohibitively slow execution
+    "gobject",               // Dash: requires governance subsystem
+    "gobject check",         // Dash: requires governance subsystem
+    "gobject count",         // Dash: requires governance subsystem
+    "gobject deserialize",   // Dash: requires governance subsystem
+    "gobject get",           // Dash: requires governance subsystem
+    "gobject getcurrentvotes", // Dash: requires governance subsystem
+    "gobject list-prepared", // Dash: requires governance subsystem
+    "gobject prepare",       // Dash: requires governance subsystem
+    "gobject submit",        // Dash: requires governance subsystem
+    "gobject vote-alias",    // Dash: requires governance subsystem
+    "gobject vote-many",     // Dash: requires governance subsystem
     "importwallet", // avoid reading from disk
     "loadwallet",   // avoid reading from disk
+    "masternode",            // Dash: requires MN subsystem
+    "masternode connect",    // Dash: requires MN subsystem
+    "masternode count",      // Dash: requires MN subsystem
+    "masternode outputs",    // Dash: requires MN subsystem
+    "masternode payments",   // Dash: requires MN subsystem
+    "masternode status",     // Dash: requires MN subsystem
+    "masternode winners",    // Dash: requires MN subsystem
+    "masternodelist",        // Dash: requires MN subsystem
+    "mnauth",                // Dash: requires MN subsystem
+    "mnsync",                // Dash: requires MN subsystem
+    "protx diff",            // Dash: requires MN subsystem
+    "protx info",            // Dash: requires MN subsystem
+    "protx list",            // Dash: requires MN subsystem
+    "protx listdiff",       // Dash: requires MN subsystem
+    "protx register_submit", // Dash: requires MN subsystem
+    "protx revoke",          // Dash: requires MN subsystem
+    "protx update_service",  // Dash: requires MN subsystem
+    "quorum dkgsimerror",    // Dash: requires LLMQ subsystem
+    "quorum dkgstatus",      // Dash: requires LLMQ subsystem
+    "quorum getdata",        // Dash: requires LLMQ subsystem
+    "quorum getrecsig",      // Dash: requires LLMQ subsystem
+    "quorum hasrecsig",      // Dash: requires LLMQ subsystem
+    "quorum info",           // Dash: requires LLMQ subsystem
+    "quorum isconflicting",  // Dash: requires LLMQ subsystem
+    "quorum list",           // Dash: requires LLMQ subsystem
+    "quorum listextended",   // Dash: requires LLMQ subsystem
+    "quorum memberof",       // Dash: requires LLMQ subsystem
+    "quorum platformsign",   // Dash: requires LLMQ subsystem
+    "quorum selectquorum",   // Dash: requires LLMQ subsystem
+    "quorum sign",           // Dash: requires LLMQ subsystem
+    "quorum verify",         // Dash: requires LLMQ subsystem
     "savemempool",           // disabled as a precautionary measure: may take a file path argument in the future
     "setban",                // avoid DNS lookups
+    "spork",                 // Dash: requires spork subsystem
+    "sporkupdate",           // Dash: requires spork subsystem
     "stop",                  // avoid shutdown state
+    "submitchainlock",       // Dash: requires LLMQ subsystem
+    "verifychainlock",       // Dash: requires LLMQ subsystem
+    "verifyislock",          // Dash: requires LLMQ subsystem
+    "voteraw",               // Dash: requires governance subsystem
 };
 
 // RPC commands which are safe for fuzzing.

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -97,13 +97,17 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "getaddressmempool",     // Dash: requires address index
     "getaddresstxids",       // Dash: requires address index
     "getaddressutxos",       // Dash: requires address index
+    "getassetunlockstatuses", // Dash: requires chainstate
     "getbestchainlock",      // Dash: requires LLMQ subsystem
+    "getblockfrompeer",      // avoid network activity
     "getblockhashes",        // Dash: requires timestamp index
     "getblockheaders",       // Dash: requires block index
     "getcoinjoininfo",       // Dash: requires MN subsystem
     "getgovernanceinfo",     // Dash: requires governance subsystem
     "getislocks",            // Dash: requires LLMQ subsystem
     "getmerkleblocks",       // Dash: requires block index
+    "getrawtransactionmulti", // Dash: requires chainstate
+    "gettxchainlocks",       // Dash: requires LLMQ subsystem
     "getspentinfo",          // Dash: requires spent index
     "getspecialtxes",        // Dash: requires block index
     "getsuperblockbudget",   // Dash: requires governance subsystem
@@ -112,8 +116,10 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "gobject check",         // Dash: requires governance subsystem
     "gobject count",         // Dash: requires governance subsystem
     "gobject deserialize",   // Dash: requires governance subsystem
+    "gobject diff",          // Dash: requires governance subsystem
     "gobject get",           // Dash: requires governance subsystem
     "gobject getcurrentvotes", // Dash: requires governance subsystem
+    "gobject list",          // Dash: requires governance subsystem
     "gobject list-prepared", // Dash: requires governance subsystem
     "gobject prepare",       // Dash: requires governance subsystem
     "gobject submit",        // Dash: requires governance subsystem
@@ -124,6 +130,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "masternode",            // Dash: requires MN subsystem
     "masternode connect",    // Dash: requires MN subsystem
     "masternode count",      // Dash: requires MN subsystem
+    "masternode list",       // Dash: requires MN subsystem
     "masternode outputs",    // Dash: requires MN subsystem
     "masternode payments",   // Dash: requires MN subsystem
     "masternode status",     // Dash: requires MN subsystem
@@ -131,6 +138,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "masternodelist",        // Dash: requires MN subsystem
     "mnauth",                // Dash: requires MN subsystem
     "mnsync",                // Dash: requires MN subsystem
+    "protx",                 // Dash: requires MN subsystem
     "protx diff",            // Dash: requires MN subsystem
     "protx info",            // Dash: requires MN subsystem
     "protx list",            // Dash: requires MN subsystem
@@ -138,6 +146,8 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "protx register_submit", // Dash: requires MN subsystem
     "protx revoke",          // Dash: requires MN subsystem
     "protx update_service",  // Dash: requires MN subsystem
+    "quorum",                // Dash: requires LLMQ subsystem
+    "quorum dkginfo",        // Dash: requires LLMQ subsystem
     "quorum dkgsimerror",    // Dash: requires LLMQ subsystem
     "quorum dkgstatus",      // Dash: requires LLMQ subsystem
     "quorum getdata",        // Dash: requires LLMQ subsystem
@@ -149,6 +159,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "quorum listextended",   // Dash: requires LLMQ subsystem
     "quorum memberof",       // Dash: requires LLMQ subsystem
     "quorum platformsign",   // Dash: requires LLMQ subsystem
+    "quorum rotationinfo",   // Dash: requires LLMQ subsystem
     "quorum selectquorum",   // Dash: requires LLMQ subsystem
     "quorum sign",           // Dash: requires LLMQ subsystem
     "quorum verify",         // Dash: requires LLMQ subsystem

--- a/src/test/fuzz/simplified_mn_list_diff.cpp
+++ b/src/test/fuzz/simplified_mn_list_diff.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <stdexcept>
@@ -163,18 +164,18 @@ FUZZ_TARGET(simplified_mn_list_diff, .init = initialize_simplified_mn_list_diff)
     CSimplifiedMNListDiff roundtrip;
     ds >> roundtrip;
 
-    if (roundtrip.baseBlockHash != diff.baseBlockHash || roundtrip.blockHash != diff.blockHash ||
-        !MutableTxEqual(roundtrip.cbTx, diff.cbTx) ||
-        SerializeMerkleTree(roundtrip.cbTxMerkleTree) != SerializeMerkleTree(diff.cbTxMerkleTree) ||
-        roundtrip.deletedMNs != diff.deletedMNs || roundtrip.mnList.size() != diff.mnList.size() ||
-        roundtrip.nVersion != diff.nVersion || roundtrip.deletedQuorums != diff.deletedQuorums ||
-        roundtrip.newQuorums.size() != diff.newQuorums.size() || roundtrip.quorumsCLSigs != diff.quorumsCLSigs) {
-        throw std::runtime_error("simplified_mn_list_diff: serialized fields mismatch");
-    }
+    assert(roundtrip.baseBlockHash == diff.baseBlockHash);
+    assert(roundtrip.blockHash == diff.blockHash);
+    assert(MutableTxEqual(roundtrip.cbTx, diff.cbTx));
+    assert(SerializeMerkleTree(roundtrip.cbTxMerkleTree) == SerializeMerkleTree(diff.cbTxMerkleTree));
+    assert(roundtrip.deletedMNs == diff.deletedMNs);
+    assert(roundtrip.mnList.size() == diff.mnList.size());
+    assert(roundtrip.nVersion == diff.nVersion);
+    assert(roundtrip.deletedQuorums == diff.deletedQuorums);
+    assert(roundtrip.newQuorums.size() == diff.newQuorums.size());
+    assert(roundtrip.quorumsCLSigs == diff.quorumsCLSigs);
     for (size_t i = 0; i < diff.mnList.size(); ++i) {
-        if (roundtrip.mnList[i] != diff.mnList[i]) {
-            throw std::runtime_error("simplified_mn_list_diff: mnList mismatch");
-        }
+        assert(roundtrip.mnList[i] == diff.mnList[i]);
     }
 
     CDataStream ds_random(fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>(), SER_NETWORK, PROTOCOL_VERSION);

--- a/src/test/fuzz/simplified_mn_list_diff.cpp
+++ b/src/test/fuzz/simplified_mn_list_diff.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bls/bls.h>
+#include <evo/deterministicmns.h>
+#include <evo/netinfo.h>
+#include <evo/simplifiedmns.h>
+#include <evo/smldiff.h>
+#include <llmq/commitment.h>
+#include <script/script.h>
+#include <script/standard.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/fuzz/util_dash.h>
+#include <test/util/setup_common.h>
+#include <tinyformat.h>
+#include <version.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+const TestingSetup* g_setup;
+
+std::vector<std::byte> SerializeMerkleTree(const CPartialMerkleTree& tree)
+{
+    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+    ds << tree;
+    return {ds.begin(), ds.end()};
+}
+
+bool MutableTxEqual(const CMutableTransaction& lhs, const CMutableTransaction& rhs)
+{
+    return lhs.vin == rhs.vin &&
+           lhs.vout == rhs.vout &&
+           lhs.nVersion == rhs.nVersion &&
+           lhs.nType == rhs.nType &&
+           lhs.nLockTime == rhs.nLockTime &&
+           lhs.vExtraPayload == rhs.vExtraPayload;
+}
+
+} // namespace
+
+void initialize_simplified_mn_list_diff()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(CBaseChainParams::REGTEST);
+    g_setup = testing_setup.get();
+}
+
+FUZZ_TARGET(simplified_mn_list_diff, .init = initialize_simplified_mn_list_diff)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const int source_height = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 10000);
+    const uint256 source_hash = ConsumeUInt256(fuzzed_data_provider);
+    CDeterministicMNList list_from(source_hash, source_height, 0);
+
+    uint64_t next_internal_id = 1;
+    uint64_t next_unique_tag = 1;
+    const size_t initial_mn_count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 8);
+    for (size_t i = 0; i < initial_mn_count; ++i) {
+        const MnType mn_type = fuzzed_data_provider.ConsumeBool() ? MnType::Evo : MnType::Regular;
+        list_from.AddMN(MakeMasternode(next_internal_id++, next_unique_tag++, source_height, mn_type), /*fBumpTotalCount=*/true);
+    }
+
+    CDeterministicMNList list_to(list_from);
+    const size_t operation_count = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 24);
+    for (size_t i = 0; i < operation_count; ++i) {
+        const uint8_t op = fuzzed_data_provider.ConsumeIntegralInRange<uint8_t>(0, 2);
+        if (op == 0) {
+            const MnType mn_type = fuzzed_data_provider.ConsumeBool() ? MnType::Evo : MnType::Regular;
+            list_to.AddMN(MakeMasternode(next_internal_id++, next_unique_tag++, source_height, mn_type), /*fBumpTotalCount=*/true);
+            continue;
+        }
+
+        const auto hashes = GetProTxHashes(list_to);
+        if (hashes.empty()) continue;
+        const size_t index = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, hashes.size() - 1);
+
+        if (op == 1) {
+            list_to.RemoveMN(hashes[index]);
+            continue;
+        }
+
+        const auto old_mn = list_to.GetMN(hashes[index]);
+        if (!old_mn) continue;
+        auto new_state = std::make_shared<CDeterministicMNState>(*old_mn->pdmnState);
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<uint8_t>(0, 9)) {
+        case 0:
+            new_state->confirmedHash = HashFromTag(next_unique_tag++ ^ 0x33333333ULL);
+            break;
+        case 1: {
+            CBLSSecretKey sk;
+            sk.MakeNewKey();
+            new_state->nVersion = ProTxVersion::BasicBLS;
+            new_state->pubKeyOperator.Set(sk.GetPublicKey(), /*specificLegacyScheme=*/false);
+            break;
+        }
+        case 2:
+            new_state->keyIDVoting = CKeyID(Uint160FromTag(next_unique_tag++ ^ 0x06060606ULL));
+            break;
+        case 3: {
+            auto net_info = NetInfoInterface::MakeNetInfo(new_state->nVersion);
+            if (net_info && net_info->AddEntry(NetInfoPurpose::CORE_P2P, AddressFromTag(next_unique_tag++)) == NetInfoStatus::Success) {
+                new_state->netInfo = std::move(net_info);
+            }
+            break;
+        }
+        case 4:
+            new_state->scriptPayout = CScript() << OP_DUP << OP_HASH160 << ToByteVector(Uint160FromTag(next_unique_tag++)) << OP_EQUALVERIFY << OP_CHECKSIG;
+            break;
+        case 5:
+            new_state->scriptOperatorPayout = CScript() << OP_DUP << OP_HASH160 << ToByteVector(Uint160FromTag(next_unique_tag++ ^ 0x08080808ULL)) << OP_EQUALVERIFY << OP_CHECKSIG;
+            break;
+        case 6:
+            new_state->BanIfNotBanned(fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 100000));
+            break;
+        case 7:
+            new_state->platformNodeID = Uint160FromTag(next_unique_tag++ ^ 0x12121212ULL);
+            break;
+        case 8:
+            new_state->platformHTTPPort = fuzzed_data_provider.ConsumeIntegral<uint16_t>();
+            break;
+        case 9:
+            new_state->nRegisteredHeight = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 10000);
+            break;
+        }
+        list_to.UpdateMN(*old_mn, new_state);
+    }
+
+    list_to.SetBlockHash(ConsumeUInt256(fuzzed_data_provider));
+    list_to.SetHeight(fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 100000));
+
+    CSimplifiedMNListDiff diff;
+    diff.baseBlockHash = list_from.GetBlockHash();
+    diff.blockHash = list_to.GetBlockHash();
+    diff.cbTx = CMutableTransaction{};
+    diff.cbTxMerkleTree = CPartialMerkleTree{};
+
+    list_to.ForEachMN(/*onlyValid=*/false, [&](const auto& to_mn) {
+        const auto from_mn = list_from.GetMN(to_mn.proTxHash);
+        if (!from_mn || to_mn.to_sml_entry() != from_mn->to_sml_entry()) {
+            diff.mnList.emplace_back(to_mn.to_sml_entry());
+        }
+    });
+    list_from.ForEachMN(/*onlyValid=*/false, [&](const auto& from_mn) {
+        if (!list_to.GetMN(from_mn.proTxHash)) {
+            diff.deletedMNs.emplace_back(from_mn.proTxHash);
+        }
+    });
+
+    CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+    ds << diff;
+    CSimplifiedMNListDiff roundtrip;
+    ds >> roundtrip;
+
+    if (roundtrip.baseBlockHash != diff.baseBlockHash || roundtrip.blockHash != diff.blockHash ||
+        !MutableTxEqual(roundtrip.cbTx, diff.cbTx) ||
+        SerializeMerkleTree(roundtrip.cbTxMerkleTree) != SerializeMerkleTree(diff.cbTxMerkleTree) ||
+        roundtrip.deletedMNs != diff.deletedMNs || roundtrip.mnList.size() != diff.mnList.size() ||
+        roundtrip.nVersion != diff.nVersion || roundtrip.deletedQuorums != diff.deletedQuorums ||
+        roundtrip.newQuorums.size() != diff.newQuorums.size() || roundtrip.quorumsCLSigs != diff.quorumsCLSigs) {
+        throw std::runtime_error("simplified_mn_list_diff: serialized fields mismatch");
+    }
+    for (size_t i = 0; i < diff.mnList.size(); ++i) {
+        if (roundtrip.mnList[i] != diff.mnList[i]) {
+            throw std::runtime_error("simplified_mn_list_diff: mnList mismatch");
+        }
+    }
+
+    CDataStream ds_random(fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>(), SER_NETWORK, PROTOCOL_VERSION);
+    try {
+        CSimplifiedMNListDiff random_diff;
+        ds_random >> random_diff;
+    } catch (const std::exception&) {
+    }
+}

--- a/src/test/fuzz/simplified_mn_list_diff.cpp
+++ b/src/test/fuzz/simplified_mn_list_diff.cpp
@@ -100,8 +100,8 @@ FUZZ_TARGET(simplified_mn_list_diff, .init = initialize_simplified_mn_list_diff)
             new_state->confirmedHash = HashFromTag(next_unique_tag++ ^ 0x33333333ULL);
             break;
         case 1: {
-            CBLSSecretKey sk;
-            sk.MakeNewKey();
+            const uint256 operator_seed = HashFromTag(next_unique_tag++ ^ 0x04040404ULL);
+            const CBLSSecretKey sk{Span<const unsigned char>{operator_seed.begin(), operator_seed.size()}};
             new_state->nVersion = ProTxVersion::BasicBLS;
             new_state->pubKeyOperator.Set(sk.GetPublicKey(), /*specificLegacyScheme=*/false);
             break;

--- a/src/test/fuzz/simplified_mn_list_diff.cpp
+++ b/src/test/fuzz/simplified_mn_list_diff.cpp
@@ -126,10 +126,18 @@ FUZZ_TARGET(simplified_mn_list_diff, .init = initialize_simplified_mn_list_diff)
             new_state->BanIfNotBanned(fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 100000));
             break;
         case 7:
-            new_state->platformNodeID = Uint160FromTag(next_unique_tag++ ^ 0x12121212ULL);
+            // platformNodeID is only serialized in CSimplifiedMNListEntry when nType == Evo.
+            // Mutating it on a Regular MN would break the round-trip invariant below.
+            if (old_mn->nType == MnType::Evo) {
+                new_state->platformNodeID = Uint160FromTag(next_unique_tag++ ^ 0x12121212ULL);
+            }
             break;
         case 8:
-            new_state->platformHTTPPort = fuzzed_data_provider.ConsumeIntegral<uint16_t>();
+            // platformHTTPPort is only serialized when nType == Evo && nVersion < ExtAddr;
+            // MakeMasternode/case 1 never set nVersion >= ExtAddr, so guarding on Evo suffices.
+            if (old_mn->nType == MnType::Evo) {
+                new_state->platformHTTPPort = fuzzed_data_provider.ConsumeIntegral<uint16_t>();
+            }
             break;
         case 9:
             new_state->nRegisteredHeight = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 10000);

--- a/src/test/fuzz/special_tx_validation.cpp
+++ b/src/test/fuzz/special_tx_validation.cpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+#include <consensus/validation.h>
+#include <evo/chainhelper.h>
+#include <evo/specialtxman.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/util/mining.h>
+#include <test/util/setup_common.h>
+#include <util/check.h>
+#include <validation.h>
+#include <validationinterface.h>
+#include <version.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace {
+const TestingSetup* g_setup;
+} // namespace
+
+void initialize_special_tx_validation()
+{
+    static const auto testing_setup = MakeNoLogFileContext<const TestingSetup>(
+        CBaseChainParams::REGTEST, {"-dip3params=2:2", "-testactivationheight=v20@2", "-testactivationheight=mn_rr@2"});
+    g_setup = testing_setup.get();
+    // Mine blocks past the activation height so DIP3/v20/mn_rr are active
+    for (int i = 0; i < 3; ++i) {
+        MineBlock(g_setup->m_node, CScript() << OP_TRUE);
+    }
+    SyncWithValidationInterfaceQueue();
+}
+
+static CMutableTransaction DeserializeCandidateTx(FuzzedDataProvider& fuzzed_data_provider)
+{
+    CMutableTransaction tx;
+    bool deserialized{false};
+
+    CDataStream ds(fuzzed_data_provider.ConsumeBytes<uint8_t>(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096)),
+                   SER_NETWORK, INIT_PROTO_VERSION);
+    try {
+        int nVersion;
+        ds >> nVersion;
+        ds.SetVersion(nVersion);
+        ds >> tx;
+        deserialized = true;
+    } catch (const std::ios_base::failure&) {
+    }
+
+    if (!deserialized) {
+        tx.nVersion = fuzzed_data_provider.ConsumeBool() ? CTransaction::CURRENT_VERSION : CTransaction::SPECIAL_VERSION;
+        tx.nType = fuzzed_data_provider.ConsumeIntegral<uint16_t>();
+        tx.nLockTime = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+        tx.vExtraPayload = fuzzed_data_provider.ConsumeBytes<uint8_t>(
+            fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 256));
+    }
+
+    return tx;
+}
+
+FUZZ_TARGET(special_tx_validation, .init = initialize_special_tx_validation)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const CMutableTransaction base_candidate = DeserializeCandidateTx(fuzzed_data_provider);
+
+    static constexpr std::array<uint16_t, 9> SPECIAL_TYPES{
+        TRANSACTION_PROVIDER_REGISTER,
+        TRANSACTION_PROVIDER_UPDATE_SERVICE,
+        TRANSACTION_PROVIDER_UPDATE_REGISTRAR,
+        TRANSACTION_PROVIDER_UPDATE_REVOKE,
+        TRANSACTION_COINBASE,
+        TRANSACTION_QUORUM_COMMITMENT,
+        TRANSACTION_MNHF_SIGNAL,
+        TRANSACTION_ASSET_LOCK,
+        TRANSACTION_ASSET_UNLOCK,
+    };
+
+    auto* const special_tx = g_setup->m_node.chain_helper->special_tx.get();
+    Assert(special_tx != nullptr);
+
+    LOCK(::cs_main);
+    const CBlockIndex* const pindex_prev = g_setup->m_node.chainman->ActiveChain().Tip();
+    if (pindex_prev == nullptr) return;
+    const CCoinsViewCache& coins_view = g_setup->m_node.chainman->ActiveChainstate().CoinsTip();
+
+    const auto iterations = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(1, SPECIAL_TYPES.size());
+    for (size_t i = 0; i < iterations; ++i) {
+        CMutableTransaction mut_tx{base_candidate};
+        mut_tx.nVersion = CTransaction::SPECIAL_VERSION;
+        const auto type_idx = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, SPECIAL_TYPES.size() - 1);
+        mut_tx.nType = SPECIAL_TYPES[type_idx];
+
+        if (fuzzed_data_provider.ConsumeBool()) {
+            mut_tx.vExtraPayload = fuzzed_data_provider.ConsumeBytes<uint8_t>(
+                fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 512));
+        }
+
+        TxValidationState state;
+        const bool accepted{special_tx->CheckSpecialTx(CTransaction{mut_tx}, pindex_prev, coins_view,
+                                                       fuzzed_data_provider.ConsumeBool(), state)};
+        Assert(accepted == state.IsValid());
+    }
+}

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -142,7 +142,7 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
     outpoints_rbf = outpoints_supply;
 
     // The sum of the values of all spendable outpoints
-    constexpr CAmount SUPPLY_TOTAL{COINBASE_MATURITY * 50 * COIN};
+    constexpr CAmount SUPPLY_TOTAL{COINBASE_MATURITY * 500 * COIN};
 
     CTxMemPool tx_pool_{/*estimator=*/nullptr, /*check_ratio=*/1};
     MockedTxPool& tx_pool = *static_cast<MockedTxPool*>(&tx_pool_);

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -141,7 +141,10 @@ FUZZ_TARGET(tx_pool_standard, .init = initialize_tx_pool)
     }
     outpoints_rbf = outpoints_supply;
 
-    // The sum of the values of all spendable outpoints
+    // The sum of the values of all spendable outpoints.
+    // Upstream Bitcoin uses 50; Dash's regtest block subsidy is ~10x higher, so
+    // matching the real coinbase value avoids accounting mismatches that make
+    // the mempool refuse fuzzer-generated spends.
     constexpr CAmount SUPPLY_TOTAL{COINBASE_MATURITY * 500 * COIN};
 
     CTxMemPool tx_pool_{/*estimator=*/nullptr, /*check_ratio=*/1};

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -334,7 +334,7 @@ CMutableTransaction ConsumeTransaction(FuzzedDataProvider& fuzzed_data_provider,
     CMutableTransaction tx_mut;
     tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ?
                           CTransaction::CURRENT_VERSION :
-                          fuzzed_data_provider.ConsumeIntegral<int32_t>();
+                          fuzzed_data_provider.ConsumeIntegral<int16_t>();
     tx_mut.nLockTime = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
     const auto num_in = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, max_num_in);
     const auto num_out = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, max_num_out);

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -332,13 +332,24 @@ int64_t ConsumeTime(FuzzedDataProvider& fuzzed_data_provider, const std::optiona
 CMutableTransaction ConsumeTransaction(FuzzedDataProvider& fuzzed_data_provider, const std::optional<std::vector<uint256>>& prevout_txids, const int max_num_in, const int max_num_out) noexcept
 {
     CMutableTransaction tx_mut;
-    // Narrowed to int16_t: Dash encodes nType in the upper 16 bits of nVersion
-    // for SPECIAL_VERSION transactions. Fuzzing the full int32_t range triggers
-    // unrelated special-tx-type crashes that swamp this target; callers wanting
-    // broad nVersion coverage should use the special_tx_validation fuzz target.
-    tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ?
-                          CTransaction::CURRENT_VERSION :
-                          fuzzed_data_provider.ConsumeIntegral<int16_t>();
+    // Dash splits the on-wire 32-bit version field into a 16-bit nVersion and a
+    // 16-bit nType (upper bits). Keep a common normal-tx path
+    // (nType == TRANSACTION_NORMAL) so this helper doesn't drown the fuzzer in unrelated
+    // special-tx-type crashes; gate the full 32-bit coverage behind a bool so
+    // it still gets exercised but doesn't dominate every non-current case.
+    if (fuzzed_data_provider.ConsumeBool()) {
+        // Full 32-bit serialized version coverage: low 16 bits -> nVersion,
+        // high 16 bits -> nType.
+        const auto n32bit_version = fuzzed_data_provider.ConsumeIntegral<int32_t>();
+        tx_mut.nVersion = static_cast<int16_t>(n32bit_version & 0xffff);
+        tx_mut.nType = static_cast<uint16_t>((n32bit_version >> 16) & 0xffff);
+    } else {
+        // Common normal-tx path: high bits zero, narrow nVersion fuzzing.
+        tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ?
+                              CTransaction::CURRENT_VERSION :
+                              fuzzed_data_provider.ConsumeIntegral<int16_t>();
+        tx_mut.nType = TRANSACTION_NORMAL;
+    }
     tx_mut.nLockTime = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
     const auto num_in = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, max_num_in);
     const auto num_out = fuzzed_data_provider.ConsumeIntegralInRange<int>(0, max_num_out);

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -332,6 +332,10 @@ int64_t ConsumeTime(FuzzedDataProvider& fuzzed_data_provider, const std::optiona
 CMutableTransaction ConsumeTransaction(FuzzedDataProvider& fuzzed_data_provider, const std::optional<std::vector<uint256>>& prevout_txids, const int max_num_in, const int max_num_out) noexcept
 {
     CMutableTransaction tx_mut;
+    // Narrowed to int16_t: Dash encodes nType in the upper 16 bits of nVersion
+    // for SPECIAL_VERSION transactions. Fuzzing the full int32_t range triggers
+    // unrelated special-tx-type crashes that swamp this target; callers wanting
+    // broad nVersion coverage should use the special_tx_validation fuzz target.
     tx_mut.nVersion = fuzzed_data_provider.ConsumeBool() ?
                           CTransaction::CURRENT_VERSION :
                           fuzzed_data_provider.ConsumeIntegral<int16_t>();

--- a/src/test/fuzz/util_dash.h
+++ b/src/test/fuzz/util_dash.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_FUZZ_UTIL_DASH_H
+#define BITCOIN_TEST_FUZZ_UTIL_DASH_H
+
+#include <bls/bls.h>
+#include <evo/deterministicmns.h>
+#include <evo/netinfo.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <script/standard.h>
+#include <tinyformat.h>
+
+#include <array>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+inline uint256 HashFromTag(uint64_t tag)
+{
+    uint256 hash;
+    std::array<uint8_t, 8> seed{};
+    WriteLE64(seed.data(), tag);
+    for (size_t i = 0; i < hash.size(); ++i) {
+        hash.begin()[i] = static_cast<uint8_t>(seed[i % seed.size()] + static_cast<uint8_t>(i * 13));
+    }
+    if (hash.IsNull()) {
+        hash.begin()[0] = 1;
+    }
+    return hash;
+}
+
+inline uint160 Uint160FromTag(uint64_t tag)
+{
+    uint160 value;
+    std::array<uint8_t, 8> seed{};
+    WriteLE64(seed.data(), tag);
+    for (size_t i = 0; i < value.size(); ++i) {
+        value.begin()[i] = static_cast<uint8_t>(seed[i % seed.size()] + static_cast<uint8_t>(i * 7 + 1));
+    }
+    if (value.IsNull()) {
+        value.begin()[0] = 1;
+    }
+    return value;
+}
+
+inline std::string AddressFromTag(uint64_t tag)
+{
+    const uint32_t a = 1 + (tag % 223);
+    const uint32_t b = 1 + ((tag / 223) % 254);
+    const uint32_t c = 1 + ((tag / (223 * 254)) % 254);
+    const uint32_t d = 1 + ((tag / (223 * 254 * 254)) % 254);
+    const uint32_t port = 1000 + (tag % 50000);
+    return strprintf("%u.%u.%u.%u:%u", a, b, c, d, port);
+}
+
+inline CDeterministicMNCPtr MakeMasternode(const uint64_t internal_id, const uint64_t unique_tag, const int height, const MnType mn_type = MnType::Regular)
+{
+    auto state = std::make_shared<CDeterministicMNState>();
+    state->nVersion = mn_type == MnType::Evo ? ProTxVersion::BasicBLS : ProTxVersion::LegacyBLS;
+    state->nRegisteredHeight = height;
+    state->nLastPaidHeight = height > 0 ? height - 1 : 0;
+    state->nConsecutivePayments = static_cast<int>(unique_tag % 4);
+    state->nPoSePenalty = static_cast<int>(unique_tag % 8);
+    state->nPoSeRevivedHeight = -1;
+    state->nRevocationReason = CProUpRevTx::REASON_NOT_SPECIFIED;
+    state->confirmedHash = HashFromTag(unique_tag ^ 0x01010101ULL);
+    state->confirmedHashWithProRegTxHash = HashFromTag(unique_tag ^ 0x02020202ULL);
+    state->keyIDOwner = CKeyID(Uint160FromTag(unique_tag ^ 0x03030303ULL));
+    state->keyIDVoting = CKeyID(Uint160FromTag(unique_tag ^ 0x04040404ULL));
+    state->netInfo = NetInfoInterface::MakeNetInfo(state->nVersion);
+    if (!state->netInfo ||
+        state->netInfo->AddEntry(NetInfoPurpose::CORE_P2P, AddressFromTag(unique_tag)) != NetInfoStatus::Success) {
+        throw std::runtime_error("failed to create deterministic masternode netInfo");
+    }
+
+    if (mn_type == MnType::Evo) {
+        state->platformNodeID = Uint160FromTag(unique_tag ^ 0xABABABABULL);
+        state->platformP2PPort = static_cast<uint16_t>(10000 + (unique_tag % 50000));
+        state->platformHTTPPort = static_cast<uint16_t>(11000 + (unique_tag % 50000));
+    }
+
+    auto dmn = std::make_shared<CDeterministicMN>(internal_id, mn_type);
+    dmn->proTxHash = HashFromTag(unique_tag ^ 0x11111111ULL);
+    dmn->collateralOutpoint = COutPoint(HashFromTag(unique_tag ^ 0x22222222ULL), static_cast<uint32_t>(unique_tag % 8));
+    dmn->nOperatorReward = static_cast<uint16_t>(unique_tag % 10000);
+    dmn->pdmnState = state;
+    return dmn;
+}
+
+inline std::vector<uint256> GetProTxHashes(const CDeterministicMNList& mn_list)
+{
+    std::vector<uint256> hashes;
+    mn_list.ForEachMN(/*onlyValid=*/false, [&](const CDeterministicMN& dmn) { hashes.push_back(dmn.proTxHash); });
+    return hashes;
+}
+
+#endif // BITCOIN_TEST_FUZZ_UTIL_DASH_H

--- a/src/test/fuzz/utxo_snapshot.cpp
+++ b/src/test/fuzz/utxo_snapshot.cpp
@@ -21,6 +21,7 @@ const std::vector<std::shared_ptr<CBlock>>* g_chain;
 
 void initialize_chain()
 {
+    SelectParams(CBaseChainParams::REGTEST);
     const auto params{CreateChainParams(ArgsManager{}, CBaseChainParams::REGTEST)};
     static const auto chain{CreateBlockChain(2 * COINBASE_MATURITY, *params)};
     g_chain = &chain;

--- a/src/test/llmq_snapshot_tests.cpp
+++ b/src/test/llmq_snapshot_tests.cpp
@@ -68,6 +68,33 @@ BOOST_AUTO_TEST_CASE(quorum_snapshot_serialization_test)
     BOOST_CHECK(deserialized.mnSkipList == snapshot.mnSkipList);
 }
 
+BOOST_AUTO_TEST_CASE(quorum_snapshot_inplace_redeserialization_test)
+{
+    // Regression test: CDBWrapper::Read performs in-place deserialization into a caller-supplied
+    // object. The Unserialize path must reset mnSkipList so stale entries from a prior read are
+    // not retained when a smaller snapshot is read into the same object.
+    CQuorumSnapshot first(CreateBitVector(8, {0, 2, 4, 6}), SnapshotSkipMode::MODE_SKIPPING_ENTRIES,
+                          {100, 200, 300, 400, 500});
+    CQuorumSnapshot second(CreateBitVector(4, {1, 3}), SnapshotSkipMode::MODE_NO_SKIPPING_ENTRIES, {7, 8});
+
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss1 << first;
+    CDataStream ss2(SER_NETWORK, PROTOCOL_VERSION);
+    ss2 << second;
+
+    CQuorumSnapshot target;
+    ss1 >> target;
+    BOOST_CHECK(target.mnSkipList == first.mnSkipList);
+
+    // Re-deserialize into the same object. Without the clear() in Unserialize, the second
+    // snapshot's entries would be appended onto the first snapshot's entries.
+    ss2 >> target;
+    BOOST_CHECK(target.activeQuorumMembers == second.activeQuorumMembers);
+    BOOST_CHECK_EQUAL(target.mnSkipListMode, second.mnSkipListMode);
+    BOOST_CHECK(target.mnSkipList == second.mnSkipList);
+    BOOST_CHECK_EQUAL(target.mnSkipList.size(), second.mnSkipList.size());
+}
+
 BOOST_AUTO_TEST_CASE(quorum_snapshot_skip_modes_test)
 {
     // Test all skip modes

--- a/test/sanitizer_suppressions/lsan
+++ b/test/sanitizer_suppressions/lsan
@@ -1,2 +1,3 @@
 # Suppress warnings triggered in dependencies
 leak:libQt5Widgets
+leak:libdashbls

--- a/test/util/data/non-backported.txt
+++ b/test/util/data/non-backported.txt
@@ -59,6 +59,17 @@ src/test/coinjoin_*.cpp
 src/test/dip0020opcodes_tests.cpp
 src/test/dynamic_activation*.cpp
 src/test/evo*.cpp
+src/test/fuzz/asset_lock_unlock.cpp
+src/test/fuzz/bls_operations.cpp
+src/test/fuzz/coinjoin.cpp
+src/test/fuzz/deserialize_dash.cpp
+src/test/fuzz/deterministic_mn_list_diff.cpp
+src/test/fuzz/governance_proposal_validator.cpp
+src/test/fuzz/llmq_messages.cpp
+src/test/fuzz/process_message_dash.cpp
+src/test/fuzz/roundtrip_dash.cpp
+src/test/fuzz/simplified_mn_list_diff.cpp
+src/test/fuzz/special_tx_validation.cpp
 src/test/llmq*.cpp
 src/test/util/llmq_tests.h
 src/test/governance*.cpp

--- a/test/util/data/non-backported.txt
+++ b/test/util/data/non-backported.txt
@@ -70,6 +70,7 @@ src/test/fuzz/process_message_dash.cpp
 src/test/fuzz/roundtrip_dash.cpp
 src/test/fuzz/simplified_mn_list_diff.cpp
 src/test/fuzz/special_tx_validation.cpp
+src/test/fuzz/util_dash.h
 src/test/llmq*.cpp
 src/test/util/llmq_tests.h
 src/test/governance*.cpp


### PR DESCRIPTION
# Summary

Consolidates all active Dash Core fuzzing work into a single branch/PR
so we avoid cross-PR merge conflicts.

This PR now contains both:

1. **Fuzz-target expansion for Dash-specific code paths**
   (deserialization, roundtrip, and functional validators)
2. **Fuzzing infrastructure**
   (CI regression workflow, corpus tooling, and continuous fuzz daemon)

This is the end-to-end delivery for the Dash Core fuzzing initiative
([tracker#108](https://github.com/thepastaclaw/tracker/issues/108)).

## Included work (folded into this PR)

The following previously separate fuzz PRs were merged into this branch
and closed in favor of this consolidated PR:

- [#7161](https://github.com/dashpay/dash/pull/7161)
  — Dash-specific deserialization fuzz targets
- [#7162](https://github.com/dashpay/dash/pull/7162)
  — roundtrip serialize/deserialize fuzz targets
- [#7166](https://github.com/dashpay/dash/pull/7166)
  — governance proposal validator fuzz target
- [#7167](https://github.com/dashpay/dash/pull/7167)
  — BLS operations + BLS IES fuzz targets
- [#7168](https://github.com/dashpay/dash/pull/7168)
  — asset lock/unlock validation fuzz targets
- [#7169](https://github.com/dashpay/dash/pull/7169)
  — special transaction validation fuzz target
- [#7172](https://github.com/dashpay/dash/pull/7172)
  — LLMQ message handler fuzz target
- [#7174](https://github.com/dashpay/dash/pull/7174)
  — CoinJoin validation fuzz targets

## What this PR now delivers

### 1) Dash-specific fuzz target coverage

Adds broad fuzz coverage for Dash-specific serialization and functional
validation paths across:

- `evo/` (ProTx, asset lock/unlock, deterministic MN structures)
- `llmq/` (commitments, DKG/session message handling, quorum data)
- `governance/` (objects/votes/proposal validation)
- `coinjoin/` (queue/broadcast/denomination/status/entry logic)
- `bls/` (operations, aggregation, threshold ops, IES encryption)

### 2) CI fuzz regression workflow (`test-fuzz.yml`)

- Runs after existing `linux64_fuzz`
- Replays corpus inputs against all fuzz targets
- Seeds inherited targets from `bitcoin-core/qa-assets`
- Generates synthetic seeds for Dash-specific targets
- Runs smoke tests for targets without corpus
- Controlled by existing `SKIP_LINUX64_FUZZ` variable

### 3) Continuous fuzzing daemon

`contrib/fuzz/continuous_fuzz_daemon.sh`:

- Loops all targets with configurable per-target runtime
- Persists corpus at `~/fuzz_corpus/<target>/`
- Stores crash artifacts at `~/fuzz_crashes/<target>/`
- Supports daemon mode and `--single-cycle`
- Includes a systemd service file for deployment

### 4) Seed corpus generator

`contrib/fuzz/seed_corpus_from_chain.py`:

- Extracts real serialized artifacts from a running Dash node
- Covers blocks, special transactions, governance, MN/quorum data
- Supports `--synthetic-only` for offline corpus generation

## Validation

### Build verification

Built fuzz binary with `--enable-fuzz-binary` (PROVIDE_FUZZ_MAIN_FUNCTION
deterministic mode) on macOS arm64 (Apple Silicon, clang, 16 cores).
Binary compiled successfully with all 95 Dash-specific targets registered
(252 total targets including inherited Bitcoin Core targets).

### Target registration check

All 95 new Dash-specific fuzz targets confirmed registered in the binary:

- **43 deserialization targets** covering: evo (ProTx, asset lock/unlock,
  deterministic MN, credit pool), llmq (commitments, DKG messages, quorum
  snapshots, sig shares), governance (objects, votes), coinjoin (queue,
  broadcast, entry, status, accept), bls (IES encrypted blobs, multi-recipient)
- **37 roundtrip targets** verifying serialize-deserialize-reserialize
  consistency for all major Dash protocol structures
- **15 functional targets**: `asset_lock_tx`, `asset_lock_tx_raw`,
  `asset_unlock_fee`, `bls_operations`, `bls_ies`, `coinjoin_broadcasttx`,
  `coinjoin_denominations`, `coinjoin_entry_addscriptsig`, `coinjoin_queue`,
  `coinjoin_status_update`, `deterministic_mn_list_diff`,
  `governance_proposal_validator`, `llmq_messages`, `special_tx_validation`,
  `process_message_dash`

### Concrete run results

Each of the 95 Dash-specific targets was exercised with 21 inputs
(20 random seed inputs of varying sizes 1-256 bytes + 1 empty input).
All targets processed every input without crashes or hangs.

Summary: 95/95 targets PASS, 0 crashes, 0 timeouts.

| Category | Targets | Inputs each | Result |
| --- | --- | --- | --- |
| Deserialization (evo) | 13 | 21 | all PASS |
| Deserialization (llmq) | 14 | 21 | all PASS |
| Deserialization (governance) | 5 | 21 | all PASS |
| Deserialization (coinjoin) | 5 | 21 | all PASS |
| Deserialization (bls) | 3 | 21 | all PASS |
| Deserialization (other) | 3 | 21 | all PASS |
| Roundtrip (all domains) | 37 | 21 | all PASS |
| Functional validators | 15 | 21 | all PASS |

Total inputs processed: **1,995** (95 targets x 21 inputs)

### Continuous daemon validation

Daemon dry-run confirmed on Guix VM — target enumeration, corpus dir
creation, and crash dir creation all verified:

```bash
./continuous_fuzz_daemon.sh --dry-run
./continuous_fuzz_daemon.sh --single-cycle --targets bls_operations \
  --time-per-target 10
```

### Seed corpus generation

Synthetic corpus generation validated (offline mode, no running node):

```bash
python3 contrib/fuzz/seed_corpus_from_chain.py --synthetic-only -o /tmp/corpus
```

### CI behavior

- Reuses existing `linux64_fuzz` artifacts
- Integrated as a regression gate for corpus replay on PRs

### Notes on validation scope

This validation confirms all targets build, register, and handle arbitrary
input without crashing in deterministic mode. Extended fuzzing campaigns
(with libFuzzer engine + coverage feedback) are tracked separately under
the continuous fuzzing deployment plan.

## Bugs surfaced during fuzzing (pre-existing issues)

- CoinJoin timeout path UB surfaced by fuzzing
  (`CCoinJoinQueue::IsTimeOutOfBounds` signed overflow case)
- BLS library leak surfaced during long `bls_operations` campaigns
  (libdashbls internals)
- Roundtrip deserialize issue found/fixed in related work:
  `CQuorumSnapshot::Unserialize` missing `mnSkipList.clear()`
  before read loop

## Notes

- This PR supersedes the listed closed fuzz PRs as the single
  review/merge unit for fuzzing.
- Keeping this work in one branch is intended to minimize rebase churn
  while review is in progress.
