### PR TITLE
refactor: remove dependencies of CInstantSendManager on mempool, signer, chainstate

### DIFF
--- a/src/active/context.cpp
+++ b/src/active/context.cpp
@@ -32,7 +32,6 @@ ActiveContext::ActiveContext(CBLSWorker& bls_worker, ChainstateManager& chainman
                              const CMasternodeSync& mn_sync, const CBLSSecretKey& operator_sk,
                              const llmq::QvvecSyncModeMap& sync_map, const util::DbWrapperParams& db_params,
                              bool quorums_recovery, bool quorums_watch) :
-    m_isman{isman},
     m_qman{qman},
     nodeman{std::make_unique<CActiveMasternodeManager>(connman, dmnman, operator_sk)},
     dkgdbgman{std::make_unique<llmq::CDKGDebugManager>(dmnman, qsnapman, chainman)},
@@ -53,14 +52,12 @@ ActiveContext::ActiveContext(CBLSWorker& bls_worker, ChainstateManager& chainman
                                                                qblockman, qsnapman, *nodeman, chainman, sporkman,
                                                                llmq_params, quorums_watch, quorum_idx);
     });
-    m_isman.ConnectSigner(is_signer.get());
     m_qman.ConnectManagers(qman_handler.get(), qdkgsman.get());
 }
 
 ActiveContext::~ActiveContext()
 {
     m_qman.DisconnectManagers();
-    m_isman.DisconnectSigner();
 }
 
 void ActiveContext::Start(CConnman& connman, PeerManager& peerman, int16_t worker_count)

--- a/src/active/context.h
+++ b/src/active/context.h
@@ -100,6 +100,7 @@ private:
 public:
     const std::unique_ptr<instantsend::InstantSendSigner> is_signer;
 
+public:
     /** Owned by PeerManager, use GetCJServer() */
     CCoinJoinServer* m_cj_server{nullptr};
 };

--- a/src/active/context.h
+++ b/src/active/context.h
@@ -54,7 +54,6 @@ struct DbWrapperParams;
 
 struct ActiveContext final : public CValidationInterface {
 private:
-    llmq::CInstantSendManager& m_isman;
     llmq::CQuorumManager& m_qman;
 
 public:
@@ -97,6 +96,8 @@ private:
     const std::unique_ptr<llmq::CEHFSignalsHandler> ehf_sighandler;
     const std::unique_ptr<llmq::QuorumParticipant> qman_handler;
     const std::unique_ptr<chainlock::ChainLockSigner> cl_signer;
+
+public:
     const std::unique_ptr<instantsend::InstantSendSigner> is_signer;
 
     /** Owned by PeerManager, use GetCJServer() */

--- a/src/active/context.h
+++ b/src/active/context.h
@@ -100,7 +100,6 @@ private:
 public:
     const std::unique_ptr<instantsend::InstantSendSigner> is_signer;
 
-public:
     /** Owned by PeerManager, use GetCJServer() */
     CCoinJoinServer* m_cj_server{nullptr};
 };

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -85,7 +85,6 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
 void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx, int64_t nAcceptTime,
                                                          uint64_t mempool_sequence)
 {
-    Assert(m_llmq_ctx)->isman->TransactionAddedToMempool(ptx);
     m_dstxman.TransactionAddedToMempool(ptx);
 }
 

--- a/src/dsnotificationinterface.cpp
+++ b/src/dsnotificationinterface.cpp
@@ -5,34 +5,25 @@
 
 #include <dsnotificationinterface.h>
 
-#include <util/check.h>
-#include <validation.h>
-
 #include <coinjoin/coinjoin.h>
 #include <evo/deterministicmns.h>
 #include <evo/mnauth.h>
 #include <governance/governance.h>
 #include <instantsend/instantsend.h>
-#include <llmq/context.h>
-#include <llmq/dkgsessionmgr.h>
-#include <llmq/ehf_signals.h>
-#include <llmq/quorumsman.h>
 #include <masternode/sync.h>
+#include <util/check.h>
+#include <validation.h>
 
-CDSNotificationInterface::CDSNotificationInterface(CConnman& connman,
-                                                   CDSTXManager& dstxman,
-                                                   CMasternodeSync& mn_sync,
-                                                   CGovernanceManager& govman,
-                                                   const ChainstateManager& chainman,
-                                                   const std::unique_ptr<CDeterministicMNManager>& dmnman,
-                                                   const std::unique_ptr<LLMQContext>& llmq_ctx) :
+
+CDSNotificationInterface::CDSNotificationInterface(CConnman& connman, CDSTXManager& dstxman, CMasternodeSync& mn_sync,
+                                                   CGovernanceManager& govman, const ChainstateManager& chainman,
+                                                   const std::unique_ptr<CDeterministicMNManager>& dmnman) :
     m_connman{connman},
     m_dstxman{dstxman},
     m_mn_sync{mn_sync},
     m_govman{govman},
     m_chainman{chainman},
-    m_dmnman{dmnman},
-    m_llmq_ctx{llmq_ctx}
+    m_dmnman{dmnman}
 {
 }
 
@@ -76,7 +67,6 @@ void CDSNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, con
         m_dstxman.UpdatedBlockTip(pindexNew);
     }
 
-    m_llmq_ctx->isman->UpdatedBlockTip(pindexNew);
     if (m_govman.IsValid()) {
         m_govman.UpdatedBlockTip(pindexNew);
     }
@@ -88,21 +78,13 @@ void CDSNotificationInterface::TransactionAddedToMempool(const CTransactionRef& 
     m_dstxman.TransactionAddedToMempool(ptx);
 }
 
-void CDSNotificationInterface::TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason,
-                                                             uint64_t mempool_sequence)
-{
-    Assert(m_llmq_ctx)->isman->TransactionRemovedFromMempool(ptx);
-}
-
 void CDSNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
 {
-    Assert(m_llmq_ctx)->isman->BlockConnected(pblock, pindex);
     m_dstxman.BlockConnected(pblock, pindex);
 }
 
 void CDSNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
 {
-    Assert(m_llmq_ctx)->isman->BlockDisconnected(pblock, pindexDisconnected);
     m_dstxman.BlockDisconnected(pblock, pindexDisconnected);
 }
 
@@ -117,7 +99,6 @@ void CDSNotificationInterface::NotifyMasternodeListChanged(bool undo, const CDet
 void CDSNotificationInterface::NotifyChainLock(const CBlockIndex* pindex,
                                                const std::shared_ptr<const chainlock::ChainLockSig>& clsig)
 {
-    Assert(m_llmq_ctx)->isman->NotifyChainLock(pindex);
     if (m_mn_sync.IsBlockchainSynced()) {
         m_dstxman.NotifyChainLock(pindex);
     }

--- a/src/dsnotificationinterface.h
+++ b/src/dsnotificationinterface.h
@@ -13,7 +13,6 @@ class CDeterministicMNManager;
 class CGovernanceManager;
 class ChainstateManager;
 class CMasternodeSync;
-struct LLMQContext;
 
 class CDSNotificationInterface : public CValidationInterface
 {
@@ -21,13 +20,9 @@ public:
     CDSNotificationInterface() = delete;
     CDSNotificationInterface(const CDSNotificationInterface&) = delete;
     CDSNotificationInterface& operator=(const CDSNotificationInterface&) = delete;
-    explicit CDSNotificationInterface(CConnman& connman,
-                                      CDSTXManager& dstxman,
-                                      CMasternodeSync& mn_sync,
-                                      CGovernanceManager& govman,
-                                      const ChainstateManager& chainman,
-                                      const std::unique_ptr<CDeterministicMNManager>& dmnman,
-                                      const std::unique_ptr<LLMQContext>& llmq_ctx);
+    explicit CDSNotificationInterface(CConnman& connman, CDSTXManager& dstxman, CMasternodeSync& mn_sync,
+                                      CGovernanceManager& govman, const ChainstateManager& chainman,
+                                      const std::unique_ptr<CDeterministicMNManager>& dmnman);
     virtual ~CDSNotificationInterface();
 
     // a small helper to initialize current block height in sub-modules on startup
@@ -40,8 +35,6 @@ protected:
     void SynchronousUpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
     void TransactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime, uint64_t mempool_sequence) override;
-    void TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason,
-                                       uint64_t mempool_sequence) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
     void NotifyMasternodeListChanged(bool undo, const CDeterministicMNList& oldMNList, const CDeterministicMNListDiff& diff) override;
@@ -54,7 +47,6 @@ private:
     CGovernanceManager& m_govman;
     const ChainstateManager& m_chainman;
     const std::unique_ptr<CDeterministicMNManager>& m_dmnman;
-    const std::unique_ptr<LLMQContext>& m_llmq_ctx;
 };
 
 extern std::unique_ptr<CDSNotificationInterface> g_ds_notification_interface;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2209,7 +2209,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 7d: Setup other Dash services
 
-    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, node.active_ctx ? node.active_ctx->is_signer.get() : nullptr, *node.llmq_ctx->qman, chainman.ActiveChainstate(), *node.mempool, *node.mn_sync));
+    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, node.active_ctx ? node.active_ctx->is_signer.get() : nullptr, *node.llmq_ctx->sigman, *node.llmq_ctx->qman, chainman.ActiveChainstate(), *node.mempool, *node.mn_sync));
     node.peerman->AddExtraHandler(std::make_unique<llmq::NetSigning>(node.peerman.get(), *node.llmq_ctx->sigman, node.active_ctx ? node.active_ctx->shareman.get() : nullptr, *node.sporkman));
 
     if (node.active_ctx) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2209,7 +2209,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 7d: Setup other Dash services
 
-    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, node.active_ctx ? node.active_ctx->is_signer.get() : nullptr, *node.llmq_ctx->sigman, *node.llmq_ctx->qman, chainman.ActiveChainstate(), *node.mempool, *node.mn_sync));
+    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, node.active_ctx ? node.active_ctx->is_signer.get() : nullptr, *node.llmq_ctx->sigman, *node.llmq_ctx->qman, *node.chainlocks, chainman.ActiveChainstate(), *node.mempool, *node.mn_sync));
     node.peerman->AddExtraHandler(std::make_unique<llmq::NetSigning>(node.peerman.get(), *node.llmq_ctx->sigman, node.active_ctx ? node.active_ctx->shareman.get() : nullptr, *node.sporkman));
 
     if (node.active_ctx) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2208,7 +2208,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 7d: Setup other Dash services
 
-    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, *node.llmq_ctx->qman, chainman.ActiveChainstate(), *node.mempool));
+    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, *node.llmq_ctx->qman, chainman.ActiveChainstate(), *node.mempool, *node.mn_sync));
     node.peerman->AddExtraHandler(std::make_unique<llmq::NetSigning>(node.peerman.get(), *node.llmq_ctx->sigman, node.active_ctx ? node.active_ctx->shareman.get() : nullptr, *node.sporkman));
 
     if (node.active_ctx) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2208,7 +2208,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 7d: Setup other Dash services
 
-    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, *node.llmq_ctx->qman, chainman.ActiveChainstate(), *node.mempool, *node.mn_sync));
+    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, node.active_ctx ? node.active_ctx->is_signer.get() : nullptr, *node.llmq_ctx->qman, chainman.ActiveChainstate(), *node.mempool, *node.mn_sync));
     node.peerman->AddExtraHandler(std::make_unique<llmq::NetSigning>(node.peerman.get(), *node.llmq_ctx->sigman, node.active_ctx ? node.active_ctx->shareman.get() : nullptr, *node.sporkman));
 
     if (node.active_ctx) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2208,7 +2208,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 7d: Setup other Dash services
 
-    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, *node.llmq_ctx->qman, chainman.ActiveChainstate()));
+    node.peerman->AddExtraHandler(std::make_unique<NetInstantSend>(node.peerman.get(), *node.llmq_ctx->isman, *node.llmq_ctx->qman, chainman.ActiveChainstate(), *node.mempool));
     node.peerman->AddExtraHandler(std::make_unique<llmq::NetSigning>(node.peerman.get(), *node.llmq_ctx->sigman, node.active_ctx ? node.active_ctx->shareman.get() : nullptr, *node.sporkman));
 
     if (node.active_ctx) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -97,6 +97,7 @@
 #include <instantsend/net_instantsend.h>
 #include <llmq/context.h>
 #include <llmq/dkgsessionmgr.h>
+#include <llmq/signing.h>
 #include <llmq/net_signing.h>
 #include <llmq/options.h>
 #include <llmq/observer/context.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2176,7 +2176,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     RegisterValidationInterface(node.peerman.get());
 
     g_ds_notification_interface = std::make_unique<CDSNotificationInterface>(
-        *node.connman, *node.dstxman, *node.mn_sync, *node.govman, chainman, node.dmnman, node.llmq_ctx
+        *node.connman, *node.dstxman, *node.mn_sync, *node.govman, chainman, node.dmnman // todo: replace unique_ptr for dmnman to reference
     );
     RegisterValidationInterface(g_ds_notification_interface.get());
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2419,6 +2419,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         // GetMainSignals().UpdatedBlockTip(::ChainActive().Tip());
         g_ds_notification_interface->InitializeCurrentBlockTip();
 
+        // Seed InstantSend tip-height cache; NetInstantSend receives future
+        // updates via CValidationInterface but misses InitializeCurrentBlockTip.
+        // TODO: move cache updates from NetInstantSend to g_ds_notification due to specific of Tip's processing
+        node.llmq_ctx->isman->CacheTipHeight(chainman.ActiveChain().Tip());
+
         {
             // Get all UTXOs for each MN collateral in one go so that we can fill coin cache early
             // and reduce further locking overhead for cs_main in other parts of code including GUI

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -144,13 +144,13 @@ void CInstantSendManager::AddPendingISLock(const uint256& hash, const instantsen
     pendingNoTxInstantSendLocks.try_emplace(hash, instantsend::PendingISLockFromPeer{from, islock});
 }
 
-void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& tx)
+void CInstantSendManager::TransactionIsRemoved(const CTransactionRef& tx)
 {
     if (tx->vin.empty()) {
         return;
     }
 
-    instantsend::InstantSendLockPtr islock = db.GetInstantSendLockByTxid(tx->GetHash());
+    instantsend::InstantSendLockPtr islock = GetInstantSendLockByTxid(tx->GetHash());
 
     if (islock == nullptr) {
         return;
@@ -161,49 +161,14 @@ void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& t
     RemoveConflictingLock(::SerializeHash(*islock), *islock);
 }
 
-void CInstantSendManager::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
+void CInstantSendManager::WriteBlockISLocks(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
 {
-    if (!IsInstantSendEnabled()) {
-        return;
-    }
-
-    CacheTipHeight(pindex);
-
-    if (m_mn_sync.IsBlockchainSynced()) {
-        const bool has_chainlock = m_chainlocks.HasChainLock(pindex->nHeight, pindex->GetBlockHash());
-        for (const auto& tx : pblock->vtx) {
-            if (tx->IsCoinBase() || tx->vin.empty()) {
-                // coinbase and TXs with no inputs can't be locked
-                continue;
-            }
-
-            if (!IsLocked(tx->GetHash()) && !has_chainlock) {
-                if (auto signer = m_signer.load(std::memory_order_acquire); signer) {
-                    signer->ProcessTx(*tx, true, Params().GetConsensus());
-                }
-                // TX is not locked, so make sure it is tracked
-                AddNonLockedTx(tx, pindex);
-            } else {
-                // TX is locked, so make sure we don't track it anymore
-                RemoveNonLockedTx(tx->GetHash(), true);
-            }
-        }
-    }
-
     db.WriteBlockInstantSendLocks(pblock, pindex);
 }
 
-void CInstantSendManager::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock,
-                                            const CBlockIndex* pindexDisconnected)
+void CInstantSendManager::RemoveBlockISLocks(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
 {
-    {
-        LOCK(cs_height_cache);
-        m_cached_block_heights.erase(pindexDisconnected->GetBlockHash());
-    }
-
-    CacheTipHeight(pindexDisconnected->pprev);
-
-    db.RemoveBlockInstantSendLocks(pblock, pindexDisconnected);
+    db.RemoveBlockInstantSendLocks(pblock, pindex);
 }
 
 instantsend::InstantSendLockPtr CInstantSendManager::AttachISLockToTx(const CTransactionRef& tx)
@@ -337,30 +302,6 @@ void CInstantSendManager::TryEmplacePendingLock(const uint256& hash, const NodeI
     LOCK(cs_pendingLocks);
     if (!pendingInstantSendLocks.count(hash)) {
         pendingInstantSendLocks.emplace(hash, instantsend::PendingISLockFromPeer{id, islock});
-    }
-}
-
-void CInstantSendManager::NotifyChainLock(const CBlockIndex* pindexChainLock)
-{
-    HandleFullyConfirmedBlock(pindexChainLock);
-}
-
-void CInstantSendManager::UpdatedBlockTip(const CBlockIndex* pindexNew)
-{
-    CacheTipHeight(pindexNew);
-
-    bool fDIP0008Active = pindexNew->pprev && pindexNew->pprev->nHeight >= Params().GetConsensus().DIP0008Height;
-
-    if (m_chainlocks.IsEnabled() && fDIP0008Active) {
-        // Nothing to do here. We should keep all islocks and let chainlocks handle them.
-        return;
-    }
-
-    int nConfirmedHeight = pindexNew->nHeight - Params().GetConsensus().nInstantSendKeepLock;
-    const CBlockIndex* pindex = pindexNew->GetAncestor(nConfirmedHeight);
-
-    if (pindex) {
-        HandleFullyConfirmedBlock(pindex);
     }
 }
 
@@ -631,6 +572,12 @@ void CInstantSendManager::CacheBlockHeight(const CBlockIndex* const block_index)
 {
     LOCK(cs_height_cache);
     CacheBlockHeightInternal(block_index);
+}
+
+void CInstantSendManager::CacheDisconnectBlock(const CBlockIndex* pindexDisconnected)
+{
+    LOCK(cs_height_cache);
+    m_cached_block_heights.erase(pindexDisconnected->GetBlockHash());
 }
 
 std::optional<int> CInstantSendManager::GetBlockHeight(const uint256& hash) const

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -489,18 +489,22 @@ bool CInstantSendManager::RejectConflictingBlocks() const
     return true;
 }
 
-void CInstantSendManager::RemoveArchivedInstantSendLocks(int nUntilHeight)
+Uint256HashMap<instantsend::InstantSendLockPtr> CInstantSendManager::RemoveConfirmedInstantSendLocks(const CBlockIndex* pindex)
 {
-    db.RemoveArchivedInstantSendLocks(nUntilHeight);
-}
+    int nUntilHeight = pindex->nHeight;
+    auto removeISLocks = db.RemoveConfirmedInstantSendLocks(nUntilHeight);
 
-Uint256HashMap<instantsend::InstantSendLockPtr> CInstantSendManager::RemoveConfirmedInstantSendLocks(int nUntilHeight)
-{
-    return db.RemoveConfirmedInstantSendLocks(nUntilHeight);
-}
+    for (const auto& [islockHash, islock] : removeISLocks) {
+        LogPrint(BCLog::INSTANTSEND, "NetInstantSend::%s -- txid=%s, islock=%s: removed islock as it got fully confirmed\n",
+                 __func__, islock->txid.ToString(), islockHash.ToString());
 
-void CInstantSendManager::RemoveNonLockedForConfirmed(const CBlockIndex* pindex)
-{
+        // And we don't need the recovered sig for the ISLOCK anymore, as the block in which it got mined is considered
+        // fully confirmed now
+        sigman.TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend, islock->GetRequestId());
+    }
+
+    db.RemoveArchivedInstantSendLocks(nUntilHeight - 100);
+
     // Find all previously unlocked TXs that got locked by this fully confirmed (ChainLock) block and remove them
     // from the nonLockedTxs map. Also collect all children of these TXs and mark them for retrying of IS locking.
     std::vector<uint256> toRemove;
@@ -518,6 +522,7 @@ void CInstantSendManager::RemoveNonLockedForConfirmed(const CBlockIndex* pindex)
         // This will also add children to pendingRetryTxs
         RemoveNonLockedTx(txid, true);
     }
-}
 
+    return removeISLocks;
+}
 } // namespace llmq

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -408,36 +408,6 @@ void CInstantSendManager::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
     }
 }
 
-void CInstantSendManager::RemoveMempoolConflictsForLock(const uint256& hash, const instantsend::InstantSendLock& islock)
-{
-    Uint256HashMap<CTransactionRef> toDelete;
-
-    {
-        LOCK(mempool.cs);
-
-        for (const auto& in : islock.inputs) {
-            auto it = mempool.mapNextTx.find(in);
-            if (it == mempool.mapNextTx.end()) {
-                continue;
-            }
-            if (it->second->GetHash() != islock.txid) {
-                toDelete.emplace(it->second->GetHash(), mempool.get(it->second->GetHash()));
-
-                LogPrintf("CInstantSendManager::%s -- txid=%s, islock=%s: mempool TX %s with input %s conflicts with islock\n", __func__,
-                          islock.txid.ToString(), hash.ToString(), it->second->GetHash().ToString(), in.ToStringShort());
-            }
-        }
-
-        for (const auto& p : toDelete) {
-            mempool.removeRecursive(*p.second, MemPoolRemovalReason::CONFLICT);
-        }
-    }
-
-    for (const auto& p : toDelete) {
-        RemoveConflictedTx(*p.second);
-    }
-}
-
 void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock)
 {
     // Lets first collect all non-locked TXs which conflict with the given ISLOCK

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -562,17 +562,14 @@ void CInstantSendManager::CacheTipHeight(const CBlockIndex* const tip) const
 
 int CInstantSendManager::GetTipHeight() const
 {
-    {
-        LOCK(cs_height_cache);
-        if (m_cached_tip_height >= 0) {
-            return m_cached_tip_height;
-        }
+    // It returns the cached tip height which is updated through notification mechanism
+    // If cached tip is not set by any reason, it's okay to return 0 because
+    // chainstate is not fully loaded yet and tip is not set
+    LOCK(cs_height_cache);
+    if (m_cached_tip_height >= 0) {
+        return m_cached_tip_height;
     }
-
-    const CBlockIndex* tip = WITH_LOCK(::cs_main, return m_chainstate.m_chain.Tip());
-
-    CacheTipHeight(tip);
-    return tip ? tip->nHeight : -1;
+    return 0;
 }
 
 bool CInstantSendManager::IsInstantSendEnabled() const

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -12,7 +12,6 @@
 #include <node/blockstorage.h>
 #include <spork.h>
 #include <stats/client.h>
-#include <txmempool.h>
 #include <validation.h>
 
 using node::fImporting;
@@ -41,14 +40,13 @@ Uint256HashSet GetIdsFromLockable(const std::vector<T>& vec)
 } // anonymous namespace
 
 CInstantSendManager::CInstantSendManager(const chainlock::Chainlocks& chainlocks, CChainState& chainstate,
-                                         CSigningManager& _sigman, CSporkManager& sporkman, CTxMemPool& _mempool,
+                                         CSigningManager& _sigman, CSporkManager& sporkman,
                                          const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params) :
     db{db_params},
     m_chainlocks{chainlocks},
     m_chainstate{chainstate},
     sigman{_sigman},
     spork_manager{sporkman},
-    mempool{_mempool},
     m_mn_sync{mn_sync}
 {
 }

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -493,15 +493,6 @@ Uint256HashMap<instantsend::InstantSendLockPtr> CInstantSendManager::RemoveConfi
     int nUntilHeight = pindex->nHeight;
     auto removeISLocks = db.RemoveConfirmedInstantSendLocks(nUntilHeight);
 
-    for (const auto& [islockHash, islock] : removeISLocks) {
-        LogPrint(BCLog::INSTANTSEND, "NetInstantSend::%s -- txid=%s, islock=%s: removed islock as it got fully confirmed\n",
-                 __func__, islock->txid.ToString(), islockHash.ToString());
-
-        // And we don't need the recovered sig for the ISLOCK anymore, as the block in which it got mined is considered
-        // fully confirmed now
-        sigman.TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend, islock->GetRequestId());
-    }
-
     db.RemoveArchivedInstantSendLocks(nUntilHeight - 100);
 
     // Find all previously unlocked TXs that got locked by this fully confirmed (ChainLock) block and remove them

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -146,41 +146,6 @@ void CInstantSendManager::AddPendingISLock(const uint256& hash, const instantsen
     pendingNoTxInstantSendLocks.try_emplace(hash, instantsend::PendingISLockFromPeer{from, islock});
 }
 
-void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
-{
-    if (!IsInstantSendEnabled() || !m_mn_sync.IsBlockchainSynced() || tx->vin.empty()) {
-        return;
-    }
-
-    instantsend::InstantSendLockPtr islock{nullptr};
-    {
-        LOCK(cs_pendingLocks);
-        auto it = pendingNoTxInstantSendLocks.begin();
-        while (it != pendingNoTxInstantSendLocks.end()) {
-            if (it->second.islock->txid == tx->GetHash()) {
-                // we received an islock earlier
-                LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
-                         tx->GetHash().ToString(), it->first.ToString());
-                islock = it->second.islock;
-                pendingInstantSendLocks.try_emplace(it->first, it->second);
-                pendingNoTxInstantSendLocks.erase(it);
-                break;
-            }
-            ++it;
-        }
-    }
-
-    if (islock == nullptr) {
-        if (auto signer = m_signer.load(std::memory_order_acquire); signer) {
-            signer->ProcessTx(*tx, false, Params().GetConsensus());
-        }
-        // TX is not locked, so make sure it is tracked
-        AddNonLockedTx(tx, nullptr);
-    } else {
-        RemoveMempoolConflictsForLock(::SerializeHash(*islock), *islock);
-    }
-}
-
 void CInstantSendManager::TransactionRemovedFromMempool(const CTransactionRef& tx)
 {
     if (tx->vin.empty()) {
@@ -243,6 +208,26 @@ void CInstantSendManager::BlockDisconnected(const std::shared_ptr<const CBlock>&
     db.RemoveBlockInstantSendLocks(pblock, pindexDisconnected);
 }
 
+instantsend::InstantSendLockPtr CInstantSendManager::AttachISLockToTx(const CTransactionRef& tx)
+{
+    instantsend::InstantSendLockPtr ret_islock{nullptr};
+    LOCK(cs_pendingLocks);
+    auto it = pendingNoTxInstantSendLocks.begin();
+    while (it != pendingNoTxInstantSendLocks.end()) {
+        if (it->second.islock->txid == tx->GetHash()) {
+            // we received an islock earlier, let's put it back into pending and verify/lock
+            LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
+                     tx->GetHash().ToString(), it->first.ToString());
+            ret_islock = it->second.islock;
+            pendingInstantSendLocks.try_emplace(it->first, it->second);
+            pendingNoTxInstantSendLocks.erase(it);
+            return ret_islock;
+        }
+        ++it;
+    }
+    return ret_islock; // not found, nullptr
+}
+
 void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlockIndex* pindexMined)
 {
     {
@@ -259,22 +244,7 @@ void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlock
             }
         }
     }
-    {
-        LOCK(cs_pendingLocks);
-        auto it = pendingNoTxInstantSendLocks.begin();
-        while (it != pendingNoTxInstantSendLocks.end()) {
-            if (it->second.islock->txid == tx->GetHash()) {
-                // we received an islock earlier, let's put it back into pending and verify/lock
-                LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
-                         tx->GetHash().ToString(), it->first.ToString());
-                pendingInstantSendLocks.try_emplace(it->first, it->second);
-                pendingNoTxInstantSendLocks.erase(it);
-                break;
-            }
-            ++it;
-        }
-    }
-
+    AttachISLockToTx(tx);
     if (ShouldReportISLockTiming()) {
         LOCK(cs_timingsTxSeen);
         // Only insert the time the first time we see the tx, as we sometimes try to resign

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -16,12 +16,10 @@ using node::fImporting;
 using node::fReindex;
 
 namespace llmq {
-CInstantSendManager::CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSigningManager& _sigman,
-                                         CSporkManager& sporkman, const CMasternodeSync& mn_sync,
-                                         const util::DbWrapperParams& db_params) :
+CInstantSendManager::CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSporkManager& sporkman,
+                                         const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params) :
     db{db_params},
     m_chainlocks{chainlocks},
-    sigman{_sigman},
     spork_manager{sporkman},
     m_mn_sync{mn_sync}
 {

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -7,7 +7,6 @@
 #include <chainlock/chainlock.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
-#include <instantsend/signing.h>
 #include <masternode/sync.h>
 #include <node/blockstorage.h>
 #include <spork.h>

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -145,22 +145,19 @@ void CInstantSendManager::RemoveBlockISLocks(const std::shared_ptr<const CBlock>
 
 instantsend::InstantSendLockPtr CInstantSendManager::AttachISLockToTx(const CTransactionRef& tx)
 {
-    instantsend::InstantSendLockPtr ret_islock{nullptr};
     LOCK(cs_pendingLocks);
-    auto it = pendingNoTxInstantSendLocks.begin();
-    while (it != pendingNoTxInstantSendLocks.end()) {
-        if (it->second.islock->txid == tx->GetHash()) {
-            // we received an islock earlier, let's put it back into pending and verify/lock
-            LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
-                     tx->GetHash().ToString(), it->first.ToString());
-            ret_islock = it->second.islock;
-            pendingInstantSendLocks.try_emplace(it->first, it->second);
-            pendingNoTxInstantSendLocks.erase(it);
-            return ret_islock;
-        }
-        ++it;
+    for (auto it = pendingNoTxInstantSendLocks.begin(); it != pendingNoTxInstantSendLocks.end(); ++it) {
+        if (it->second.islock->txid != tx->GetHash()) continue;
+
+        // we received an islock earlier, let's put it back into pending and verify/lock
+        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s\n", __func__,
+                 tx->GetHash().ToString(), it->first.ToString());
+        auto islock = it->second.islock;
+        pendingInstantSendLocks.try_emplace(it->first, it->second);
+        pendingNoTxInstantSendLocks.erase(it);
+        return islock;
     }
-    return ret_islock; // not found, nullptr
+    return nullptr;
 }
 
 void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlockIndex* pindexMined)
@@ -290,7 +287,7 @@ std::unordered_map<const CBlockIndex*, Uint256HashMap<CTransactionRef>> CInstant
     return conflicts;
 }
 
-bool CInstantSendManager::IsKnownTx(const uint256& islockHash) const
+bool CInstantSendManager::HasTxForLock(const uint256& islockHash) const
 {
     LOCK(cs_pendingLocks);
     return pendingNoTxInstantSendLocks.find(islockHash) == pendingNoTxInstantSendLocks.end();

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -12,7 +12,6 @@
 #include <node/blockstorage.h>
 #include <spork.h>
 #include <stats/client.h>
-#include <validation.h>
 
 using node::fImporting;
 using node::fReindex;
@@ -39,12 +38,11 @@ Uint256HashSet GetIdsFromLockable(const std::vector<T>& vec)
 }
 } // anonymous namespace
 
-CInstantSendManager::CInstantSendManager(const chainlock::Chainlocks& chainlocks, CChainState& chainstate,
-                                         CSigningManager& _sigman, CSporkManager& sporkman,
-                                         const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params) :
+CInstantSendManager::CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSigningManager& _sigman,
+                                         CSporkManager& sporkman, const CMasternodeSync& mn_sync,
+                                         const util::DbWrapperParams& db_params) :
     db{db_params},
     m_chainlocks{chainlocks},
-    m_chainstate{chainstate},
     sigman{_sigman},
     spork_manager{sporkman},
     m_mn_sync{mn_sync}
@@ -511,16 +509,10 @@ CInstantSendManager::Counts CInstantSendManager::GetCounts() const
     return ret;
 }
 
-void CInstantSendManager::CacheBlockHeightInternal(const CBlockIndex* const block_index) const
-{
-    AssertLockHeld(cs_height_cache);
-    m_cached_block_heights.insert(block_index->GetBlockHash(), block_index->nHeight);
-}
-
 void CInstantSendManager::CacheBlockHeight(const CBlockIndex* const block_index) const
 {
     LOCK(cs_height_cache);
-    CacheBlockHeightInternal(block_index);
+    m_cached_block_heights.insert(block_index->GetBlockHash(), block_index->nHeight);
 }
 
 void CInstantSendManager::CacheDisconnectBlock(const CBlockIndex* pindexDisconnected)
@@ -529,31 +521,21 @@ void CInstantSendManager::CacheDisconnectBlock(const CBlockIndex* pindexDisconne
     m_cached_block_heights.erase(pindexDisconnected->GetBlockHash());
 }
 
-std::optional<int> CInstantSendManager::GetBlockHeight(const uint256& hash) const
+std::optional<int> CInstantSendManager::GetCachedHeight(const uint256& hash) const
 {
-    if (hash.IsNull()) {
-        return std::nullopt;
-    }
-    {
-        LOCK(cs_height_cache);
-        int cached_height{0};
-        if (m_cached_block_heights.get(hash, cached_height)) return cached_height;
-    }
+    LOCK(cs_height_cache);
 
-    const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(hash));
-    if (pindex == nullptr) {
-        return std::nullopt;
-    }
+    int cached_height{0};
+    if (m_cached_block_heights.get(hash, cached_height)) return cached_height;
 
-    CacheBlockHeight(pindex);
-    return pindex->nHeight;
+    return std::nullopt;
 }
 
 void CInstantSendManager::CacheTipHeight(const CBlockIndex* const tip) const
 {
     LOCK(cs_height_cache);
     if (tip) {
-        CacheBlockHeightInternal(tip);
+        m_cached_block_heights.insert(tip->GetBlockHash(), tip->nHeight);
         m_cached_tip_height = tip->nHeight;
     } else {
         m_cached_tip_height = -1;

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -4,7 +4,6 @@
 
 #include <instantsend/instantsend.h>
 
-#include <chainlock/chainlock.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <masternode/sync.h>
@@ -16,10 +15,9 @@ using node::fImporting;
 using node::fReindex;
 
 namespace llmq {
-CInstantSendManager::CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSporkManager& sporkman,
-                                         const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params) :
+CInstantSendManager::CInstantSendManager(CSporkManager& sporkman, const CMasternodeSync& mn_sync,
+                                         const util::DbWrapperParams& db_params) :
     db{db_params},
-    m_chainlocks{chainlocks},
     spork_manager{sporkman},
     m_mn_sync{mn_sync}
 {

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -14,17 +14,9 @@
 #include <stats/client.h>
 #include <txmempool.h>
 #include <validation.h>
-#include <validationinterface.h>
-
-// Forward declaration to break dependency over node/transaction.h
-namespace node {
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool,
-                               const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock);
-} // namespace node
 
 using node::fImporting;
 using node::fReindex;
-using node::GetTransaction;
 
 namespace llmq {
 namespace {
@@ -118,22 +110,15 @@ instantsend::PendingState CInstantSendManager::FetchPendingLocks()
     return ret;
 }
 
-std::variant<uint256, CTransactionRef, std::monostate> CInstantSendManager::ProcessInstantSendLock(
-    NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock)
+bool CInstantSendManager::PreVerifyIsLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, NodeId from) const
 {
-    LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s: processing islock, peer=%d\n",
-             __func__, islock->txid.ToString(), hash.ToString(), from);
-
-    if (auto signer = m_signer.load(std::memory_order_acquire); signer) {
-        signer->ClearLockFromQueue(islock);
-    }
     if (db.KnownInstantSendLock(hash)) {
-        return std::monostate{};
+        return false;
     }
 
     if (const auto sameTxIsLock = db.GetInstantSendLockByTxid(islock->txid)) {
         // can happen, nothing to do
-        return std::monostate{};
+        return false;
     }
     for (const auto& in : islock->inputs) {
         const auto sameOutpointIsLock = db.GetInstantSendLockByInput(in);
@@ -142,62 +127,23 @@ std::variant<uint256, CTransactionRef, std::monostate> CInstantSendManager::Proc
                       islock->txid.ToString(), hash.ToString(), in.ToStringShort(), ::SerializeHash(*sameOutpointIsLock).ToString(), from);
         }
     }
+    return true;
+}
 
-    uint256 hashBlock{};
-    auto tx = GetTransaction(nullptr, &mempool, islock->txid, Params().GetConsensus(), hashBlock);
-    const bool found_transaction{tx != nullptr};
-    // we ignore failure here as we must be able to propagate the lock even if we don't have the TX locally
-    std::optional<int> minedHeight = GetBlockHeight(hashBlock);
-    if (found_transaction) {
-        if (!minedHeight.has_value()) {
-            const CBlockIndex* pindexMined = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(hashBlock));
-            if (pindexMined != nullptr) {
-                CacheBlockHeight(pindexMined);
-                minedHeight = pindexMined->nHeight;
-            }
-        }
-        // Let's see if the TX that was locked by this islock is already mined in a ChainLocked block. If yes,
-        // we can simply ignore the islock, as the ChainLock implies locking of all TXs in that chain
-        if (minedHeight.has_value() && m_chainlocks.HasChainLock(*minedHeight, hashBlock)) {
-            LogPrint(BCLog::INSTANTSEND, /* Continued */
-                     "CInstantSendManager::%s -- txlock=%s, islock=%s: dropping islock as it already got a "
-                     "ChainLock in block %s, peer=%d\n",
-                     __func__, islock->txid.ToString(), hash.ToString(), hashBlock.ToString(), from);
-            return std::monostate{};
-        }
+void CInstantSendManager::WriteNewISLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock,
+                                         std::optional<int> minedHeight)
+{
+    db.WriteNewInstantSendLock(hash, islock);
+    if (minedHeight.has_value()) {
+        db.WriteInstantSendLockMined(hash, *minedHeight);
     }
+}
 
-    if (found_transaction) {
-        db.WriteNewInstantSendLock(hash, islock);
-        if (minedHeight.has_value()) {
-            db.WriteInstantSendLockMined(hash, *minedHeight);
-        }
-    } else {
-        // put it in a separate pending map and try again later
-        LOCK(cs_pendingLocks);
-        pendingNoTxInstantSendLocks.try_emplace(hash, instantsend::PendingISLockFromPeer{from, islock});
-    }
-
-    // This will also add children TXs to pendingRetryTxs
-    RemoveNonLockedTx(islock->txid, true);
-    // We don't need the recovered sigs for the inputs anymore. This prevents unnecessary propagation of these sigs.
-    // We only need the ISLOCK from now on to detect conflicts
-    TruncateRecoveredSigsForInputs(*islock);
-    ResolveBlockConflicts(hash, *islock);
-
-    if (found_transaction) {
-        RemoveMempoolConflictsForLock(hash, *islock);
-        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- notify about lock %s for tx %s\n", __func__,
-                 hash.ToString(), tx->GetHash().ToString());
-        GetMainSignals().NotifyTransactionLock(tx, islock);
-        // bump mempool counter to make sure newly locked txes are picked up by getblocktemplate
-        mempool.AddTransactionsUpdated(1);
-    }
-
-    if (found_transaction) {
-        return tx;
-    }
-    return islock->txid;
+void CInstantSendManager::AddPendingISLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, NodeId from)
+{
+    // put it in a separate pending map and try again later
+    LOCK(cs_pendingLocks);
+    pendingNoTxInstantSendLocks.try_emplace(hash, instantsend::PendingISLockFromPeer{from, islock});
 }
 
 void CInstantSendManager::TransactionAddedToMempool(const CTransactionRef& tx)
@@ -811,4 +757,5 @@ bool CInstantSendManager::RejectConflictingBlocks() const
     }
     return true;
 }
+
 } // namespace llmq

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -347,7 +347,8 @@ void CInstantSendManager::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
     }
 }
 
-void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock)
+std::unordered_map<const CBlockIndex*, Uint256HashMap<CTransactionRef>> CInstantSendManager::RetrieveISConflicts(
+    const uint256& islockHash, const instantsend::InstantSendLock& islock)
 {
     // Lets first collect all non-locked TXs which conflict with the given ISLOCK
     std::unordered_map<const CBlockIndex*, Uint256HashMap<CTransactionRef>> conflicts;
@@ -375,65 +376,13 @@ void CInstantSendManager::ResolveBlockConflicts(const uint256& islockHash, const
         }
     }
 
-    // Lets see if any of the conflicts was already mined into a ChainLocked block
-    bool hasChainLockedConflict = false;
-    for (const auto& p : conflicts) {
-        const auto* pindex = p.first;
-        if (m_chainlocks.HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
-            hasChainLockedConflict = true;
-            break;
-        }
-    }
+    return conflicts;
+}
 
-    // If a conflict was mined into a ChainLocked block, then we have no other choice and must prune the ISLOCK and all
-    // chained ISLOCKs that build on top of this one. The probability of this is practically zero and can only happen
-    // when large parts of the masternode network are controlled by an attacker. In this case we must still find
-    // consensus and its better to sacrifice individual ISLOCKs then to sacrifice whole ChainLocks.
-    if (hasChainLockedConflict) {
-        LogPrintf("CInstantSendManager::%s -- txid=%s, islock=%s: at least one conflicted TX already got a ChainLock\n",
-                  __func__, islock.txid.ToString(), islockHash.ToString());
-        RemoveConflictingLock(islockHash, islock);
-        return;
-    }
-
-    bool isLockedTxKnown = WITH_LOCK(cs_pendingLocks, return pendingNoTxInstantSendLocks.find(islockHash) ==
-                                                             pendingNoTxInstantSendLocks.end());
-
-    bool activateBestChain = false;
-    for (const auto& p : conflicts) {
-        const auto* pindex = p.first;
-        for (const auto& p2 : p.second) {
-            const auto& tx = *p2.second;
-            RemoveConflictedTx(tx);
-        }
-
-        LogPrintf("CInstantSendManager::%s -- invalidating block %s\n", __func__, pindex->GetBlockHash().ToString());
-
-        BlockValidationState state;
-        // need non-const pointer
-        auto pindex2 = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(pindex->GetBlockHash()));
-        if (!m_chainstate.InvalidateBlock(state, pindex2)) {
-            LogPrintf("CInstantSendManager::%s -- InvalidateBlock failed: %s\n", __func__, state.ToString());
-            // This should not have happened and we are in a state were it's not safe to continue anymore
-            assert(false);
-        }
-        if (isLockedTxKnown) {
-            activateBestChain = true;
-        } else {
-            LogPrintf("CInstantSendManager::%s -- resetting block %s\n", __func__, pindex2->GetBlockHash().ToString());
-            LOCK(::cs_main);
-            m_chainstate.ResetBlockFailureFlags(pindex2);
-        }
-    }
-
-    if (activateBestChain) {
-        BlockValidationState state;
-        if (!m_chainstate.ActivateBestChain(state)) {
-            LogPrintf("CInstantSendManager::%s -- ActivateBestChain failed: %s\n", __func__, state.ToString());
-            // This should not have happened and we are in a state were it's not safe to continue anymore
-            assert(false);
-        }
-    }
+bool CInstantSendManager::IsKnownTx(const uint256& islockHash) const
+{
+    LOCK(cs_pendingLocks);
+    return pendingNoTxInstantSendLocks.find(islockHash) == pendingNoTxInstantSendLocks.end();
 }
 
 void CInstantSendManager::RemoveConflictingLock(const uint256& islockHash, const instantsend::InstantSendLock& islock)

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -17,27 +17,6 @@ using node::fImporting;
 using node::fReindex;
 
 namespace llmq {
-namespace {
-template <typename T>
-    requires std::same_as<T, CTxIn> || std::same_as<T, COutPoint>
-Uint256HashSet GetIdsFromLockable(const std::vector<T>& vec)
-{
-    Uint256HashSet ret{};
-    if (vec.empty()) return ret;
-    ret.reserve(vec.size());
-    for (const auto& in : vec) {
-        if constexpr (std::is_same_v<T, COutPoint>) {
-            ret.emplace(instantsend::GenInputLockRequestId(in));
-        } else if constexpr (std::is_same_v<T, CTxIn>) {
-            ret.emplace(instantsend::GenInputLockRequestId(in.prevout));
-        } else {
-            assert(false);
-        }
-    }
-    return ret;
-}
-} // anonymous namespace
-
 CInstantSendManager::CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSigningManager& _sigman,
                                          CSporkManager& sporkman, const CMasternodeSync& mn_sync,
                                          const util::DbWrapperParams& db_params) :
@@ -274,25 +253,6 @@ std::vector<CTransactionRef> CInstantSendManager::PrepareTxToRetry()
     return txns;
 }
 
-void CInstantSendManager::RemoveConflictedTx(const CTransaction& tx)
-{
-    RemoveNonLockedTx(tx.GetHash(), false);
-    if (auto signer = m_signer.load(std::memory_order_acquire); signer) {
-        signer->ClearInputsFromQueue(GetIdsFromLockable(tx.vin));
-    }
-}
-
-void CInstantSendManager::TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock)
-{
-    auto ids = GetIdsFromLockable(islock.inputs);
-    if (auto signer = m_signer.load(std::memory_order_acquire); signer) {
-        signer->ClearInputsFromQueue(ids);
-    }
-    for (const auto& id : ids) {
-        sigman.TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend, id);
-    }
-}
-
 void CInstantSendManager::TryEmplacePendingLock(const uint256& hash, const NodeId id,
                                                 const instantsend::InstantSendLockPtr& islock)
 {
@@ -300,48 +260,6 @@ void CInstantSendManager::TryEmplacePendingLock(const uint256& hash, const NodeI
     LOCK(cs_pendingLocks);
     if (!pendingInstantSendLocks.count(hash)) {
         pendingInstantSendLocks.emplace(hash, instantsend::PendingISLockFromPeer{id, islock});
-    }
-}
-
-void CInstantSendManager::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
-{
-    if (!IsInstantSendEnabled()) {
-        return;
-    }
-
-    auto removeISLocks = db.RemoveConfirmedInstantSendLocks(pindex->nHeight);
-
-    for (const auto& [islockHash, islock] : removeISLocks) {
-        LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, islock=%s: removed islock as it got fully confirmed\n", __func__,
-                 islock->txid.ToString(), islockHash.ToString());
-
-        // No need to keep recovered sigs for fully confirmed IS locks, as there is no chance for conflicts
-        // from now on. All inputs are spent now and can't be spend in any other TX.
-        TruncateRecoveredSigsForInputs(*islock);
-
-        // And we don't need the recovered sig for the ISLOCK anymore, as the block in which it got mined is considered
-        // fully confirmed now
-        sigman.TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend, islock->GetRequestId());
-    }
-
-    db.RemoveArchivedInstantSendLocks(pindex->nHeight - 100);
-
-    // Find all previously unlocked TXs that got locked by this fully confirmed (ChainLock) block and remove them
-    // from the nonLockedTxs map. Also collect all children of these TXs and mark them for retrying of IS locking.
-    std::vector<uint256> toRemove;
-    {
-        LOCK(cs_nonLocked);
-        for (const auto& p : nonLockedTxs) {
-            const auto* pindexMined = p.second.pindexMined;
-
-            if (pindexMined && pindex->GetAncestor(pindexMined->nHeight) == pindexMined) {
-                toRemove.emplace_back(p.first);
-            }
-        }
-    }
-    for (const auto& txid : toRemove) {
-        // This will also add children to pendingRetryTxs
-        RemoveNonLockedTx(txid, true);
     }
 }
 
@@ -569,6 +487,37 @@ bool CInstantSendManager::RejectConflictingBlocks() const
         return false;
     }
     return true;
+}
+
+void CInstantSendManager::RemoveArchivedInstantSendLocks(int nUntilHeight)
+{
+    db.RemoveArchivedInstantSendLocks(nUntilHeight);
+}
+
+Uint256HashMap<instantsend::InstantSendLockPtr> CInstantSendManager::RemoveConfirmedInstantSendLocks(int nUntilHeight)
+{
+    return db.RemoveConfirmedInstantSendLocks(nUntilHeight);
+}
+
+void CInstantSendManager::RemoveNonLockedForConfirmed(const CBlockIndex* pindex)
+{
+    // Find all previously unlocked TXs that got locked by this fully confirmed (ChainLock) block and remove them
+    // from the nonLockedTxs map. Also collect all children of these TXs and mark them for retrying of IS locking.
+    std::vector<uint256> toRemove;
+    {
+        LOCK(cs_nonLocked);
+        for (const auto& p : nonLockedTxs) {
+            const auto* pindexMined = p.second.pindexMined;
+
+            if (pindexMined && pindex->GetAncestor(pindexMined->nHeight) == pindexMined) {
+                toRemove.emplace_back(p.first);
+            }
+        }
+    }
+    for (const auto& txid : toRemove) {
+        // This will also add children to pendingRetryTxs
+        RemoveNonLockedTx(txid, true);
+    }
 }
 
 } // namespace llmq

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -142,7 +142,6 @@ private:
     void HandleFullyConfirmedBlock(const CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
 
-public:
     bool IsLocked(const uint256& txHash) const override;
     bool IsWaitingForTx(const uint256& txHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
     instantsend::InstantSendLockPtr GetConflictingLock(const CTransaction& tx) const override;
@@ -157,28 +156,20 @@ public:
     CSigningManager& Sigman() { return sigman; }
     const chainlock::Chainlocks& Chainlocks() { return m_chainlocks; }
 
+    void RemoveBlockISLocks(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex);
+    void WriteBlockISLocks(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex);
     void WriteNewISLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, std::optional<int> minedHeight);
     void AddPendingISLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, NodeId from)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
 
     bool PreVerifyIsLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, NodeId from) const;
 
-    // -- CValidationInterface
-    void UpdatedBlockTip(const CBlockIndex* pindexNew)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry, !cs_height_cache);
-    void TransactionRemovedFromMempool(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry, !cs_timingsTxSeen, !cs_height_cache);
-    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
-    void NotifyChainLock(const CBlockIndex* pindexChainLock) EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
-
-
     bool AlreadyHave(const CInv& inv) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
     bool GetInstantSendLockByHash(const uint256& hash, instantsend::InstantSendLock& ret) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
     instantsend::InstantSendLockPtr GetInstantSendLockByTxid(const uint256& txid) const;
 
+    void TransactionIsRemoved(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void RemoveConflictingLock(const uint256& islockHash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void TryEmplacePendingLock(const uint256& hash, const NodeId id, const instantsend::InstantSendLockPtr& islock) override
@@ -195,6 +186,7 @@ public:
     Counts GetCounts() const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks, !cs_nonLocked);
 
     void CacheBlockHeight(const CBlockIndex* const block_index) const EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
+    void CacheDisconnectBlock(const CBlockIndex* pindexDisconnected) EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     std::optional<int> GetBlockHeight(const uint256& hash) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void CacheTipHeight(const CBlockIndex* const tip) const EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     int GetTipHeight() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -9,7 +9,6 @@
 #include <instantsend/lock.h>
 
 #include <net_types.h>
-#include <primitives/transaction.h>
 #include <protocol.h>
 #include <saltedhasher.h>
 #include <sync.h>
@@ -17,7 +16,6 @@
 #include <unordered_lru_cache.h>
 
 #include <optional>
-#include <unordered_set>
 #include <vector>
 
 class CBlockIndex;
@@ -30,6 +28,7 @@ struct LLMQParams;
 namespace util {
 struct DbWrapperParams;
 } // namespace util
+typedef std::shared_ptr<const CTransaction> CTransactionRef;
 
 namespace instantsend {
 

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -173,10 +173,8 @@ public:
      * allows ChainLocks to continue even while this spork is disabled.
      */
     bool RejectConflictingBlocks() const;
-    void RemoveArchivedInstantSendLocks(int nUntilHeight);
-    Uint256HashMap<instantsend::InstantSendLockPtr> RemoveConfirmedInstantSendLocks(int nUntilHeight);
+    Uint256HashMap<instantsend::InstantSendLockPtr> RemoveConfirmedInstantSendLocks(const CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
-    void RemoveNonLockedForConfirmed(const CBlockIndex* pindex);
 };
 } // namespace llmq
 

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -135,8 +135,10 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
 
     void TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock);
-    void ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry, !cs_height_cache);
+    std::unordered_map<const CBlockIndex*, Uint256HashMap<CTransactionRef>> RetrieveISConflicts(
+        const uint256& islockHash, const instantsend::InstantSendLock& islock)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks);
+    bool IsKnownTx(const uint256& islockHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
 
 private:
     void HandleFullyConfirmedBlock(const CBlockIndex* pindex)

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -104,7 +104,7 @@ public:
     std::unordered_map<const CBlockIndex*, Uint256HashMap<CTransactionRef>> RetrieveISConflicts(
         const uint256& islockHash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks);
-    bool IsKnownTx(const uint256& islockHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
+    bool HasTxForLock(const uint256& islockHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
 
     bool IsLocked(const uint256& txHash) const;
     bool IsWaitingForTx(const uint256& txHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -31,10 +31,6 @@ namespace util {
 struct DbWrapperParams;
 } // namespace util
 
-namespace chainlock {
-class Chainlocks;
-}
-
 namespace instantsend {
 
 struct PendingISLockFromPeer {
@@ -58,8 +54,6 @@ class CInstantSendManager
 {
 private:
     instantsend::CInstantSendDb db;
-
-    const chainlock::Chainlocks& m_chainlocks;
     CSporkManager& spork_manager;
     const CMasternodeSync& m_mn_sync;
 
@@ -97,8 +91,8 @@ public:
     CInstantSendManager() = delete;
     CInstantSendManager(const CInstantSendManager&) = delete;
     CInstantSendManager& operator=(const CInstantSendManager&) = delete;
-    explicit CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSporkManager& sporkman,
-                                 const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params);
+    explicit CInstantSendManager(CSporkManager& sporkman, const CMasternodeSync& mn_sync,
+                                 const util::DbWrapperParams& db_params);
     ~CInstantSendManager();
 
     void AddNonLockedTx(const CTransactionRef& tx, const CBlockIndex* pindexMined)
@@ -124,7 +118,6 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
     [[nodiscard]] std::vector<CTransactionRef> PrepareTxToRetry()
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
-    const chainlock::Chainlocks& Chainlocks() { return m_chainlocks; }
 
     void RemoveBlockISLocks(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex);
     void WriteBlockISLocks(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex);

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -28,7 +28,6 @@ class CChainState;
 class CDataStream;
 class CMasternodeSync;
 class CSporkManager;
-class CTxMemPool;
 namespace Consensus {
 struct LLMQParams;
 } // namespace Consensus
@@ -70,7 +69,6 @@ private:
     CChainState& m_chainstate;
     CSigningManager& sigman;
     CSporkManager& spork_manager;
-    CTxMemPool& mempool;
     const CMasternodeSync& m_mn_sync;
 
     std::atomic<instantsend::InstantSendSigner*> m_signer{nullptr};
@@ -112,8 +110,8 @@ public:
     CInstantSendManager(const CInstantSendManager&) = delete;
     CInstantSendManager& operator=(const CInstantSendManager&) = delete;
     explicit CInstantSendManager(const chainlock::Chainlocks& chainlocks, CChainState& chainstate,
-                                 CSigningManager& _sigman, CSporkManager& sporkman, CTxMemPool& _mempool,
-                                 const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params);
+                                 CSigningManager& _sigman, CSporkManager& sporkman, const CMasternodeSync& mn_sync,
+                                 const util::DbWrapperParams& db_params);
     ~CInstantSendManager();
 
     void ConnectSigner(gsl::not_null<instantsend::InstantSendSigner*> signer)

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -11,6 +11,7 @@
 #include <net_types.h>
 #include <primitives/transaction.h>
 #include <protocol.h>
+#include <saltedhasher.h>
 #include <sync.h>
 #include <threadsafety.h>
 #include <unordered_lru_cache.h>
@@ -18,8 +19,6 @@
 #include <optional>
 #include <unordered_set>
 #include <vector>
-
-#include <saltedhasher.h>
 
 class CBlockIndex;
 class CDataStream;
@@ -54,7 +53,6 @@ struct PendingState {
 } // namespace instantsend
 
 namespace llmq {
-class CSigningManager;
 
 class CInstantSendManager
 {
@@ -62,7 +60,6 @@ private:
     instantsend::CInstantSendDb db;
 
     const chainlock::Chainlocks& m_chainlocks;
-    CSigningManager& sigman;
     CSporkManager& spork_manager;
     const CMasternodeSync& m_mn_sync;
 
@@ -100,7 +97,7 @@ public:
     CInstantSendManager() = delete;
     CInstantSendManager(const CInstantSendManager&) = delete;
     CInstantSendManager& operator=(const CInstantSendManager&) = delete;
-    explicit CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSigningManager& _sigman, CSporkManager& sporkman,
+    explicit CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSporkManager& sporkman,
                                  const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params);
     ~CInstantSendManager();
 
@@ -127,7 +124,6 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
     [[nodiscard]] std::vector<CTransactionRef> PrepareTxToRetry()
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
-    CSigningManager& Sigman() { return sigman; }
     const chainlock::Chainlocks& Chainlocks() { return m_chainlocks; }
 
     void RemoveBlockISLocks(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex);

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -130,17 +130,23 @@ public:
 private:
     void AddNonLockedTx(const CTransactionRef& tx, const CBlockIndex* pindexMined)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_timingsTxSeen);
+
+public:
     void RemoveNonLockedTx(const uint256& txid, bool retryChildren)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
+
+private:
     void RemoveConflictedTx(const CTransaction& tx)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
-    void TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock);
 
+public:
+    void TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock);
     void RemoveMempoolConflictsForLock(const uint256& hash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
     void ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry, !cs_height_cache);
 
+private:
     void HandleFullyConfirmedBlock(const CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
 
@@ -157,9 +163,13 @@ public:
     [[nodiscard]] std::vector<CTransactionRef> PrepareTxToRetry()
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
     CSigningManager& Sigman() { return sigman; }
-    [[nodiscard]] std::variant<uint256, CTransactionRef, std::monostate> ProcessInstantSendLock(
-        NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry, !cs_height_cache);
+    const chainlock::Chainlocks& Chainlocks() { return m_chainlocks; }
+
+    void WriteNewISLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, std::optional<int> minedHeight);
+    void AddPendingISLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, NodeId from)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
+
+    bool PreVerifyIsLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, NodeId from) const;
 
     void TransactionAddedToMempool(const CTransactionRef& tx)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry, !cs_timingsTxSeen);

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -24,7 +24,6 @@
 #include <saltedhasher.h>
 
 class CBlockIndex;
-class CChainState;
 class CDataStream;
 class CMasternodeSync;
 class CSporkManager;
@@ -66,7 +65,6 @@ private:
     instantsend::CInstantSendDb db;
 
     const chainlock::Chainlocks& m_chainlocks;
-    CChainState& m_chainstate;
     CSigningManager& sigman;
     CSporkManager& spork_manager;
     const CMasternodeSync& m_mn_sync;
@@ -103,15 +101,12 @@ private:
         GUARDED_BY(cs_height_cache);
     mutable int m_cached_tip_height GUARDED_BY(cs_height_cache){-1};
 
-    void CacheBlockHeightInternal(const CBlockIndex* const block_index) const EXCLUSIVE_LOCKS_REQUIRED(cs_height_cache);
-
 public:
     CInstantSendManager() = delete;
     CInstantSendManager(const CInstantSendManager&) = delete;
     CInstantSendManager& operator=(const CInstantSendManager&) = delete;
-    explicit CInstantSendManager(const chainlock::Chainlocks& chainlocks, CChainState& chainstate,
-                                 CSigningManager& _sigman, CSporkManager& sporkman, const CMasternodeSync& mn_sync,
-                                 const util::DbWrapperParams& db_params);
+    explicit CInstantSendManager(const chainlock::Chainlocks& chainlocks, CSigningManager& _sigman, CSporkManager& sporkman,
+                                 const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params);
     ~CInstantSendManager();
 
     void ConnectSigner(gsl::not_null<instantsend::InstantSendSigner*> signer)
@@ -187,9 +182,9 @@ private:
     };
     Counts GetCounts() const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks, !cs_nonLocked);
 
-    void CacheBlockHeight(const CBlockIndex* const block_index) const EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
+    void CacheBlockHeight(const CBlockIndex* const block_index) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void CacheDisconnectBlock(const CBlockIndex* pindexDisconnected) EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
-    std::optional<int> GetBlockHeight(const uint256& hash) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
+    std::optional<int> GetCachedHeight(const uint256& hash) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void CacheTipHeight(const CBlockIndex* const tip) const EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     int GetTipHeight() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
 

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -7,7 +7,6 @@
 
 #include <instantsend/db.h>
 #include <instantsend/lock.h>
-#include <instantsend/signing.h>
 
 #include <net_types.h>
 #include <primitives/transaction.h>
@@ -57,7 +56,7 @@ struct PendingState {
 namespace llmq {
 class CSigningManager;
 
-class CInstantSendManager final : public instantsend::InstantSendSignerParent
+class CInstantSendManager
 {
 private:
     instantsend::CInstantSendDb db;
@@ -117,9 +116,9 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks);
     bool IsKnownTx(const uint256& islockHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
 
-    bool IsLocked(const uint256& txHash) const override;
+    bool IsLocked(const uint256& txHash) const;
     bool IsWaitingForTx(const uint256& txHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
-    instantsend::InstantSendLockPtr GetConflictingLock(const CTransaction& tx) const override;
+    instantsend::InstantSendLockPtr GetConflictingLock(const CTransaction& tx) const;
 
     /* Helpers for communications between CInstantSendManager & NetInstantSend */
     // This helper returns up to 32 pending locks and remove them from queue of pending
@@ -147,7 +146,7 @@ public:
     void TransactionIsRemoved(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void RemoveConflictingLock(const uint256& islockHash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
-    void TryEmplacePendingLock(const uint256& hash, const NodeId id, const instantsend::InstantSendLockPtr& islock) override
+    void TryEmplacePendingLock(const uint256& hash, const NodeId id, const instantsend::InstantSendLockPtr& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
 
     size_t GetInstantSendLockCount() const;
@@ -160,13 +159,13 @@ public:
     };
     Counts GetCounts() const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks, !cs_nonLocked);
 
-    void CacheBlockHeight(const CBlockIndex* const block_index) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
+    void CacheBlockHeight(const CBlockIndex* const block_index) const EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void CacheDisconnectBlock(const CBlockIndex* pindexDisconnected) EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
-    std::optional<int> GetCachedHeight(const uint256& hash) const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
+    std::optional<int> GetCachedHeight(const uint256& hash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void CacheTipHeight(const CBlockIndex* const tip) const EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
-    int GetTipHeight() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
+    int GetTipHeight() const EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
 
-    bool IsInstantSendEnabled() const override;
+    bool IsInstantSendEnabled() const;
     /**
      * If true, MN should sign all transactions, if false, MN should not sign
      * transactions in mempool, but should sign txes included in a block. This

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -19,7 +19,6 @@
 #include <atomic>
 #include <optional>
 #include <unordered_set>
-#include <variant>
 #include <vector>
 
 #include <saltedhasher.h>
@@ -127,22 +126,17 @@ public:
 
     instantsend::InstantSendSigner* Signer() const { return m_signer.load(std::memory_order_acquire); }
 
-private:
     void AddNonLockedTx(const CTransactionRef& tx, const CBlockIndex* pindexMined)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_timingsTxSeen);
-
-public:
     void RemoveNonLockedTx(const uint256& txid, bool retryChildren)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
 
-private:
+    instantsend::InstantSendLockPtr AttachISLockToTx(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
+
     void RemoveConflictedTx(const CTransaction& tx)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
 
-public:
     void TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock);
-    void RemoveMempoolConflictsForLock(const uint256& hash, const instantsend::InstantSendLock& islock)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
     void ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry, !cs_height_cache);
 
@@ -171,23 +165,21 @@ public:
 
     bool PreVerifyIsLock(const uint256& hash, const instantsend::InstantSendLockPtr& islock, NodeId from) const;
 
-    void TransactionAddedToMempool(const CTransactionRef& tx)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry, !cs_timingsTxSeen);
+    // -- CValidationInterface
+    void UpdatedBlockTip(const CBlockIndex* pindexNew)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry, !cs_height_cache);
     void TransactionRemovedFromMempool(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_pendingRetry, !cs_timingsTxSeen, !cs_height_cache);
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);
+    void NotifyChainLock(const CBlockIndex* pindexChainLock) EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
+
 
     bool AlreadyHave(const CInv& inv) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
     bool GetInstantSendLockByHash(const uint256& hash, instantsend::InstantSendLock& ret) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
     instantsend::InstantSendLockPtr GetInstantSendLockByTxid(const uint256& txid) const;
-
-    void NotifyChainLock(const CBlockIndex* pindexChainLock)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
-    void UpdatedBlockTip(const CBlockIndex* pindexNew)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry, !cs_height_cache);
 
     void RemoveConflictingLock(const uint256& islockHash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_height_cache);

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -16,7 +16,6 @@
 #include <threadsafety.h>
 #include <unordered_lru_cache.h>
 
-#include <atomic>
 #include <optional>
 #include <unordered_set>
 #include <vector>
@@ -39,7 +38,6 @@ class Chainlocks;
 }
 
 namespace instantsend {
-class InstantSendSigner;
 
 struct PendingISLockFromPeer {
     NodeId node_id;
@@ -68,8 +66,6 @@ private:
     CSigningManager& sigman;
     CSporkManager& spork_manager;
     const CMasternodeSync& m_mn_sync;
-
-    std::atomic<instantsend::InstantSendSigner*> m_signer{nullptr};
 
     mutable Mutex cs_pendingLocks;
     // Incoming and not verified yet
@@ -109,16 +105,6 @@ public:
                                  const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params);
     ~CInstantSendManager();
 
-    void ConnectSigner(gsl::not_null<instantsend::InstantSendSigner*> signer)
-    {
-        // Prohibit double initialization
-        assert(m_signer.load(std::memory_order_acquire) == nullptr);
-        m_signer.store(signer, std::memory_order_release);
-    }
-    void DisconnectSigner() { m_signer.store(nullptr, std::memory_order_release); }
-
-    instantsend::InstantSendSigner* Signer() const { return m_signer.load(std::memory_order_acquire); }
-
     void AddNonLockedTx(const CTransactionRef& tx, const CBlockIndex* pindexMined)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks, !cs_timingsTxSeen);
     void RemoveNonLockedTx(const uint256& txid, bool retryChildren)
@@ -126,18 +112,10 @@ public:
 
     instantsend::InstantSendLockPtr AttachISLockToTx(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
 
-    void RemoveConflictedTx(const CTransaction& tx)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
-
-    void TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock);
     std::unordered_map<const CBlockIndex*, Uint256HashMap<CTransactionRef>> RetrieveISConflicts(
         const uint256& islockHash, const instantsend::InstantSendLock& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingLocks);
     bool IsKnownTx(const uint256& islockHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
-
-private:
-    void HandleFullyConfirmedBlock(const CBlockIndex* pindex)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
 
     bool IsLocked(const uint256& txHash) const override;
     bool IsWaitingForTx(const uint256& txHash) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingLocks);
@@ -195,6 +173,10 @@ private:
      * allows ChainLocks to continue even while this spork is disabled.
      */
     bool RejectConflictingBlocks() const;
+    void RemoveArchivedInstantSendLocks(int nUntilHeight);
+    Uint256HashMap<instantsend::InstantSendLockPtr> RemoveConfirmedInstantSendLocks(int nUntilHeight);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_nonLocked, !cs_pendingRetry);
+    void RemoveNonLockedForConfirmed(const CBlockIndex* pindex);
 };
 } // namespace llmq
 

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -6,6 +6,7 @@
 
 #include <bls/bls_batchverifier.h>
 #include <chainlock/chainlock.h>
+#include <consensus/params.h>
 #include <cxxtimer.hpp>
 #include <instantsend/instantsend.h>
 #include <llmq/commitment.h>
@@ -442,4 +443,72 @@ void NetInstantSend::RemoveMempoolConflictsForLock(const uint256& hash, const in
     for (const auto& p : toDelete) {
         m_is_manager.RemoveConflictedTx(*p.second);
     }
+}
+
+void NetInstantSend::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
+{
+    m_is_manager.CacheTipHeight(pindexNew);
+
+    bool fDIP0008Active = pindexNew->pprev && pindexNew->pprev->nHeight >= Params().GetConsensus().DIP0008Height;
+
+    if (m_is_manager.Chainlocks().IsEnabled() && fDIP0008Active) {
+        // Nothing to do here. We should keep all islocks and let chainlocks handle them.
+        return;
+    }
+
+    int nConfirmedHeight = pindexNew->nHeight - Params().GetConsensus().nInstantSendKeepLock;
+    const CBlockIndex* pindex = pindexNew->GetAncestor(nConfirmedHeight);
+
+    if (pindex) {
+        m_is_manager.HandleFullyConfirmedBlock(pindex);
+    }
+}
+
+void NetInstantSend::TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason,
+                                                   uint64_t mempool_sequence)
+{
+    m_is_manager.TransactionIsRemoved(tx);
+}
+
+void NetInstantSend::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
+{
+    if (!m_is_manager.IsInstantSendEnabled()) {
+        return;
+    }
+
+    m_is_manager.CacheTipHeight(pindex);
+
+    if (m_mn_sync.IsBlockchainSynced()) {
+        const bool has_chainlock = m_is_manager.Chainlocks().HasChainLock(pindex->nHeight, pindex->GetBlockHash());
+        for (const auto& tx : pblock->vtx) {
+            if (tx->IsCoinBase() || tx->vin.empty()) {
+                // coinbase and TXs with no inputs can't be locked
+                continue;
+            }
+
+            if (!m_is_manager.IsLocked(tx->GetHash()) && !has_chainlock) {
+                if (auto signer = m_is_manager.Signer(); signer) {
+                    signer->ProcessTx(*tx, true, Params().GetConsensus());
+                }
+                // TX is not locked, so make sure it is tracked
+                m_is_manager.AddNonLockedTx(tx, pindex);
+            } else {
+                // TX is locked, so make sure we don't track it anymore
+                m_is_manager.RemoveNonLockedTx(tx->GetHash(), true);
+            }
+        }
+    }
+    m_is_manager.WriteBlockISLocks(pblock, pindex);
+}
+
+void NetInstantSend::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected)
+{
+    m_is_manager.CacheDisconnectBlock(pindexDisconnected);
+    m_is_manager.CacheTipHeight(pindexDisconnected->pprev);
+    m_is_manager.RemoveBlockISLocks(pblock, pindexDisconnected);
+}
+
+void NetInstantSend::NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const chainlock::ChainLockSig>& clsig)
+{
+    m_is_manager.HandleFullyConfirmedBlock(pindex);
 }

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -352,7 +352,7 @@ void NetInstantSend::ProcessPendingISLocks(std::vector<instantsend::PendingISLoc
 
 void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock)
 {
-    LogPrint(BCLog::INSTANTSEND, "NetSigning::%s -- txid=%s, islock=%s: processing islock, peer=%d\n", __func__,
+    LogPrint(BCLog::INSTANTSEND, "NetInstantSend::%s -- txid=%s, islock=%s: processing islock, peer=%d\n", __func__,
              islock->txid.ToString(), hash.ToString(), from);
 
     if (m_signer) {
@@ -364,21 +364,13 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
     auto tx = GetTransaction(nullptr, &m_mempool, islock->txid, Params().GetConsensus(), hashBlock);
     const bool found_transaction{tx != nullptr};
     // we ignore failure here as we must be able to propagate the lock even if we don't have the TX locally
-    std::optional<int> minedHeight = GetBlockHeight(m_is_manager, m_chainstate, hashBlock);
+    const auto minedHeight = GetBlockHeight(m_is_manager, m_chainstate, hashBlock);
     if (found_transaction) {
-        if (!minedHeight.has_value()) {
-            const CBlockIndex* pindexMined = WITH_LOCK(::cs_main,
-                                                       return m_chainstate.m_blockman.LookupBlockIndex(hashBlock));
-            if (pindexMined != nullptr) {
-                m_is_manager.CacheBlockHeight(pindexMined);
-                minedHeight = pindexMined->nHeight;
-            }
-        }
         // Let's see if the TX that was locked by this islock is already mined in a ChainLocked block. If yes,
         // we can simply ignore the islock, as the ChainLock implies locking of all TXs in that chain
         if (minedHeight.has_value() && m_chainlocks.HasChainLock(*minedHeight, hashBlock)) {
             LogPrint(BCLog::INSTANTSEND, /* Continued */
-                     "NetSigning::%s -- txlock=%s, islock=%s: dropping islock as it already got a "
+                     "NetInstantSend::%s -- txlock=%s, islock=%s: dropping islock as it already got a "
                      "ChainLock in block %s, peer=%d\n",
                      __func__, islock->txid.ToString(), hash.ToString(), hashBlock.ToString(), from);
             return;
@@ -387,7 +379,6 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
     } else {
         m_is_manager.AddPendingISLock(hash, islock, from);
     }
-
 
     // This will also add children TXs to pendingRetryTxs
     m_is_manager.RemoveNonLockedTx(islock->txid, true);
@@ -398,8 +389,8 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
 
     if (found_transaction) {
         RemoveMempoolConflictsForLock(hash, *islock);
-        LogPrint(BCLog::INSTANTSEND, "NetSigning::%s -- notify about lock %s for tx %s\n", __func__, hash.ToString(),
-                 tx->GetHash().ToString());
+        LogPrint(BCLog::INSTANTSEND, "NetInstantSend::%s -- notify about lock %s for tx %s\n", __func__,
+                 hash.ToString(), tx->GetHash().ToString());
         GetMainSignals().NotifyTransactionLock(tx, islock);
         // bump m_mempool counter to make sure newly locked txes are picked up by getblocktemplate
         m_mempool.AddTransactionsUpdated(1);
@@ -588,7 +579,7 @@ void NetInstantSend::ResolveBlockConflicts(const uint256& islockHash, const inst
         return;
     }
 
-    bool isLockedTxKnown = m_is_manager.IsKnownTx(islockHash);
+    bool hasTxForLock = m_is_manager.HasTxForLock(islockHash);
 
     bool activateBestChain = false;
     for (const auto& p : conflicts) {
@@ -605,7 +596,7 @@ void NetInstantSend::ResolveBlockConflicts(const uint256& islockHash, const inst
             // This should not have happened and we are in a state were it's not safe to continue anymore
             assert(false);
         }
-        if (isLockedTxKnown) {
+        if (hasTxForLock) {
             activateBestChain = true;
         } else {
             LogPrintf("NetInstantSend::%s -- resetting block %s\n", __func__, pindex2->GetBlockHash().ToString());

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -5,19 +5,27 @@
 #include <instantsend/net_instantsend.h>
 
 #include <bls/bls_batchverifier.h>
-#include <node/interface_ui.h>
+#include <chainlock/chainlock.h>
 #include <cxxtimer.hpp>
 #include <instantsend/instantsend.h>
 #include <llmq/commitment.h>
 #include <llmq/quorumsman.h>
 #include <llmq/signhash.h>
 #include <llmq/signing.h>
+#include <node/interface_ui.h>
 #include <util/thread.h>
 #include <validation.h>
 
 #include <chrono>
 #include <set>
 
+// Forward declaration to break dependency over node/transaction.h
+namespace node {
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool,
+                               const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock);
+} // namespace node
+
+using node::GetTransaction;
 namespace {
 constexpr int BATCH_VERIFIER_SOURCE_THRESHOLD{8};
 constexpr int INVALID_ISLOCK_MISBEHAVIOR_SCORE{100};
@@ -309,6 +317,68 @@ void NetInstantSend::ProcessPendingISLocks(std::vector<instantsend::PendingISLoc
         ProcessPendingInstantSendLocks(llmq_params, dkgInterval, /*ban=*/true, still_pending);
     }
     uiInterface.NotifyInstantSendChanged();
+}
+
+std::variant<uint256, CTransactionRef, std::monostate> NetInstantSend::ProcessInstantSendLock(
+    NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock)
+{
+    LogPrint(BCLog::INSTANTSEND, "NetSigning::%s -- txid=%s, islock=%s: processing islock, peer=%d\n", __func__,
+             islock->txid.ToString(), hash.ToString(), from);
+
+    if (auto signer = m_is_manager.Signer(); signer) {
+        signer->ClearLockFromQueue(islock);
+    }
+    if (!m_is_manager.PreVerifyIsLock(hash, islock, from)) return std::monostate{};
+
+    uint256 hashBlock{};
+    auto tx = GetTransaction(nullptr, &m_mempool, islock->txid, Params().GetConsensus(), hashBlock);
+    const bool found_transaction{tx != nullptr};
+    // we ignore failure here as we must be able to propagate the lock even if we don't have the TX locally
+    std::optional<int> minedHeight = m_is_manager.GetBlockHeight(hashBlock);
+    if (found_transaction) {
+        if (!minedHeight.has_value()) {
+            const CBlockIndex* pindexMined = WITH_LOCK(::cs_main,
+                                                       return m_chainstate.m_blockman.LookupBlockIndex(hashBlock));
+            if (pindexMined != nullptr) {
+                m_is_manager.CacheBlockHeight(pindexMined);
+                minedHeight = pindexMined->nHeight;
+            }
+        }
+        // Let's see if the TX that was locked by this islock is already mined in a ChainLocked block. If yes,
+        // we can simply ignore the islock, as the ChainLock implies locking of all TXs in that chain
+        if (minedHeight.has_value() && m_is_manager.Chainlocks().HasChainLock(*minedHeight, hashBlock)) {
+            LogPrint(BCLog::INSTANTSEND, /* Continued */
+                     "NetSigning::%s -- txlock=%s, islock=%s: dropping islock as it already got a "
+                     "ChainLock in block %s, peer=%d\n",
+                     __func__, islock->txid.ToString(), hash.ToString(), hashBlock.ToString(), from);
+            return std::monostate{};
+        }
+        m_is_manager.WriteNewISLock(hash, islock, minedHeight);
+    } else {
+        m_is_manager.AddPendingISLock(hash, islock, from);
+    }
+
+
+    // This will also add children TXs to pendingRetryTxs
+    m_is_manager.RemoveNonLockedTx(islock->txid, true);
+    // We don't need the recovered sigs for the inputs anymore. This prevents unnecessary propagation of these sigs.
+    // We only need the ISLOCK from now on to detect conflicts
+    m_is_manager.TruncateRecoveredSigsForInputs(*islock);
+    m_is_manager.ResolveBlockConflicts(hash, *islock);
+
+    if (found_transaction) {
+        m_is_manager.RemoveMempoolConflictsForLock(hash, *islock);
+        LogPrint(BCLog::INSTANTSEND, "NetSigning::%s -- notify about lock %s for tx %s\n", __func__, hash.ToString(),
+                 tx->GetHash().ToString());
+        GetMainSignals().NotifyTransactionLock(tx, islock);
+        // bump mempool counter to make sure newly locked txes are picked up by getblocktemplate
+        m_mempool.AddTransactionsUpdated(1);
+    }
+
+    if (found_transaction) {
+        return tx;
+    }
+    return islock->txid;
 }
 
 void NetInstantSend::WorkThreadMain()

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -445,10 +445,14 @@ void NetInstantSend::RemoveMempoolConflictsForLock(const uint256& hash, const in
     }
 }
 
-void NetInstantSend::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
+void NetInstantSend::SynchronousUpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork,
+                                                bool fInitialDownload)
 {
     m_is_manager.CacheTipHeight(pindexNew);
+}
 
+void NetInstantSend::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload)
+{
     bool fDIP0008Active = pindexNew->pprev && pindexNew->pprev->nHeight >= Params().GetConsensus().DIP0008Height;
 
     if (m_is_manager.Chainlocks().IsEnabled() && fDIP0008Active) {

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<NetInstantSend::BatchVerificationData> NetInstantSend::BuildVeri
         auto id = islock->GetRequestId();
 
         // no need to verify an ISLOCK if we already have verified the recovered sig that belongs to it
-        if (m_is_manager.Sigman().HasRecoveredSig(llmq_params.type, id, islock->txid)) {
+        if (m_sigman.HasRecoveredSig(llmq_params.type, id, islock->txid)) {
             data->alreadyVerified++;
             continue;
         }
@@ -160,7 +160,7 @@ std::unique_ptr<NetInstantSend::BatchVerificationData> NetInstantSend::BuildVeri
         // We can reconstruct the CRecoveredSig objects from the islock and pass it to the signing manager, which
         // avoids unnecessary double-verification of the signature. We however only do this when verification here
         // turns out to be good (which is checked further down)
-        if (!m_is_manager.Sigman().HasRecoveredSigForId(llmq_params.type, id)) {
+        if (!m_sigman.HasRecoveredSigForId(llmq_params.type, id)) {
             data->recSigs.try_emplace(hash, llmq::CRecoveredSig(llmq_params.type, quorum->qc->quorumHash, id, islock->txid,
                                                                 islock->sig));
         }
@@ -206,12 +206,12 @@ Uint256HashSet NetInstantSend::ApplyVerificationResults(
         auto it = data.recSigs.find(hash);
         if (it != data.recSigs.end()) {
             auto recSig = std::make_shared<llmq::CRecoveredSig>(std::move(it->second));
-            if (!m_is_manager.Sigman().HasRecoveredSigForId(llmq_params.type, recSig->getId())) {
+            if (!m_sigman.HasRecoveredSigForId(llmq_params.type, recSig->getId())) {
                 LogPrint(BCLog::INSTANTSEND, /* Continued */
                          "NetInstantSend::%s -- txid=%s, islock=%s: "
                          "passing reconstructed recSig to signing mgr, peer=%d\n",
                          __func__, islock->txid.ToString(), hash.ToString(), nodeId);
-                m_is_manager.Sigman().PushReconstructedRecoveredSig(recSig);
+                m_sigman.PushReconstructedRecoveredSig(recSig);
             }
         }
     }
@@ -631,7 +631,7 @@ void NetInstantSend::TruncateRecoveredSigsForInputs(const instantsend::InstantSe
         m_signer->ClearInputsFromQueue(ids);
     }
     for (const auto& id : ids) {
-        m_is_manager.Sigman().TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend, id);
+        m_sigman.TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend, id);
     }
 }
 
@@ -648,8 +648,7 @@ void NetInstantSend::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
 
         // And we don't need the recovered sig for the ISLOCK anymore, as the block in which it got mined is considered
         // fully confirmed now
-        m_is_manager.Sigman().TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend,
-                                                   islock->GetRequestId());
+        m_sigman.TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend, islock->GetRequestId());
 
         // No need to keep recovered sigs for fully confirmed IS locks, as there is no chance for conflicts
         // from now on. All inputs are spent now and can't be spend in any other TX.

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -641,23 +641,10 @@ void NetInstantSend::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
         return;
     }
 
-    auto removeISLocks = m_is_manager.RemoveConfirmedInstantSendLocks(pindex->nHeight);
-
-    for (const auto& [islockHash, islock] : removeISLocks) {
-        LogPrint(BCLog::INSTANTSEND, "NetInstantSend::%s -- txid=%s, islock=%s: removed islock as it got fully confirmed\n",
-                 __func__, islock->txid.ToString(), islockHash.ToString());
-
+    auto removeISLocks = m_is_manager.RemoveConfirmedInstantSendLocks(pindex);
+    for (const auto& [_, islock] : removeISLocks) {
         // No need to keep recovered sigs for fully confirmed IS locks, as there is no chance for conflicts
         // from now on. All inputs are spent now and can't be spend in any other TX.
         TruncateRecoveredSigsForInputs(*islock);
-
-        // And we don't need the recovered sig for the ISLOCK anymore, as the block in which it got mined is considered
-        // fully confirmed now
-        m_is_manager.Sigman().TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend,
-                                                   islock->GetRequestId());
     }
-
-    m_is_manager.RemoveArchivedInstantSendLocks(pindex->nHeight - 100);
-
-    m_is_manager.RemoveNonLockedForConfirmed(pindex);
 }

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -642,7 +642,15 @@ void NetInstantSend::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
     }
 
     auto removeISLocks = m_is_manager.RemoveConfirmedInstantSendLocks(pindex);
-    for (const auto& [_, islock] : removeISLocks) {
+    for (const auto& [islockHash, islock] : removeISLocks) {
+        LogPrint(BCLog::INSTANTSEND, "NetInstantSend::%s -- txid=%s, islock=%s: removed islock as it got fully confirmed\n",
+                 __func__, islock->txid.ToString(), islockHash.ToString());
+
+        // And we don't need the recovered sig for the ISLOCK anymore, as the block in which it got mined is considered
+        // fully confirmed now
+        m_is_manager.Sigman().TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend,
+                                                   islock->GetRequestId());
+
         // No need to keep recovered sigs for fully confirmed IS locks, as there is no chance for conflicts
         // from now on. All inputs are spent now and can't be spend in any other TX.
         TruncateRecoveredSigsForInputs(*islock);

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -9,6 +9,7 @@
 #include <consensus/params.h>
 #include <cxxtimer.hpp>
 #include <instantsend/instantsend.h>
+#include <instantsend/signing.h>
 #include <llmq/commitment.h>
 #include <llmq/quorumsman.h>
 #include <llmq/signhash.h>
@@ -218,6 +219,27 @@ Uint256HashSet NetInstantSend::ApplyVerificationResults(
     return badISLocks;
 }
 
+namespace {
+template <typename T>
+    requires std::same_as<T, CTxIn> || std::same_as<T, COutPoint>
+Uint256HashSet GetIdsFromLockable(const std::vector<T>& vec)
+{
+    Uint256HashSet ret{};
+    if (vec.empty()) return ret;
+    ret.reserve(vec.size());
+    for (const auto& in : vec) {
+        if constexpr (std::is_same_v<T, COutPoint>) {
+            ret.emplace(instantsend::GenInputLockRequestId(in));
+        } else if constexpr (std::is_same_v<T, CTxIn>) {
+            ret.emplace(instantsend::GenInputLockRequestId(in.prevout));
+        } else {
+            assert(false);
+        }
+    }
+    return ret;
+}
+} // anonymous namespace
+
 void NetInstantSend::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
     if (msg_type != NetMsgType::ISDLOCK) {
@@ -333,8 +355,8 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
     LogPrint(BCLog::INSTANTSEND, "NetSigning::%s -- txid=%s, islock=%s: processing islock, peer=%d\n", __func__,
              islock->txid.ToString(), hash.ToString(), from);
 
-    if (auto signer = m_is_manager.Signer(); signer) {
-        signer->ClearLockFromQueue(islock);
+    if (m_signer) {
+        m_signer->ClearLockFromQueue(islock);
     }
     if (!m_is_manager.PreVerifyIsLock(hash, islock, from)) return;
 
@@ -371,7 +393,7 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
     m_is_manager.RemoveNonLockedTx(islock->txid, true);
     // We don't need the recovered sigs for the inputs anymore. This prevents unnecessary propagation of these sigs.
     // We only need the ISLOCK from now on to detect conflicts
-    m_is_manager.TruncateRecoveredSigsForInputs(*islock);
+    TruncateRecoveredSigsForInputs(*islock);
     ResolveBlockConflicts(hash, *islock);
 
     if (found_transaction) {
@@ -402,8 +424,8 @@ void NetInstantSend::WorkThreadMain()
             if (!locks.empty()) {
                 ProcessPendingISLocks(std::move(locks));
             }
-            if (auto signer = m_is_manager.Signer(); signer) {
-                signer->ProcessPendingRetryLockTxs(m_is_manager.PrepareTxToRetry());
+            if (m_signer) {
+                m_signer->ProcessPendingRetryLockTxs(m_is_manager.PrepareTxToRetry());
             }
             return more_work;
         }();
@@ -422,13 +444,23 @@ void NetInstantSend::TransactionAddedToMempool(const CTransactionRef& tx, int64_
 
     instantsend::InstantSendLockPtr islock = m_is_manager.AttachISLockToTx(tx);
     if (islock == nullptr) {
-        if (auto signer = m_is_manager.Signer(); signer) {
-            signer->ProcessTx(*tx, false, Params().GetConsensus());
+        if (m_signer) {
+            m_signer->ProcessTx(*tx, false, Params().GetConsensus());
         }
         // TX is not locked, so make sure it is tracked
         m_is_manager.AddNonLockedTx(tx, nullptr);
     } else {
         RemoveMempoolConflictsForLock(::SerializeHash(*islock), *islock);
+    }
+}
+
+void NetInstantSend::ClearConflicting(const Uint256HashMap<CTransactionRef>& to_delete)
+{
+    for (const auto& [_, tx] : to_delete) {
+        m_is_manager.RemoveNonLockedTx(tx->GetHash(), false);
+        if (m_signer) {
+            m_signer->ClearInputsFromQueue(GetIdsFromLockable(tx->vin));
+        }
     }
 }
 
@@ -456,10 +488,7 @@ void NetInstantSend::RemoveMempoolConflictsForLock(const uint256& hash, const in
             m_mempool.removeRecursive(*p.second, MemPoolRemovalReason::CONFLICT);
         }
     }
-
-    for (const auto& p : toDelete) {
-        m_is_manager.RemoveConflictedTx(*p.second);
-    }
+    ClearConflicting(toDelete);
 }
 
 void NetInstantSend::SynchronousUpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork,
@@ -481,7 +510,7 @@ void NetInstantSend::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockI
     const CBlockIndex* pindex = pindexNew->GetAncestor(nConfirmedHeight);
 
     if (pindex) {
-        m_is_manager.HandleFullyConfirmedBlock(pindex);
+        HandleFullyConfirmedBlock(pindex);
     }
 }
 
@@ -508,8 +537,8 @@ void NetInstantSend::BlockConnected(const std::shared_ptr<const CBlock>& pblock,
             }
 
             if (!m_is_manager.IsLocked(tx->GetHash()) && !has_chainlock) {
-                if (auto signer = m_is_manager.Signer(); signer) {
-                    signer->ProcessTx(*tx, true, Params().GetConsensus());
+                if (m_signer) {
+                    m_signer->ProcessTx(*tx, true, Params().GetConsensus());
                 }
                 // TX is not locked, so make sure it is tracked
                 m_is_manager.AddNonLockedTx(tx, pindex);
@@ -531,7 +560,7 @@ void NetInstantSend::BlockDisconnected(const std::shared_ptr<const CBlock>& pblo
 
 void NetInstantSend::NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const chainlock::ChainLockSig>& clsig)
 {
-    m_is_manager.HandleFullyConfirmedBlock(pindex);
+    HandleFullyConfirmedBlock(pindex);
 }
 
 void NetInstantSend::ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock)
@@ -564,10 +593,7 @@ void NetInstantSend::ResolveBlockConflicts(const uint256& islockHash, const inst
     bool activateBestChain = false;
     for (const auto& p : conflicts) {
         const auto* pindex = p.first;
-        for (const auto& p2 : p.second) {
-            const auto& tx = *p2.second;
-            m_is_manager.RemoveConflictedTx(tx);
-        }
+        ClearConflicting(p.second);
 
         LogPrintf("NetInstantSend::%s -- invalidating block %s\n", __func__, pindex->GetBlockHash().ToString());
 
@@ -596,4 +622,42 @@ void NetInstantSend::ResolveBlockConflicts(const uint256& islockHash, const inst
             assert(false);
         }
     }
+}
+
+void NetInstantSend::TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock)
+{
+    auto ids = GetIdsFromLockable(islock.inputs);
+    if (m_signer) {
+        m_signer->ClearInputsFromQueue(ids);
+    }
+    for (const auto& id : ids) {
+        m_is_manager.Sigman().TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend, id);
+    }
+}
+
+void NetInstantSend::HandleFullyConfirmedBlock(const CBlockIndex* pindex)
+{
+    if (!m_is_manager.IsInstantSendEnabled()) {
+        return;
+    }
+
+    auto removeISLocks = m_is_manager.RemoveConfirmedInstantSendLocks(pindex->nHeight);
+
+    for (const auto& [islockHash, islock] : removeISLocks) {
+        LogPrint(BCLog::INSTANTSEND, "NetInstantSend::%s -- txid=%s, islock=%s: removed islock as it got fully confirmed\n",
+                 __func__, islock->txid.ToString(), islockHash.ToString());
+
+        // No need to keep recovered sigs for fully confirmed IS locks, as there is no chance for conflicts
+        // from now on. All inputs are spent now and can't be spend in any other TX.
+        TruncateRecoveredSigsForInputs(*islock);
+
+        // And we don't need the recovered sig for the ISLOCK anymore, as the block in which it got mined is considered
+        // fully confirmed now
+        m_is_manager.Sigman().TruncateRecoveredSig(Params().GetConsensus().llmqTypeDIP0024InstantSend,
+                                                   islock->GetRequestId());
+    }
+
+    m_is_manager.RemoveArchivedInstantSendLocks(pindex->nHeight - 100);
+
+    m_is_manager.RemoveNonLockedForConfirmed(pindex);
 }

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -24,7 +24,7 @@
 
 // Forward declaration to break dependency over node/transaction.h
 namespace node {
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const m_mempool,
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool,
                                const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock);
 } // namespace node
 

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -36,6 +36,23 @@ constexpr int OLD_ACTIVE_SET_FAILURE_MISBEHAVIOR_SCORE{20};
 constexpr auto WORK_THREAD_SLEEP_INTERVAL{std::chrono::milliseconds{100}};
 } // namespace
 
+static std::optional<int> GetBlockHeight(llmq::CInstantSendManager& is_manager, const CChainState& chainstate,
+                                         const uint256& hash)
+{
+    if (hash.IsNull()) {
+        return std::nullopt;
+    }
+    auto ret = is_manager.GetCachedHeight(hash);
+    if (ret) return ret;
+
+    const CBlockIndex* pindex = WITH_LOCK(::cs_main, return chainstate.m_blockman.LookupBlockIndex(hash));
+    if (pindex == nullptr) {
+        return std::nullopt;
+    }
+    is_manager.CacheBlockHeight(pindex);
+    return pindex->nHeight;
+}
+
 struct NetInstantSend::BatchVerificationData {
     CBLSBatchVerifier<NodeId, uint256> batchVerifier{false, true, BATCH_VERIFIER_SOURCE_THRESHOLD};
     Uint256HashMap<llmq::CRecoveredSig> recSigs;
@@ -55,7 +72,7 @@ bool NetInstantSend::ValidateIncomingISLock(const instantsend::InstantSendLock& 
 
 std::optional<int> NetInstantSend::ResolveCycleHeight(const uint256& cycle_hash)
 {
-    auto cycle_height = m_is_manager.GetBlockHeight(cycle_hash);
+    auto cycle_height = GetBlockHeight(m_is_manager, m_chainstate, cycle_hash);
     if (cycle_height) {
         return cycle_height;
     }
@@ -113,7 +130,7 @@ std::unique_ptr<NetInstantSend::BatchVerificationData> NetInstantSend::BuildVeri
             continue;
         }
 
-        auto cycleHeightOpt = m_is_manager.GetBlockHeight(islock->cycleHash);
+        auto cycleHeightOpt = GetBlockHeight(m_is_manager, m_chainstate, islock->cycleHash);
         if (!cycleHeightOpt) {
             data->batchVerifier.badSources.emplace(nodeId);
             continue;
@@ -325,7 +342,7 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
     auto tx = GetTransaction(nullptr, &m_mempool, islock->txid, Params().GetConsensus(), hashBlock);
     const bool found_transaction{tx != nullptr};
     // we ignore failure here as we must be able to propagate the lock even if we don't have the TX locally
-    std::optional<int> minedHeight = m_is_manager.GetBlockHeight(hashBlock);
+    std::optional<int> minedHeight = GetBlockHeight(m_is_manager, m_chainstate, hashBlock);
     if (found_transaction) {
         if (!minedHeight.has_value()) {
             const CBlockIndex* pindexMined = WITH_LOCK(::cs_main,

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -12,6 +12,7 @@
 #include <llmq/quorumsman.h>
 #include <llmq/signhash.h>
 #include <llmq/signing.h>
+#include <masternode/sync.h>
 #include <node/interface_ui.h>
 #include <util/thread.h>
 #include <validation.h>
@@ -21,7 +22,7 @@
 
 // Forward declaration to break dependency over node/transaction.h
 namespace node {
-CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const mempool,
+CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMemPool* const m_mempool,
                                const uint256& hash, const Consensus::Params& consensusParams, uint256& hashBlock);
 } // namespace node
 
@@ -180,16 +181,7 @@ Uint256HashSet NetInstantSend::ApplyVerificationResults(
             continue;
         }
 
-        CInv inv(MSG_ISDLOCK, hash);
-        auto ret = m_is_manager.ProcessInstantSendLock(nodeId, hash, islock);
-        if (std::holds_alternative<uint256>(ret)) {
-            m_peer_manager->PeerRelayInvFiltered(inv, std::get<uint256>(ret));
-            m_peer_manager->PeerAskPeersForTransaction(islock->txid);
-        } else if (std::holds_alternative<CTransactionRef>(ret)) {
-            m_peer_manager->PeerRelayInvFiltered(inv, *std::get<CTransactionRef>(ret));
-        } else {
-            assert(std::holds_alternative<std::monostate>(ret));
-        }
+        ProcessInstantSendLock(nodeId, hash, islock);
 
         // Pass a reconstructed recovered sig to the signing manager to avoid double-verification of the sig.
         auto it = data.recSigs.find(hash);
@@ -290,7 +282,6 @@ Uint256HashSet NetInstantSend::ProcessPendingInstantSendLocks(
     return ApplyVerificationResults(llmq_params, ban, *batch, pend);
 }
 
-
 void NetInstantSend::ProcessPendingISLocks(std::vector<instantsend::PendingISLockEntry>&& locks_to_process)
 {
     // TODO Investigate if leaving this is ok
@@ -319,8 +310,7 @@ void NetInstantSend::ProcessPendingISLocks(std::vector<instantsend::PendingISLoc
     uiInterface.NotifyInstantSendChanged();
 }
 
-std::variant<uint256, CTransactionRef, std::monostate> NetInstantSend::ProcessInstantSendLock(
-    NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock)
+void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock)
 {
     LogPrint(BCLog::INSTANTSEND, "NetSigning::%s -- txid=%s, islock=%s: processing islock, peer=%d\n", __func__,
              islock->txid.ToString(), hash.ToString(), from);
@@ -328,7 +318,7 @@ std::variant<uint256, CTransactionRef, std::monostate> NetInstantSend::ProcessIn
     if (auto signer = m_is_manager.Signer(); signer) {
         signer->ClearLockFromQueue(islock);
     }
-    if (!m_is_manager.PreVerifyIsLock(hash, islock, from)) return std::monostate{};
+    if (!m_is_manager.PreVerifyIsLock(hash, islock, from)) return;
 
     uint256 hashBlock{};
     auto tx = GetTransaction(nullptr, &m_mempool, islock->txid, Params().GetConsensus(), hashBlock);
@@ -351,7 +341,7 @@ std::variant<uint256, CTransactionRef, std::monostate> NetInstantSend::ProcessIn
                      "NetSigning::%s -- txlock=%s, islock=%s: dropping islock as it already got a "
                      "ChainLock in block %s, peer=%d\n",
                      __func__, islock->txid.ToString(), hash.ToString(), hashBlock.ToString(), from);
-            return std::monostate{};
+            return;
         }
         m_is_manager.WriteNewISLock(hash, islock, minedHeight);
     } else {
@@ -367,18 +357,21 @@ std::variant<uint256, CTransactionRef, std::monostate> NetInstantSend::ProcessIn
     m_is_manager.ResolveBlockConflicts(hash, *islock);
 
     if (found_transaction) {
-        m_is_manager.RemoveMempoolConflictsForLock(hash, *islock);
+        RemoveMempoolConflictsForLock(hash, *islock);
         LogPrint(BCLog::INSTANTSEND, "NetSigning::%s -- notify about lock %s for tx %s\n", __func__, hash.ToString(),
                  tx->GetHash().ToString());
         GetMainSignals().NotifyTransactionLock(tx, islock);
-        // bump mempool counter to make sure newly locked txes are picked up by getblocktemplate
+        // bump m_mempool counter to make sure newly locked txes are picked up by getblocktemplate
         m_mempool.AddTransactionsUpdated(1);
     }
 
+    CInv inv(MSG_ISDLOCK, hash);
     if (found_transaction) {
-        return tx;
+        m_peer_manager->PeerRelayInvFiltered(inv, *tx);
+    } else {
+        m_peer_manager->PeerRelayInvFiltered(inv, islock->txid);
+        m_peer_manager->PeerAskPeersForTransaction(islock->txid);
     }
-    return islock->txid;
 }
 
 void NetInstantSend::WorkThreadMain()
@@ -400,5 +393,53 @@ void NetInstantSend::WorkThreadMain()
         if (!fMoreWork && !workInterrupt.sleep_for(WORK_THREAD_SLEEP_INTERVAL)) {
             return;
         }
+    }
+}
+
+void NetInstantSend::TransactionAddedToMempool(const CTransactionRef& tx, int64_t, uint64_t mempool_sequence)
+{
+    if (!m_is_manager.IsInstantSendEnabled() || !m_mn_sync.IsBlockchainSynced() || tx->vin.empty()) {
+        return;
+    }
+
+    instantsend::InstantSendLockPtr islock = m_is_manager.AttachISLockToTx(tx);
+    if (islock == nullptr) {
+        if (auto signer = m_is_manager.Signer(); signer) {
+            signer->ProcessTx(*tx, false, Params().GetConsensus());
+        }
+        // TX is not locked, so make sure it is tracked
+        m_is_manager.AddNonLockedTx(tx, nullptr);
+    } else {
+        RemoveMempoolConflictsForLock(::SerializeHash(*islock), *islock);
+    }
+}
+
+void NetInstantSend::RemoveMempoolConflictsForLock(const uint256& hash, const instantsend::InstantSendLock& islock)
+{
+    Uint256HashMap<CTransactionRef> toDelete;
+
+    {
+        LOCK(m_mempool.cs);
+
+        for (const auto& in : islock.inputs) {
+            auto it = m_mempool.mapNextTx.find(in);
+            if (it == m_mempool.mapNextTx.end()) {
+                continue;
+            }
+            if (it->second->GetHash() != islock.txid) {
+                toDelete.emplace(it->second->GetHash(), m_mempool.get(it->second->GetHash()));
+
+                LogPrintf("%s -- txid=%s, mempool TX %s with input %s conflicts with islock=%s\n", __func__,
+                          islock.txid.ToString(), it->second->GetHash().ToString(), in.ToStringShort(), hash.ToString());
+            }
+        }
+
+        for (const auto& p : toDelete) {
+            m_mempool.removeRecursive(*p.second, MemPoolRemovalReason::CONFLICT);
+        }
+    }
+
+    for (const auto& p : toDelete) {
+        m_is_manager.RemoveConflictedTx(*p.second);
     }
 }

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -355,7 +355,7 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
     // We don't need the recovered sigs for the inputs anymore. This prevents unnecessary propagation of these sigs.
     // We only need the ISLOCK from now on to detect conflicts
     m_is_manager.TruncateRecoveredSigsForInputs(*islock);
-    m_is_manager.ResolveBlockConflicts(hash, *islock);
+    ResolveBlockConflicts(hash, *islock);
 
     if (found_transaction) {
         RemoveMempoolConflictsForLock(hash, *islock);
@@ -511,4 +511,68 @@ void NetInstantSend::BlockDisconnected(const std::shared_ptr<const CBlock>& pblo
 void NetInstantSend::NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const chainlock::ChainLockSig>& clsig)
 {
     m_is_manager.HandleFullyConfirmedBlock(pindex);
+}
+
+void NetInstantSend::ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock)
+{
+    auto conflicts = m_is_manager.RetrieveISConflicts(islockHash, islock);
+
+    // Lets see if any of the conflicts was already mined into a ChainLocked block
+    bool hasChainLockedConflict = false;
+    for (const auto& p : conflicts) {
+        const auto* pindex = p.first;
+        if (m_is_manager.Chainlocks().HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
+            hasChainLockedConflict = true;
+            break;
+        }
+    }
+
+    // If a conflict was mined into a ChainLocked block, then we have no other choice and must prune the ISLOCK and all
+    // chained ISLOCKs that build on top of this one. The probability of this is practically zero and can only happen
+    // when large parts of the masternode network are controlled by an attacker. In this case we must still find
+    // consensus and its better to sacrifice individual ISLOCKs then to sacrifice whole ChainLocks.
+    if (hasChainLockedConflict) {
+        LogPrintf("NetInstantSend::%s -- txid=%s, islock=%s: at least one conflicted TX already got a ChainLock\n",
+                  __func__, islock.txid.ToString(), islockHash.ToString());
+        m_is_manager.RemoveConflictingLock(islockHash, islock);
+        return;
+    }
+
+    bool isLockedTxKnown = m_is_manager.IsKnownTx(islockHash);
+
+    bool activateBestChain = false;
+    for (const auto& p : conflicts) {
+        const auto* pindex = p.first;
+        for (const auto& p2 : p.second) {
+            const auto& tx = *p2.second;
+            m_is_manager.RemoveConflictedTx(tx);
+        }
+
+        LogPrintf("NetInstantSend::%s -- invalidating block %s\n", __func__, pindex->GetBlockHash().ToString());
+
+        BlockValidationState state;
+        // need non-const pointer
+        auto pindex2 = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(pindex->GetBlockHash()));
+        if (!m_chainstate.InvalidateBlock(state, pindex2)) {
+            LogPrintf("NetInstantSend::%s -- InvalidateBlock failed: %s\n", __func__, state.ToString());
+            // This should not have happened and we are in a state were it's not safe to continue anymore
+            assert(false);
+        }
+        if (isLockedTxKnown) {
+            activateBestChain = true;
+        } else {
+            LogPrintf("NetInstantSend::%s -- resetting block %s\n", __func__, pindex2->GetBlockHash().ToString());
+            LOCK(::cs_main);
+            m_chainstate.ResetBlockFailureFlags(pindex2);
+        }
+    }
+
+    if (activateBestChain) {
+        BlockValidationState state;
+        if (!m_chainstate.ActivateBestChain(state)) {
+            LogPrintf("NetInstantSend::%s -- ActivateBestChain failed: %s\n", __func__, state.ToString());
+            // This should not have happened and we are in a state were it's not safe to continue anymore
+            assert(false);
+        }
+    }
 }

--- a/src/instantsend/net_instantsend.cpp
+++ b/src/instantsend/net_instantsend.cpp
@@ -376,7 +376,7 @@ void NetInstantSend::ProcessInstantSendLock(NodeId from, const uint256& hash, co
         }
         // Let's see if the TX that was locked by this islock is already mined in a ChainLocked block. If yes,
         // we can simply ignore the islock, as the ChainLock implies locking of all TXs in that chain
-        if (minedHeight.has_value() && m_is_manager.Chainlocks().HasChainLock(*minedHeight, hashBlock)) {
+        if (minedHeight.has_value() && m_chainlocks.HasChainLock(*minedHeight, hashBlock)) {
             LogPrint(BCLog::INSTANTSEND, /* Continued */
                      "NetSigning::%s -- txlock=%s, islock=%s: dropping islock as it already got a "
                      "ChainLock in block %s, peer=%d\n",
@@ -501,7 +501,7 @@ void NetInstantSend::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockI
 {
     bool fDIP0008Active = pindexNew->pprev && pindexNew->pprev->nHeight >= Params().GetConsensus().DIP0008Height;
 
-    if (m_is_manager.Chainlocks().IsEnabled() && fDIP0008Active) {
+    if (m_chainlocks.IsEnabled() && fDIP0008Active) {
         // Nothing to do here. We should keep all islocks and let chainlocks handle them.
         return;
     }
@@ -529,7 +529,7 @@ void NetInstantSend::BlockConnected(const std::shared_ptr<const CBlock>& pblock,
     m_is_manager.CacheTipHeight(pindex);
 
     if (m_mn_sync.IsBlockchainSynced()) {
-        const bool has_chainlock = m_is_manager.Chainlocks().HasChainLock(pindex->nHeight, pindex->GetBlockHash());
+        const bool has_chainlock = m_chainlocks.HasChainLock(pindex->nHeight, pindex->GetBlockHash());
         for (const auto& tx : pblock->vtx) {
             if (tx->IsCoinBase() || tx->vin.empty()) {
                 // coinbase and TXs with no inputs can't be locked
@@ -571,7 +571,7 @@ void NetInstantSend::ResolveBlockConflicts(const uint256& islockHash, const inst
     bool hasChainLockedConflict = false;
     for (const auto& p : conflicts) {
         const auto* pindex = p.first;
-        if (m_is_manager.Chainlocks().HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
+        if (m_chainlocks.HasChainLock(pindex->nHeight, pindex->GetBlockHash())) {
             hasChainLockedConflict = true;
             break;
         }

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -9,11 +9,11 @@
 #include <saltedhasher.h>
 
 #include <util/threadinterrupt.h>
+#include <validationinterface.h>
 
 #include <memory>
 #include <optional>
 #include <thread>
-#include <variant>
 #include <vector>
 
 class CChainState;
@@ -22,6 +22,7 @@ namespace Consensus {
 struct LLMQParams;
 } // namespace Consensus
 
+class CMasternodeSync;
 class CTxMemPool;
 
 namespace instantsend {
@@ -34,16 +35,17 @@ class CInstantSendManager;
 class CQuorumManager;
 } // namespace llmq
 
-class NetInstantSend final : public NetHandler
+class NetInstantSend final : public NetHandler, public CValidationInterface
 {
 public:
     NetInstantSend(PeerManagerInternal* peer_manager, llmq::CInstantSendManager& is_manager, llmq::CQuorumManager& qman,
-                   CChainState& chainstate, CTxMemPool& mempool) :
+                   CChainState& chainstate, CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
         NetHandler(peer_manager),
         m_is_manager{is_manager},
         m_qman(qman),
         m_chainstate{chainstate},
-        m_mempool{mempool}
+        m_mempool{mempool},
+        m_mn_sync{mn_sync}
     {
         workInterrupt.reset();
     }
@@ -54,6 +56,9 @@ public:
     void Interrupt() override { workInterrupt(); };
 
     void WorkThreadMain();
+
+protected:
+    void TransactionAddedToMempool(const CTransactionRef&, int64_t, uint64_t mempool_sequence) override;
 
 private:
     struct BatchVerificationData;
@@ -71,8 +76,7 @@ private:
         const std::vector<instantsend::PendingISLockEntry>& pend);
 
     void ProcessPendingISLocks(std::vector<instantsend::PendingISLockEntry>&& locks_to_process);
-    std::variant<uint256, CTransactionRef, std::monostate> ProcessInstantSendLock(
-        NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock);
+    void ProcessInstantSendLock(NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock);
 
     Uint256HashSet ProcessPendingInstantSendLocks(
         const Consensus::LLMQParams& llmq_params, int signOffset, bool ban,
@@ -81,6 +85,7 @@ private:
     llmq::CQuorumManager& m_qman;
     const CChainState& m_chainstate;
     CTxMemPool& m_mempool;
+    const CMasternodeSync& m_mn_sync;
 
     std::thread workThread;
     CThreadInterrupt workInterrupt;

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -30,6 +30,7 @@ struct PendingISLockEntry;
 class InstantSendSigner;
 } // namespace instantsend
 namespace llmq {
+class CSigningManager;
 class CInstantSendManager;
 class CQuorumManager;
 } // namespace llmq
@@ -38,11 +39,12 @@ class NetInstantSend final : public NetHandler, public CValidationInterface
 {
 public:
     NetInstantSend(PeerManagerInternal* peer_manager, llmq::CInstantSendManager& is_manager,
-                   instantsend::InstantSendSigner* signer, llmq::CQuorumManager& qman, CChainState& chainstate,
-                   CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
+                   instantsend::InstantSendSigner* signer, llmq::CSigningManager& sigman, llmq::CQuorumManager& qman,
+                   CChainState& chainstate, CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
         NetHandler(peer_manager),
         m_is_manager{is_manager},
         m_signer{signer},
+        m_sigman{sigman},
         m_qman(qman),
         m_chainstate{chainstate},
         m_mempool{mempool},
@@ -102,6 +104,7 @@ private:
 
     llmq::CInstantSendManager& m_is_manager;
     instantsend::InstantSendSigner* m_signer; // non-null only for masternode
+    llmq::CSigningManager& m_sigman;
     llmq::CQuorumManager& m_qman;
     CChainState& m_chainstate;
     CTxMemPool& m_mempool;

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -13,6 +13,7 @@
 #include <memory>
 #include <optional>
 #include <thread>
+#include <variant>
 #include <vector>
 
 class CChainState;
@@ -20,8 +21,12 @@ class CChainState;
 namespace Consensus {
 struct LLMQParams;
 } // namespace Consensus
+
+class CTxMemPool;
+
 namespace instantsend {
 struct InstantSendLock;
+using InstantSendLockPtr = std::shared_ptr<InstantSendLock>;
 struct PendingISLockEntry;
 } // namespace instantsend
 namespace llmq {
@@ -33,11 +38,12 @@ class NetInstantSend final : public NetHandler
 {
 public:
     NetInstantSend(PeerManagerInternal* peer_manager, llmq::CInstantSendManager& is_manager, llmq::CQuorumManager& qman,
-                   CChainState& chainstate) :
+                   CChainState& chainstate, CTxMemPool& mempool) :
         NetHandler(peer_manager),
         m_is_manager{is_manager},
         m_qman(qman),
-        m_chainstate{chainstate}
+        m_chainstate{chainstate},
+        m_mempool{mempool}
     {
         workInterrupt.reset();
     }
@@ -65,6 +71,8 @@ private:
         const std::vector<instantsend::PendingISLockEntry>& pend);
 
     void ProcessPendingISLocks(std::vector<instantsend::PendingISLockEntry>&& locks_to_process);
+    std::variant<uint256, CTransactionRef, std::monostate> ProcessInstantSendLock(
+        NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock);
 
     Uint256HashSet ProcessPendingInstantSendLocks(
         const Consensus::LLMQParams& llmq_params, int signOffset, bool ban,
@@ -72,6 +80,7 @@ private:
     llmq::CInstantSendManager& m_is_manager;
     llmq::CQuorumManager& m_qman;
     const CChainState& m_chainstate;
+    CTxMemPool& m_mempool;
 
     std::thread workThread;
     CThreadInterrupt workInterrupt;

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -77,6 +77,7 @@ private:
 
     void ProcessPendingISLocks(std::vector<instantsend::PendingISLockEntry>&& locks_to_process);
     void ProcessInstantSendLock(NodeId from, const uint256& hash, const instantsend::InstantSendLockPtr& islock);
+    void RemoveMempoolConflictsForLock(const uint256& hash, const instantsend::InstantSendLock& islock);
 
     Uint256HashSet ProcessPendingInstantSendLocks(
         const Consensus::LLMQParams& llmq_params, int signOffset, bool ban,

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -6,8 +6,6 @@
 #define BITCOIN_INSTANTSEND_NET_INSTANTSEND_H
 
 #include <net_processing.h>
-#include <saltedhasher.h>
-
 #include <util/threadinterrupt.h>
 #include <validationinterface.h>
 
@@ -58,7 +56,14 @@ public:
     void WorkThreadMain();
 
 protected:
+    // -- CValidationInterface
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override;
     void TransactionAddedToMempool(const CTransactionRef&, int64_t, uint64_t mempool_sequence) override;
+    void TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason,
+                                       uint64_t mempool_sequence) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) override;
+    void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
+    void NotifyChainLock(const CBlockIndex* pindex, const std::shared_ptr<const chainlock::ChainLockSig>& clsig) override;
 
 private:
     struct BatchVerificationData;
@@ -84,7 +89,7 @@ private:
         const std::vector<instantsend::PendingISLockEntry>& pend);
     llmq::CInstantSendManager& m_is_manager;
     llmq::CQuorumManager& m_qman;
-    const CChainState& m_chainstate;
+    CChainState& m_chainstate;
     CTxMemPool& m_mempool;
     const CMasternodeSync& m_mn_sync;
 

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -27,6 +27,7 @@ namespace instantsend {
 struct InstantSendLock;
 using InstantSendLockPtr = std::shared_ptr<InstantSendLock>;
 struct PendingISLockEntry;
+class InstantSendSigner;
 } // namespace instantsend
 namespace llmq {
 class CInstantSendManager;
@@ -36,10 +37,12 @@ class CQuorumManager;
 class NetInstantSend final : public NetHandler, public CValidationInterface
 {
 public:
-    NetInstantSend(PeerManagerInternal* peer_manager, llmq::CInstantSendManager& is_manager, llmq::CQuorumManager& qman,
-                   CChainState& chainstate, CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
+    NetInstantSend(PeerManagerInternal* peer_manager, llmq::CInstantSendManager& is_manager,
+                   instantsend::InstantSendSigner* signer, llmq::CQuorumManager& qman, CChainState& chainstate,
+                   CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
         NetHandler(peer_manager),
         m_is_manager{is_manager},
+        m_signer{signer},
         m_qman(qman),
         m_chainstate{chainstate},
         m_mempool{mempool},
@@ -92,7 +95,13 @@ private:
 
     void ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock);
 
+    void TruncateRecoveredSigsForInputs(const instantsend::InstantSendLock& islock);
+
+    void HandleFullyConfirmedBlock(const CBlockIndex* pindex);
+    void ClearConflicting(const Uint256HashMap<CTransactionRef>& to_delete);
+
     llmq::CInstantSendManager& m_is_manager;
+    instantsend::InstantSendSigner* m_signer; // non-null only for masternode
     llmq::CQuorumManager& m_qman;
     CChainState& m_chainstate;
     CTxMemPool& m_mempool;

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -20,6 +20,10 @@ namespace Consensus {
 struct LLMQParams;
 } // namespace Consensus
 
+namespace chainlock {
+class Chainlocks;
+} // namespace chainlock
+
 class CMasternodeSync;
 class CTxMemPool;
 
@@ -40,12 +44,14 @@ class NetInstantSend final : public NetHandler, public CValidationInterface
 public:
     NetInstantSend(PeerManagerInternal* peer_manager, llmq::CInstantSendManager& is_manager,
                    instantsend::InstantSendSigner* signer, llmq::CSigningManager& sigman, llmq::CQuorumManager& qman,
-                   CChainState& chainstate, CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
+                   const chainlock::Chainlocks& chainlocks, CChainState& chainstate, CTxMemPool& mempool,
+                   const CMasternodeSync& mn_sync) :
         NetHandler(peer_manager),
         m_is_manager{is_manager},
         m_signer{signer},
         m_sigman{sigman},
         m_qman(qman),
+        m_chainlocks{chainlocks},
         m_chainstate{chainstate},
         m_mempool{mempool},
         m_mn_sync{mn_sync}
@@ -106,6 +112,7 @@ private:
     instantsend::InstantSendSigner* m_signer; // non-null only for masternode
     llmq::CSigningManager& m_sigman;
     llmq::CQuorumManager& m_qman;
+    const chainlock::Chainlocks& m_chainlocks;
     CChainState& m_chainstate;
     CTxMemPool& m_mempool;
     const CMasternodeSync& m_mn_sync;

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -57,6 +57,8 @@ public:
 
 protected:
     // -- CValidationInterface
+    void SynchronousUpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork,
+                                    bool fInitialDownload) override;
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override;
     void TransactionAddedToMempool(const CTransactionRef&, int64_t, uint64_t mempool_sequence) override;
     void TransactionRemovedFromMempool(const CTransactionRef& ptx, MemPoolRemovalReason reason,

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -87,6 +87,9 @@ private:
     Uint256HashSet ProcessPendingInstantSendLocks(
         const Consensus::LLMQParams& llmq_params, int signOffset, bool ban,
         const std::vector<instantsend::PendingISLockEntry>& pend);
+
+    void ResolveBlockConflicts(const uint256& islockHash, const instantsend::InstantSendLock& islock);
+
     llmq::CInstantSendManager& m_is_manager;
     llmq::CQuorumManager& m_qman;
     CChainState& m_chainstate;

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -4,17 +4,17 @@
 
 #include <instantsend/signing.h>
 
+#include <chain.h>
 #include <chainlock/chainlock.h>
+#include <chainparams.h>
+#include <index/txindex.h>
+#include <instantsend/instantsend.h>
 #include <llmq/quorumsman.h>
 #include <llmq/signing_shares.h>
+#include <logging.h>
 #include <masternode/sync.h>
 #include <spork.h>
 #include <util/helpers.h>
-
-#include <chain.h>
-#include <chainparams.h>
-#include <index/txindex.h>
-#include <logging.h>
 #include <validation.h>
 
 #include <ranges>
@@ -31,7 +31,7 @@ using node::GetTransaction;
 
 namespace instantsend {
 InstantSendSigner::InstantSendSigner(CChainState& chainstate, const chainlock::Chainlocks& chainlocks,
-                                     InstantSendSignerParent& isman, llmq::CSigningManager& sigman,
+                                     llmq::CInstantSendManager& isman, llmq::CSigningManager& sigman,
                                      llmq::CSigSharesManager& shareman, llmq::CQuorumManager& qman,
                                      CSporkManager& sporkman, CTxMemPool& mempool, const CMasternodeSync& mn_sync) :
     m_chainstate{chainstate},

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -207,28 +207,36 @@ bool InstantSendSigner::CheckCanLock(const COutPoint& outpoint, bool printDebug,
         return false;
     }
 
-    const auto blockHeight = m_isman.GetBlockHeight(hashBlock);
-    if (!blockHeight) {
-        if (printDebug) {
-            LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to determine mined height for parent TX %s\n", __func__,
-                     txHash.ToString(), outpoint.hash.ToString());
+    int blockHeight{0};
+    if (!hashBlock.IsNull()) {
+        auto ret = m_isman.GetCachedHeight(hashBlock);
+        if (ret) blockHeight = *ret;
+
+        const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(hashBlock));
+        if (pindex == nullptr) {
+            if (printDebug) {
+                LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to determine mined height for parent TX %s\n",
+                         __func__, txHash.ToString(), outpoint.hash.ToString());
+            }
+            return false;
         }
-        return false;
+        m_isman.CacheBlockHeight(pindex);
+        blockHeight = pindex->nHeight;
     }
 
     const int tipHeight = m_isman.GetTipHeight();
 
-    if (tipHeight < *blockHeight) {
+    if (tipHeight < blockHeight) {
         if (printDebug) {
             LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: cached tip height %d is below block height %d for parent TX %s\n",
-                     __func__, txHash.ToString(), tipHeight, *blockHeight, outpoint.hash.ToString());
+                     __func__, txHash.ToString(), tipHeight, blockHeight, outpoint.hash.ToString());
         }
         return false;
     }
 
-    const int nTxAge = tipHeight - *blockHeight + 1;
+    const int nTxAge = tipHeight - blockHeight + 1;
 
-    if (nTxAge < nInstantSendConfirmationsRequired && !m_chainlocks.HasChainLock(*blockHeight, hashBlock)) {
+    if (nTxAge < nInstantSendConfirmationsRequired && !m_chainlocks.HasChainLock(blockHeight, hashBlock)) {
         if (printDebug) {
             LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: outpoint %s too new and not ChainLocked. nTxAge=%d, nInstantSendConfirmationsRequired=%d\n", __func__,
                      txHash.ToString(), outpoint.ToStringShort(), nTxAge, nInstantSendConfirmationsRequired);

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -209,19 +209,20 @@ bool InstantSendSigner::CheckCanLock(const COutPoint& outpoint, bool printDebug,
 
     int blockHeight{0};
     if (!hashBlock.IsNull()) {
-        auto ret = m_isman.GetCachedHeight(hashBlock);
-        if (ret) blockHeight = *ret;
-
-        const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(hashBlock));
-        if (pindex == nullptr) {
-            if (printDebug) {
-                LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to determine mined height for parent TX %s\n",
-                         __func__, txHash.ToString(), outpoint.hash.ToString());
+        if (auto ret = m_isman.GetCachedHeight(hashBlock)) {
+            blockHeight = *ret;
+        } else {
+            const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(hashBlock));
+            if (pindex == nullptr) {
+                if (printDebug) {
+                    LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to determine mined height for parent TX %s\n",
+                             __func__, txHash.ToString(), outpoint.hash.ToString());
+                }
+                return false;
             }
-            return false;
+            m_isman.CacheBlockHeight(pindex);
+            blockHeight = pindex->nHeight;
         }
-        m_isman.CacheBlockHeight(pindex);
-        blockHeight = pindex->nHeight;
     }
 
     const int tipHeight = m_isman.GetTipHeight();

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -199,30 +199,28 @@ bool InstantSendSigner::CheckCanLock(const COutPoint& outpoint, bool printDebug,
     uint256 hashBlock{};
     const auto tx = GetTransaction(nullptr, &m_mempool, outpoint.hash, params, hashBlock);
     // this relies on enabled txindex and won't work if we ever try to remove the requirement for txindex for masternodes
-    if (!tx) {
+    if (!tx || hashBlock.IsNull()) {
         if (printDebug) {
-            LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to find parent TX %s\n", __func__, txHash.ToString(),
+            LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to find parent TX %s in mined block\n", __func__, txHash.ToString(),
                      outpoint.hash.ToString());
         }
         return false;
     }
 
     int blockHeight{0};
-    if (!hashBlock.IsNull()) {
-        if (auto ret = m_isman.GetCachedHeight(hashBlock)) {
-            blockHeight = *ret;
-        } else {
-            const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(hashBlock));
-            if (pindex == nullptr) {
-                if (printDebug) {
-                    LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to determine mined height for parent TX %s\n",
-                             __func__, txHash.ToString(), outpoint.hash.ToString());
-                }
-                return false;
+    if (auto ret = m_isman.GetCachedHeight(hashBlock)) {
+        blockHeight = *ret;
+    } else {
+        const CBlockIndex* pindex = WITH_LOCK(::cs_main, return m_chainstate.m_blockman.LookupBlockIndex(hashBlock));
+        if (pindex == nullptr) {
+            if (printDebug) {
+                LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: failed to determine mined height for parent TX %s\n",
+                         __func__, txHash.ToString(), outpoint.hash.ToString());
             }
-            m_isman.CacheBlockHeight(pindex);
-            blockHeight = pindex->nHeight;
+            return false;
         }
+        m_isman.CacheBlockHeight(pindex);
+        blockHeight = pindex->nHeight;
     }
 
     const int tipHeight = m_isman.GetTipHeight();

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -6,11 +6,10 @@
 #define BITCOIN_INSTANTSEND_SIGNING_H
 
 #include <instantsend/lock.h>
-#include <instantsend/signing.h>
 #include <llmq/signing.h>
 #include <primitives/transaction.h>
-
-#include <optional>
+#include <sync.h>
+#include <threadsafety.h>
 
 class CMasternodeSync;
 class CSporkManager;

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -39,8 +39,9 @@ public:
     virtual bool IsLocked(const uint256& txHash) const = 0;
     virtual InstantSendLockPtr GetConflictingLock(const CTransaction& tx) const = 0;
     virtual void TryEmplacePendingLock(const uint256& hash, const NodeId id, const InstantSendLockPtr& islock) = 0;
-    virtual std::optional<int> GetBlockHeight(const uint256& hash) const = 0;
+    virtual std::optional<int> GetCachedHeight(const uint256& hash) const = 0;
     virtual int GetTipHeight() const = 0;
+    virtual void CacheBlockHeight(const CBlockIndex* const block_index) const = 0;
 };
 
 class InstantSendSigner final : public llmq::CRecoveredSigsListener

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -6,6 +6,7 @@
 #define BITCOIN_INSTANTSEND_SIGNING_H
 
 #include <instantsend/lock.h>
+#include <instantsend/signing.h>
 #include <llmq/signing.h>
 #include <primitives/transaction.h>
 
@@ -30,26 +31,13 @@ class CQuorumManager;
 } // namespace llmq
 
 namespace instantsend {
-class InstantSendSignerParent
-{
-public:
-    virtual ~InstantSendSignerParent() = default;
-
-    virtual bool IsInstantSendEnabled() const = 0;
-    virtual bool IsLocked(const uint256& txHash) const = 0;
-    virtual InstantSendLockPtr GetConflictingLock(const CTransaction& tx) const = 0;
-    virtual void TryEmplacePendingLock(const uint256& hash, const NodeId id, const InstantSendLockPtr& islock) = 0;
-    virtual std::optional<int> GetCachedHeight(const uint256& hash) const = 0;
-    virtual int GetTipHeight() const = 0;
-    virtual void CacheBlockHeight(const CBlockIndex* const block_index) const = 0;
-};
 
 class InstantSendSigner final : public llmq::CRecoveredSigsListener
 {
 private:
     CChainState& m_chainstate;
     const chainlock::Chainlocks& m_chainlocks;
-    InstantSendSignerParent& m_isman;
+    llmq::CInstantSendManager& m_isman;
     llmq::CSigningManager& m_sigman;
     llmq::CSigSharesManager& m_shareman;
     llmq::CQuorumManager& m_qman;
@@ -81,7 +69,7 @@ public:
     InstantSendSigner(const InstantSendSigner&) = delete;
     InstantSendSigner& operator=(const InstantSendSigner&) = delete;
     explicit InstantSendSigner(CChainState& chainstate, const chainlock::Chainlocks& chainlocks,
-                               InstantSendSignerParent& isman, llmq::CSigningManager& sigman,
+                               llmq::CInstantSendManager& isman, llmq::CSigningManager& sigman,
                                llmq::CSigSharesManager& shareman, llmq::CQuorumManager& qman, CSporkManager& sporkman,
                                CTxMemPool& mempool, const CMasternodeSync& mn_sync);
     ~InstantSendSigner();

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -23,7 +23,7 @@ LLMQContext::LLMQContext(CDeterministicMNManager& dmnman, CEvoDB& evo_db, CSpork
     qman{std::make_unique<llmq::CQuorumManager>(*bls_worker, dmnman, evo_db, *quorum_block_processor, *qsnapman,
                                                 chainman, db_params)},
     sigman{std::make_unique<llmq::CSigningManager>(*qman, db_params, max_recsigs_age)},
-    isman{std::make_unique<llmq::CInstantSendManager>(chainlocks, *sigman, sporkman, mn_sync, db_params)}
+    isman{std::make_unique<llmq::CInstantSendManager>(chainlocks, sporkman, mn_sync, db_params)}
 {
     // Have to start it early to let VerifyDB check ChainLock signatures in coinbase
     bls_worker->Start(worker_count);

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -23,8 +23,7 @@ LLMQContext::LLMQContext(CDeterministicMNManager& dmnman, CEvoDB& evo_db, CSpork
     qman{std::make_unique<llmq::CQuorumManager>(*bls_worker, dmnman, evo_db, *quorum_block_processor, *qsnapman,
                                                 chainman, db_params)},
     sigman{std::make_unique<llmq::CSigningManager>(*qman, db_params, max_recsigs_age)},
-    isman{std::make_unique<llmq::CInstantSendManager>(chainlocks, chainman.ActiveChainstate(), *sigman, sporkman,
-                                                      mn_sync, db_params)}
+    isman{std::make_unique<llmq::CInstantSendManager>(chainlocks, *sigman, sporkman, mn_sync, db_params)}
 {
     // Have to start it early to let VerifyDB check ChainLock signatures in coinbase
     bls_worker->Start(worker_count);

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -13,7 +13,7 @@
 #include <validation.h>
 
 LLMQContext::LLMQContext(CDeterministicMNManager& dmnman, CEvoDB& evo_db, CSporkManager& sporkman,
-                         chainlock::Chainlocks& chainlocks, ChainstateManager& chainman, const CMasternodeSync& mn_sync,
+                         ChainstateManager& chainman, const CMasternodeSync& mn_sync,
                          const util::DbWrapperParams& db_params, int8_t bls_threads, int16_t worker_count,
                          int64_t max_recsigs_age) :
     bls_worker{std::make_shared<CBLSWorker>()},
@@ -23,7 +23,7 @@ LLMQContext::LLMQContext(CDeterministicMNManager& dmnman, CEvoDB& evo_db, CSpork
     qman{std::make_unique<llmq::CQuorumManager>(*bls_worker, dmnman, evo_db, *quorum_block_processor, *qsnapman,
                                                 chainman, db_params)},
     sigman{std::make_unique<llmq::CSigningManager>(*qman, db_params, max_recsigs_age)},
-    isman{std::make_unique<llmq::CInstantSendManager>(chainlocks, sporkman, mn_sync, db_params)}
+    isman{std::make_unique<llmq::CInstantSendManager>(sporkman, mn_sync, db_params)}
 {
     // Have to start it early to let VerifyDB check ChainLock signatures in coinbase
     bls_worker->Start(worker_count);

--- a/src/llmq/context.cpp
+++ b/src/llmq/context.cpp
@@ -13,9 +13,9 @@
 #include <validation.h>
 
 LLMQContext::LLMQContext(CDeterministicMNManager& dmnman, CEvoDB& evo_db, CSporkManager& sporkman,
-                         chainlock::Chainlocks& chainlocks, CTxMemPool& mempool, ChainstateManager& chainman,
-                         const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params, int8_t bls_threads,
-                         int16_t worker_count, int64_t max_recsigs_age) :
+                         chainlock::Chainlocks& chainlocks, ChainstateManager& chainman, const CMasternodeSync& mn_sync,
+                         const util::DbWrapperParams& db_params, int8_t bls_threads, int16_t worker_count,
+                         int64_t max_recsigs_age) :
     bls_worker{std::make_shared<CBLSWorker>()},
     qsnapman{std::make_unique<llmq::CQuorumSnapshotManager>(evo_db)},
     quorum_block_processor{std::make_unique<llmq::CQuorumBlockProcessor>(chainman.ActiveChainstate(), dmnman, evo_db,
@@ -24,7 +24,7 @@ LLMQContext::LLMQContext(CDeterministicMNManager& dmnman, CEvoDB& evo_db, CSpork
                                                 chainman, db_params)},
     sigman{std::make_unique<llmq::CSigningManager>(*qman, db_params, max_recsigs_age)},
     isman{std::make_unique<llmq::CInstantSendManager>(chainlocks, chainman.ActiveChainstate(), *sigman, sporkman,
-                                                      mempool, mn_sync, db_params)}
+                                                      mn_sync, db_params)}
 {
     // Have to start it early to let VerifyDB check ChainLock signatures in coinbase
     bls_worker->Start(worker_count);

--- a/src/llmq/context.h
+++ b/src/llmq/context.h
@@ -15,7 +15,6 @@ class CDeterministicMNManager;
 class CEvoDB;
 class CMasternodeSync;
 class CSporkManager;
-class CTxMemPool;
 class PeerManager;
 
 namespace chainlock {
@@ -39,9 +38,9 @@ public:
     LLMQContext(const LLMQContext&) = delete;
     LLMQContext& operator=(const LLMQContext&) = delete;
     explicit LLMQContext(CDeterministicMNManager& dmnman, CEvoDB& evo_db, CSporkManager& sporkman,
-                         chainlock::Chainlocks& chainlocks, CTxMemPool& mempool, ChainstateManager& chainman,
-                         const CMasternodeSync& mn_sync, const util::DbWrapperParams& db_params, int8_t bls_threads,
-                         int16_t worker_count, int64_t max_recsigs_age);
+                         chainlock::Chainlocks& chainlocks, ChainstateManager& chainman, const CMasternodeSync& mn_sync,
+                         const util::DbWrapperParams& db_params, int8_t bls_threads, int16_t worker_count,
+                         int64_t max_recsigs_age);
     ~LLMQContext();
 
     /** Guaranteed if LLMQContext is initialized then all members are valid too

--- a/src/llmq/context.h
+++ b/src/llmq/context.h
@@ -17,10 +17,6 @@ class CMasternodeSync;
 class CSporkManager;
 class PeerManager;
 
-namespace chainlock {
-class Chainlocks;
-}
-
 namespace llmq {
 class CInstantSendManager;
 class CQuorumBlockProcessor;
@@ -38,7 +34,7 @@ public:
     LLMQContext(const LLMQContext&) = delete;
     LLMQContext& operator=(const LLMQContext&) = delete;
     explicit LLMQContext(CDeterministicMNManager& dmnman, CEvoDB& evo_db, CSporkManager& sporkman,
-                         chainlock::Chainlocks& chainlocks, ChainstateManager& chainman, const CMasternodeSync& mn_sync,
+                         ChainstateManager& chainman, const CMasternodeSync& mn_sync,
                          const util::DbWrapperParams& db_params, int8_t bls_threads, int16_t worker_count,
                          int64_t max_recsigs_age);
     ~LLMQContext();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4768,7 +4768,7 @@ void PeerManagerImpl::ProcessMessage(
                 // We will continue to reject this tx since it has rejected
                 // parents so avoid re-requesting it from other peers.
                 m_recent_rejects.insert(tx.GetHash());
-                m_llmq_ctx->isman->TransactionRemovedFromMempool(ptx);
+                m_llmq_ctx->isman->TransactionIsRemoved(ptx);
             }
         } else {
             m_recent_rejects.insert(tx.GetHash());
@@ -4799,7 +4799,7 @@ void PeerManagerImpl::ProcessMessage(
                 pfrom.GetId(),
                 state.ToString());
             MaybePunishNodeForTx(pfrom.GetId(), state);
-            m_llmq_ctx->isman->TransactionRemovedFromMempool(ptx);
+            m_llmq_ctx->isman->TransactionIsRemoved(ptx);
         }
         return;
     }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -230,7 +230,7 @@ void DashChainstateSetup(ChainstateManager& chainman,
     dmnman = std::make_unique<CDeterministicMNManager>(evodb, mn_metaman);
 
     llmq_ctx.reset();
-    llmq_ctx = std::make_unique<LLMQContext>(*dmnman, evodb, sporkman, chainlocks, *mempool, chainman, mn_sync,
+    llmq_ctx = std::make_unique<LLMQContext>(*dmnman, evodb, sporkman, chainlocks, chainman, mn_sync,
                                              util::DbWrapperParams{.path = data_dir, .memory = llmq_dbs_in_memory, .wipe = llmq_dbs_wipe},
                                              bls_threads, worker_count, max_recsigs_age);
     mempool->ConnectManagers(dmnman.get(), llmq_ctx->isman.get());

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -230,7 +230,7 @@ void DashChainstateSetup(ChainstateManager& chainman,
     dmnman = std::make_unique<CDeterministicMNManager>(evodb, mn_metaman);
 
     llmq_ctx.reset();
-    llmq_ctx = std::make_unique<LLMQContext>(*dmnman, evodb, sporkman, chainlocks, chainman, mn_sync,
+    llmq_ctx = std::make_unique<LLMQContext>(*dmnman, evodb, sporkman, chainman, mn_sync,
                                              util::DbWrapperParams{.path = data_dir, .memory = llmq_dbs_in_memory, .wipe = llmq_dbs_wipe},
                                              bls_threads, worker_count, max_recsigs_age);
     mempool->ConnectManagers(dmnman.get(), llmq_ctx->isman.get());

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -40,7 +40,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "evo/specialtxman -> validation -> evo/specialtxman",
     "governance/classes -> governance/object -> governance/governance -> governance/classes",
     "governance/governance -> governance/signing -> governance/object -> governance/governance",
-    "instantsend/instantsend -> instantsend/signing -> validation -> txmempool -> instantsend/instantsend",
+    "instantsend/instantsend -> node/blockstorage -> validation -> txmempool -> instantsend/instantsend",
     "llmq/blockprocessor -> llmq/utils -> llmq/snapshot -> llmq/blockprocessor",
     "llmq/commitment -> llmq/utils -> llmq/snapshot -> llmq/commitment",
     "llmq/dkgsessionhandler -> net_processing -> llmq/dkgsessionmgr -> llmq/dkgsessionhandler",

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -40,7 +40,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "evo/specialtxman -> validation -> evo/specialtxman",
     "governance/classes -> governance/object -> governance/governance -> governance/classes",
     "governance/governance -> governance/signing -> governance/object -> governance/governance",
-    "instantsend/instantsend -> validation -> txmempool -> instantsend/instantsend",
+    "instantsend/instantsend -> instantsend/signing -> validation -> txmempool -> instantsend/instantsend",
     "llmq/blockprocessor -> llmq/utils -> llmq/snapshot -> llmq/blockprocessor",
     "llmq/commitment -> llmq/utils -> llmq/snapshot -> llmq/commitment",
     "llmq/dkgsessionhandler -> net_processing -> llmq/dkgsessionmgr -> llmq/dkgsessionhandler",

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -40,7 +40,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "evo/specialtxman -> validation -> evo/specialtxman",
     "governance/classes -> governance/object -> governance/governance -> governance/classes",
     "governance/governance -> governance/signing -> governance/object -> governance/governance",
-    "instantsend/instantsend -> txmempool -> instantsend/instantsend",
+    "instantsend/instantsend -> validation -> txmempool -> instantsend/instantsend",
     "llmq/blockprocessor -> llmq/utils -> llmq/snapshot -> llmq/blockprocessor",
     "llmq/commitment -> llmq/utils -> llmq/snapshot -> llmq/commitment",
     "llmq/dkgsessionhandler -> net_processing -> llmq/dkgsessionmgr -> llmq/dkgsessionhandler",


### PR DESCRIPTION
## Issue being fixed or feature implemented

Basically, CInstantSendManager's responsibility is remembering all known instant-send locks (by using `CInstantSendDb`) and it is used all over codebase to answer a question a basic but important question "Is transaction X locked?".

In details, there are 4 public interfaces that are used to answer that question:
 - is transaction instant-send locked? `IsLocked`
 - is transaction / IS lock known? `IsKnown`, `AlreadyHave`
 - is instant-send enabled? (spork's related features, relevant for testnet & regtest only)
 - get me IS lock! (`GetInstantSendLockByTxid`, `GetInstantSendLockByHash`).

In the reality, current implementation of CInstantSendManager has knowledges about multiple systems and components that are irrelevant, but not really needed to provide this base functionality.


## What was done?
Removed dependency of CInstantSendManager on `instantsend::InstantSendSigner`, `llmq::CSigningManager`, `CChainState`, `chainlock::Chainlocks`, `CTxMemPool`.

Removing dependency on CMasternodeSync is excluded from this PR because it requires bitcoin/bitcoin#25073 to be done first.

## How Has This Been Tested?
Run unit & functional tests, linters.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone