### PR TITLE
fix(qt): reseat quorum labels when new types are inserted

### DIFF
--- a/src/qt/networkwidget.cpp
+++ b/src/qt/networkwidget.cpp
@@ -240,6 +240,7 @@ void NetworkWidget::handleQrDataChanged()
             it->second.second->setToolTip(tr("Waiting for blockchain sync…"));
             grid->addWidget(it->second.first, current_row, 0);
             grid->addWidget(it->second.second, current_row, 1);
+            needs_reseating = true;
         } else if (needs_reseating) {
             grid->removeWidget(it->second.first);
             grid->removeWidget(it->second.second);


### PR DESCRIPTION
## Issue being fixed or feature implemented
When new quorum types appear during reindexing, existing labels that follow the insertion point in the grid were not being repositioned, causing overlapping text in the Information tab's Quorums section.

before:
<img width="292" height="173" alt="Screenshot 2026-03-01 at 13 56 12" src="https://github.com/user-attachments/assets/54daacde-6e44-4771-8478-00d11d93944a" />

after:
<img width="282" height="188" alt="Screenshot 2026-03-02 at 19 07 23" src="https://github.com/user-attachments/assets/ed1f74c1-9c16-498b-ac7e-147f9601ba88" />

## What was done?

## How Has This Been Tested?
reindex with and without the patch on testnet

## Breaking Changes
n/a
## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

