### PR TITLE
fix: reject identity elements in deserialization and key generation

### DIFF
--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -66,6 +66,9 @@ void CBLSSecretKey::MakeNewKey()
         GetStrongRandBytes({buf, sizeof(buf)});
         try {
             impl = bls::PrivateKey::FromBytes(bls::Bytes(reinterpret_cast<const uint8_t*>(buf), SerSize));
+            if (impl == bls::PrivateKey()) {
+                continue;
+            }
             break;
         } catch (...) {
         }

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -111,6 +111,11 @@ public:
         } else {
             try {
                 impl = ImplType::FromBytes(bls::Bytes(vecBytes.data(), vecBytes.size()), specificLegacyScheme);
+                if (impl == ImplType()) {
+                    Reset();
+                    cachedHash.SetNull();
+                    return;
+                }
                 fValid = true;
             } catch (...) {
                 Reset();


### PR DESCRIPTION
## Issue being fixed or feature implemented
Identity elements are mathematically valid curve points but have no legitimate use in the protocol.

## What was done?
Reject BLS identity elements (point at infinity for G1/G2) at the deserialization boundary in SetBytes(). Also reject zero private keys in MakeNewKey(). Identity elements would not pass further validation anyway, reject them early.

## How Has This Been Tested?
Run tests

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

