### PR TITLE
ci: restrict guix build to tagged pushes and labeled PRs only

### DIFF
--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -9,6 +9,8 @@ on:
   pull_request_target:
     types: [labeled]
   push:
+    tags:
+      - '*'
   schedule:
     # Run weekly at 3 AM UTC on Sunday on the default branch
     - cron: '0 3 * * 0'


### PR DESCRIPTION
## Summary

Restrict the Guix Build CI workflow to only trigger on:
- **Tagged pushes** (release tags)
- **PRs with the `guix-build` label**
- **Weekly schedule** (Sunday 3 AM UTC)

Previously, the workflow triggered on **all** push events (every branch push), relying on the job-level `if` condition to skip non-tag pushes. While functionally correct, this created unnecessary skipped workflow runs on every PR update.

## Changes

- Add `tags: ['*']` filter to the `push` trigger, so only tag pushes fire the workflow
- The existing job-level `if` condition is kept as defense-in-depth

## Testing

No functional change — the workflow already skipped non-tag branch pushes via the `if` condition. This change prevents the workflow from being triggered at all on branch pushes.
