### PR TITLE
ci: migrate all workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build-amd64:
     name: Build container (amd64)
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
       repo: ${{ steps.prepare.outputs.repo }}
@@ -43,7 +43,7 @@ jobs:
           echo "repo=${REPO_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v2
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
@@ -62,14 +62,10 @@ jobs:
           platforms: linux/amd64
           tags: |
             ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ hashFiles(inputs.file) }}-amd64
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ hashFiles(inputs.file) }}-amd64
-            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ steps.prepare.outputs.tag }}
-          cache-to: type=inline
 
   build-arm64:
     name: Build container (arm64)
-    runs-on: ubuntu-24.04-arm
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -87,7 +83,7 @@ jobs:
           echo "repo=${REPO_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -98,7 +94,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v2
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
@@ -106,14 +102,10 @@ jobs:
           platforms: linux/arm64
           tags: |
             ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ hashFiles(inputs.file) }}-arm64
-          cache-from: |
-            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ hashFiles(inputs.file) }}-arm64
-            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ steps.prepare.outputs.tag }}
-          cache-to: type=inline
 
   create-manifest:
     name: Create multi-arch manifest
-    runs-on: ubuntu-24.04-arm
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     needs: [build-amd64, build-arm64]
     steps:
       - name: Checkout code
@@ -122,7 +114,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -14,7 +14,7 @@ on:
       runs-on:
         description: "Runner label to use (e.g., ubuntu-24.04 or ubuntu-24.04-arm)"
         required: false
-        default: ubuntu-24.04
+        default: blacksmith-4vcpu-ubuntu-2404
         type: string
     outputs:
       key:

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -27,7 +27,7 @@ on:
       runs-on:
         description: "Runner label to use (e.g., ubuntu-24.04 or ubuntu-24.04-arm)"
         required: false
-        default: ubuntu-24.04
+        default: blacksmith-4vcpu-ubuntu-2404
         type: string
     outputs:
       key:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   check-skip:
     name: Check skip conditions
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       skip: ${{ steps.skip-check.outputs.skip }}
     steps:
@@ -95,7 +95,7 @@ jobs:
     with:
       build-target: linux64_multiprocess
       container-path: ${{ needs.container.outputs.path }}
-      runs-on: ubuntu-24.04-arm
+      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
 
   depends-linux64_nowallet:
     name: x86_64-pc-linux-gnu_nowallet
@@ -177,7 +177,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_multiprocess.outputs.key }}
       depends-host: ${{ needs.depends-linux64_multiprocess.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_multiprocess.outputs.dep-opts }}
-      runs-on: ubuntu-24.04-arm
+      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
 
   src-linux64_nowallet:
     name: linux64_nowallet-build
@@ -213,7 +213,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_multiprocess.outputs.key }}
       depends-host: ${{ needs.depends-linux64_multiprocess.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_multiprocess.outputs.dep-opts }}
-      runs-on: ubuntu-24.04-arm
+      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
 
   src-linux64_ubsan:
     name: linux64_ubsan-build
@@ -266,7 +266,7 @@ jobs:
       bundle-key: ${{ needs.src-linux64_multiprocess.outputs.key }}
       build-target: linux64_multiprocess
       container-path: ${{ needs.container-slim.outputs.path }}
-      runs-on: ubuntu-24.04-arm
+      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
 
   test-linux64_nowallet:
     name: linux64_nowallet-test
@@ -294,7 +294,7 @@ jobs:
       bundle-key: ${{ needs.src-linux64_tsan.outputs.key }}
       build-target: linux64_tsan
       container-path: ${{ needs.container-slim.outputs.path }}
-      runs-on: ubuntu-24.04-arm
+      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
 
   test-linux64_ubsan:
     name: linux64_ubsan-test

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -18,7 +18,7 @@ on:
       runs-on:
         description: "Runner label to use (e.g., ubuntu-24.04 or ubuntu-24.04-arm)"
         required: false
-        default: ubuntu-24.04
+        default: blacksmith-4vcpu-ubuntu-2404
         type: string
 
 env:


### PR DESCRIPTION
## Summary

Migrate all CI workflows from GitHub-hosted runners to [Blacksmith](https://blacksmith.sh/) runners for faster builds and better caching. Supersedes #7196 (auto-generated bot PR) with full coverage of all workflows.

## Runner mapping

| Before | After |
|--------|-------|
| `ubuntu-latest` / `ubuntu-24.04` | `blacksmith-4vcpu-ubuntu-2404` |
| `ubuntu-24.04-arm` | `blacksmith-4vcpu-ubuntu-2404-arm` |

## Changes

**All 9 workflow files updated:**

- **`build.yml`** — `check-skip` runner + all `runs-on` values passed to sub-workflows
- **`build-container.yml`** — Runners + Docker actions (`useblacksmith/setup-docker-builder@v1`, `useblacksmith/build-push-action@v2`), removed explicit layer cache config (Blacksmith handles caching natively)
- **`build-depends.yml`**, **`build-src.yml`**, **`test-src.yml`** — Default `runs-on` input updated
- **`lint.yml`**, **`cache-depends-sources.yml`** — Hardcoded runners updated
- **`guix-build.yml`** — ARM runners updated
- **`semantic-pull-request.yml`** — Runner updated

**Architecture-aware:** Jobs that were on ARM runners stay on ARM (`blacksmith-4vcpu-ubuntu-2404-arm`); x86 jobs use the x86 variant.

## Testing

CI will validate itself — if Blacksmith runners work, the workflows pass. If they don't, we revert.
