### PR TITLE
ci:  Blacksmith runners followup

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build-amd64:
     name: Build container (amd64)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
     outputs:
       tag: ${{ steps.prepare.outputs.tag }}
       repo: ${{ steps.prepare.outputs.repo }}
@@ -43,7 +43,7 @@ jobs:
           echo "repo=${REPO_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
@@ -62,10 +62,14 @@ jobs:
           platforms: linux/amd64
           tags: |
             ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ hashFiles(inputs.file) }}-amd64
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ hashFiles(inputs.file) }}-amd64
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ steps.prepare.outputs.tag }}
+          cache-to: type=inline
 
   build-arm64:
     name: Build container (arm64)
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ${{ vars.RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
@@ -83,7 +87,7 @@ jobs:
           echo "repo=${REPO_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -94,7 +98,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: useblacksmith/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
@@ -102,10 +106,14 @@ jobs:
           platforms: linux/arm64
           tags: |
             ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ hashFiles(inputs.file) }}-arm64
+          cache-from: |
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ hashFiles(inputs.file) }}-arm64
+            type=registry,ref=ghcr.io/${{ steps.prepare.outputs.repo }}/${{ inputs.name }}:${{ steps.prepare.outputs.tag }}
+          cache-to: type=inline
 
   create-manifest:
     name: Create multi-arch manifest
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ${{ vars.RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
     needs: [build-amd64, build-arm64]
     steps:
       - name: Checkout code
@@ -114,7 +122,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
-        uses: useblacksmith/setup-docker-builder@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -13,8 +13,7 @@ on:
         type: string
       runs-on:
         description: "Runner label to use (e.g., ubuntu-24.04 or ubuntu-24.04-arm)"
-        required: false
-        default: blacksmith-4vcpu-ubuntu-2404
+        required: true
         type: string
     outputs:
       key:

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -26,8 +26,7 @@ on:
         default: ""
       runs-on:
         description: "Runner label to use (e.g., ubuntu-24.04 or ubuntu-24.04-arm)"
-        required: false
-        default: blacksmith-4vcpu-ubuntu-2404
+        required: true
         type: string
     outputs:
       key:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   check-skip:
     name: Check skip conditions
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
     outputs:
       skip: ${{ steps.skip-check.outputs.skip }}
     steps:
@@ -71,6 +71,7 @@ jobs:
     with:
       build-target: aarch64-linux
       container-path: ${{ needs.container.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   depends-linux64:
     name: x86_64-pc-linux-gnu
@@ -84,6 +85,7 @@ jobs:
     with:
       build-target: linux64
       container-path: ${{ needs.container.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   depends-linux64_multiprocess:
     name: linux64_multiprocess
@@ -95,7 +97,7 @@ jobs:
     with:
       build-target: linux64_multiprocess
       container-path: ${{ needs.container.outputs.path }}
-      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+      runs-on: ${{ vars.RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
 
   depends-linux64_nowallet:
     name: x86_64-pc-linux-gnu_nowallet
@@ -105,6 +107,7 @@ jobs:
     with:
       build-target: linux64_nowallet
       container-path: ${{ needs.container.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   depends-mac:
     name: x86_64-apple-darwin
@@ -114,6 +117,7 @@ jobs:
     with:
       build-target: mac
       container-path: ${{ needs.container.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   depends-win64:
     name: x86_64-w64-mingw32
@@ -123,6 +127,7 @@ jobs:
     with:
       build-target: win64
       container-path: ${{ needs.container.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   lint:
     name: Lint
@@ -141,6 +146,7 @@ jobs:
       depends-key: ${{ needs.depends-aarch64-linux.outputs.key }}
       depends-host: ${{ needs.depends-aarch64-linux.outputs.host }}
       depends-dep-opts: ${{ needs.depends-aarch64-linux.outputs.dep-opts }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   src-linux64:
     name: linux64-build
@@ -153,6 +159,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64.outputs.key }}
       depends-host: ${{ needs.depends-linux64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64.outputs.dep-opts }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   src-linux64_fuzz:
     name: linux64_fuzz-build
@@ -165,6 +172,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64.outputs.key }}
       depends-host: ${{ needs.depends-linux64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64.outputs.dep-opts }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   src-linux64_multiprocess:
     name: linux64_multiprocess-build
@@ -177,7 +185,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_multiprocess.outputs.key }}
       depends-host: ${{ needs.depends-linux64_multiprocess.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_multiprocess.outputs.dep-opts }}
-      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+      runs-on: ${{ vars.RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
 
   src-linux64_nowallet:
     name: linux64_nowallet-build
@@ -189,6 +197,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_nowallet.outputs.key }}
       depends-host: ${{ needs.depends-linux64_nowallet.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_nowallet.outputs.dep-opts }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   src-linux64_sqlite:
     name: linux64_sqlite-build
@@ -201,6 +210,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64.outputs.key }}
       depends-host: ${{ needs.depends-linux64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64.outputs.dep-opts }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   src-linux64_tsan:
     name: linux64_tsan-build
@@ -213,7 +223,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_multiprocess.outputs.key }}
       depends-host: ${{ needs.depends-linux64_multiprocess.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_multiprocess.outputs.dep-opts }}
-      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+      runs-on: ${{ vars.RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
 
   src-linux64_ubsan:
     name: linux64_ubsan-build
@@ -226,6 +236,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64.outputs.key }}
       depends-host: ${{ needs.depends-linux64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64.outputs.dep-opts }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   src-mac:
     name: mac-build
@@ -237,6 +248,7 @@ jobs:
       depends-key: ${{ needs.depends-mac.outputs.key }}
       depends-host: ${{ needs.depends-mac.outputs.host }}
       depends-dep-opts: ${{ needs.depends-mac.outputs.dep-opts }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   src-win64:
     name: win64-build
@@ -248,6 +260,7 @@ jobs:
       depends-key: ${{ needs.depends-win64.outputs.key }}
       depends-host: ${{ needs.depends-win64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-win64.outputs.dep-opts }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   test-linux64:
     name: linux64-test
@@ -257,6 +270,7 @@ jobs:
       bundle-key: ${{ needs.src-linux64.outputs.key }}
       build-target: linux64
       container-path: ${{ needs.container-slim.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   test-linux64_multiprocess:
     name: linux64_multiprocess-test
@@ -266,7 +280,7 @@ jobs:
       bundle-key: ${{ needs.src-linux64_multiprocess.outputs.key }}
       build-target: linux64_multiprocess
       container-path: ${{ needs.container-slim.outputs.path }}
-      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+      runs-on: ${{ vars.RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
 
   test-linux64_nowallet:
     name: linux64_nowallet-test
@@ -276,6 +290,7 @@ jobs:
       bundle-key: ${{ needs.src-linux64_nowallet.outputs.key }}
       build-target: linux64_nowallet
       container-path: ${{ needs.container-slim.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   test-linux64_sqlite:
     name: linux64_sqlite-test
@@ -285,6 +300,7 @@ jobs:
       bundle-key: ${{ needs.src-linux64_sqlite.outputs.key }}
       build-target: linux64_sqlite
       container-path: ${{ needs.container-slim.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
 
   test-linux64_tsan:
     name: linux64_tsan-test
@@ -294,7 +310,7 @@ jobs:
       bundle-key: ${{ needs.src-linux64_tsan.outputs.key }}
       build-target: linux64_tsan
       container-path: ${{ needs.container-slim.outputs.path }}
-      runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+      runs-on: ${{ vars.RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
 
   test-linux64_ubsan:
     name: linux64_ubsan-test
@@ -304,3 +320,4 @@ jobs:
       bundle-key: ${{ needs.src-linux64_ubsan.outputs.key }}
       build-target: linux64_ubsan
       container-path: ${{ needs.container-slim.outputs.path }}
+      runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}

--- a/.github/workflows/cache-depends-sources.yml
+++ b/.github/workflows/cache-depends-sources.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cache-sources:
     name: Cache depends sources
-    runs-on: ubuntu-24.04-arm
+    runs-on: ${{ vars.RUNNER_ARM64 || 'ubuntu-24.04-arm' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     name: Run linters
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
     container:
       image: ${{ inputs.container-path }}
       options: --user root

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -17,8 +17,7 @@ on:
         type: string
       runs-on:
         description: "Runner label to use (e.g., ubuntu-24.04 or ubuntu-24.04-arm)"
-        required: false
-        default: blacksmith-4vcpu-ubuntu-2404
+        required: true
         type: string
 
 env:


### PR DESCRIPTION
## Summary

Migrate the lint and depends-source-cache workflows to Blacksmith runners to keep the entire main CI pipeline on the same runner infrastructure. Fixes cache compatibility issues when build/test jobs run on Blacksmith but the cache-warming job runs on GitHub-hosted runners.

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| `cache-depends-sources.yml` | `ubuntu-24.04-arm` | `blacksmith-4vcpu-ubuntu-2404-arm` |
| `lint.yml` | `ubuntu-24.04` | `blacksmith-4vcpu-ubuntu-2404` |

Companion to #7197 (build pipeline migration).
