### PR TITLE
ci: run linux64_nowallet jobs on ARM runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,7 +160,7 @@ jobs:
       build-target: linux64_nowallet
       container-path: ${{ needs.container.outputs.path }}
       base-image-digest: ${{ needs.check-skip.outputs.base-image-digest }}
-      runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
+      runs-on: ${{ needs.check-skip.outputs['runner-arm64'] }}
 
   depends-mac:
     name: x86_64-apple-darwin
@@ -253,7 +253,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_nowallet.outputs.key }}
       depends-host: ${{ needs.depends-linux64_nowallet.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_nowallet.outputs.dep-opts }}
-      runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
+      runs-on: ${{ needs.check-skip.outputs['runner-arm64'] }}
 
   src-linux64_sqlite:
     name: linux64_sqlite-build
@@ -346,7 +346,7 @@ jobs:
       bundle-key: ${{ needs.src-linux64_nowallet.outputs.key }}
       build-target: linux64_nowallet
       container-path: ${{ needs.container-slim.outputs.path }}
-      runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
+      runs-on: ${{ needs.check-skip.outputs['runner-arm64'] }}
 
   test-linux64_sqlite:
     name: linux64_sqlite-test


### PR DESCRIPTION
## Summary

Move the `linux64_nowallet` depends, build, and test jobs to ARM runners, matching the pattern already used by `linux64_multiprocess` and `linux64_tsan`.

## Changes

In `build.yml`, switch `runs-on` for three jobs from `RUNNER_AMD64` to `RUNNER_ARM64`:
- `depends-linux64_nowallet`
- `src-linux64_nowallet`
- `test-linux64_nowallet`
