### PR TITLE
feat!: make Descriptor wallets to be created by default

### DIFF
--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -12,10 +12,8 @@ In the GUI, the `Create a new wallet` button is displayed on the main screen whe
 The following command, for example, creates a descriptor wallet. More information about this command may be found by running `dash-cli help createwallet`.
 
 ```
-$ dash-cli -named createwallet wallet_name="wallet-01" descriptors=true
+$ dash-cli createwallet "wallet-01"
 ```
-
-The `descriptors` parameter can be omitted if the intention is to create a legacy wallet. For now, the default type is the legacy wallet, but that is expected to change in a future release.
 
 By default, wallets are created in the `wallets` folder of the data directory, which varies by operating system, as shown below. The user can change the default by using the `-datadir` or `-walletdir` initialization parameters.
 
@@ -54,7 +52,7 @@ Only the wallet's private key is encrypted. All other wallet information, such a
 The wallet's private key can also be encrypted in the `createwallet` command via the `passphrase` argument:
 
 ```
-$ dash-cli -named createwallet wallet_name="wallet-01" descriptors=true passphrase="passphrase"
+$ dash-cli -named createwallet wallet_name="wallet-01" passphrase="passphrase"
 ```
 
 Note that if the passphrase is lost, all the coins in the wallet will also be lost forever.

--- a/doc/multisig-tutorial.md
+++ b/doc/multisig-tutorial.md
@@ -27,7 +27,7 @@ These three wallets should not be used directly for privacy reasons (public key 
 ```bash
 for ((n=1;n<=3;n++))
 do
- ./src/dash-cli -testnet -named createwallet wallet_name="participant_${n}" descriptors=true
+ ./src/dash-cli -testnet createwallet "participant_${n}"
 done
 ```
 
@@ -105,7 +105,7 @@ Then import the descriptors created in the previous step using the `importdescri
 After that, `getwalletinfo` can be used to check if the wallet was created successfully.
 
 ```bash
-./src/dash-cli -testnet -named createwallet wallet_name="multisig_wallet_01" disable_private_keys=true blank=true descriptors=true
+./src/dash-cli -testnet -named createwallet wallet_name="multisig_wallet_01" disable_private_keys=true blank=true
 
 ./src/dash-cli  -testnet -rpcwallet="multisig_wallet_01" importdescriptors "$multisig_desc"
 

--- a/doc/release-notes-7204.md
+++ b/doc/release-notes-7204.md
@@ -1,0 +1,21 @@
+Notable changes
+===============
+
+Updated RPCs
+------------
+
+
+Changes to wallet related RPCs can be found in the Wallet section below.
+
+Wallet
+------
+
+- Descriptor wallets are now the default wallet type. Newly created wallets
+  will use descriptors unless `descriptors=false` is set during `createwallet`, or
+  the `Descriptor wallet` checkbox is unchecked in the GUI. (dash#7204)
+
+  Note that wallet RPC commands like `importmulti` and `dumpprivkey` cannot be
+  used with descriptor wallets, so if your client code relies on these commands
+  without specifying `descriptors=false` during wallet creation, you will need
+  to update your code.
+

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -39,6 +39,7 @@ static void SetupWalletToolArgs(ArgsManager& argsman)
     argsman.AddArg("-dumpfile=<file name>", "When used with 'dump', writes out the records to this file. When used with 'createfromdump', loads the records into a new wallet.", ArgsManager::ALLOW_ANY | ArgsManager::DISALLOW_NEGATION, OptionsCategory::OPTIONS);
     argsman.AddArg("-debug=<category>", "Output debugging information (default: 0).", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-descriptors", "Create descriptors wallet. Only for 'create'", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-legacy", "Create legacy wallet. Only for 'create'", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-format=<format>", "The format of the wallet file to create. Either \"bdb\" or \"sqlite\". Only used with 'createfromdump'", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -debug is true, 0 otherwise).", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
 

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -128,6 +128,9 @@
         <property name="text">
          <string>Descriptor Wallet</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item>

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -634,7 +634,7 @@ static RPCHelpMan createwallet()
             {"blank", RPCArg::Type::BOOL, RPCArg::Default{false}, "Create a blank wallet. A blank wallet has no keys or HD seed. One can be set using upgradetohd (by mnemonic) or sethdseed (WIF private key)."},
             {"passphrase", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "Encrypt the wallet with this passphrase."},
             {"avoid_reuse", RPCArg::Type::BOOL, RPCArg::Default{false}, "Keep track of coin reuse, and treat dirty and clean coins differently with privacy considerations in mind."},
-            {"descriptors", RPCArg::Type::BOOL, RPCArg::Default{false}, "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation."},
+            {"descriptors", RPCArg::Type::BOOL, RPCArg::Default{true}, "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation."},
             {"load_on_startup", RPCArg::Type::BOOL, RPCArg::Optional::OMITTED_NAMED_ARG, "Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged."},
             {"external_signer", RPCArg::Type::BOOL, RPCArg::Default{false}, "Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true."},
         },
@@ -676,13 +676,13 @@ static RPCHelpMan createwallet()
     if (!request.params[4].isNull() && request.params[4].get_bool()) {
         flags |= WALLET_FLAG_AVOID_REUSE;
     }
-    if (!request.params[5].isNull() && request.params[5].get_bool()) {
+    if (!request.params[5].isNull() && request.params[6].isNull()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "The createwallet RPC requires specifying the 'load_on_startup' flag when param 'descriptors' is specified. Dash Core v21 introduced this requirement due to breaking changes in the createwallet RPC.");
+    }
+    if (request.params[5].isNull() || request.params[5].get_bool()) {
 #ifndef USE_SQLITE
         throw JSONRPCError(RPC_WALLET_ERROR, "Compiled without sqlite support (required for descriptor wallets)");
 #endif
-        if (request.params[6].isNull()) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "The createwallet RPC requires specifying the 'load_on_startup' flag when creating descriptor wallets. Dash Core v21 introduced this requirement due to breaking changes in the createwallet RPC.");
-        }
         flags |= WALLET_FLAG_DESCRIPTORS;
     }
     if (!request.params[7].isNull() && request.params[7].get_bool()) {

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -134,6 +134,10 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         tfm::format(std::cerr, "The -descriptors option can only be used with the 'create' command.\n");
         return false;
     }
+    if (args.IsArgSet("-legacy") && command != "create") {
+        tfm::format(std::cerr, "The -legacy option can only be used with the 'create' command.\n");
+        return false;
+    }
     if (command == "create" && !args.IsArgSet("-wallet")) {
         tfm::format(std::cerr, "Wallet name must be provided when creating a new wallet.\n");
         return false;
@@ -145,7 +149,19 @@ bool ExecuteWalletToolFunc(const ArgsManager& args, const std::string& command)
         DatabaseOptions options;
         ReadDatabaseArgs(args, options);
         options.require_create = true;
-        if (args.GetBoolArg("-descriptors", false)) {
+        // If -legacy is set, use it. Otherwise default to false.
+        bool make_legacy = args.GetBoolArg("-legacy", false);
+        // If neither -legacy nor -descriptors is set, default to true. If -descriptors is set, use its value.
+        bool make_descriptors = (!args.IsArgSet("-descriptors") && !args.IsArgSet("-legacy")) || (args.IsArgSet("-descriptors") && args.GetBoolArg("-descriptors", true));
+        if (make_legacy && make_descriptors) {
+            tfm::format(std::cerr, "Only one of -legacy or -descriptors can be set to true, not both\n");
+            return false;
+        }
+        if (!make_legacy && !make_descriptors) {
+            tfm::format(std::cerr, "One of -legacy or -descriptors must be set to true (or omitted)\n");
+            return false;
+        }
+        if (make_descriptors) {
             options.create_flags |= WALLET_FLAG_DESCRIPTORS;
             options.require_format = DatabaseFormat::SQLITE;
         }

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -32,8 +32,8 @@ class ToolWalletTest(BitcoinTestFramework):
 
     def dash_wallet_process(self, *args):
         default_args = ['-datadir={}'.format(self.nodes[0].datadir), '-chain=%s' % self.chain]
-        if self.options.descriptors and 'create' in args:
-            default_args.append('-descriptors')
+        if not self.options.descriptors and 'create' in args:
+            default_args.append('-legacy')
 
         return subprocess.Popen([self.options.bitcoinwallet] + default_args + list(args), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 


### PR DESCRIPTION
## What was done?
Descriptor wallets are created by default since Dash Core v24

References:
 - bitcoin's timeline for deprecating legacy wallets: https://github.com/bitcoin/bitcoin/issues/20160
 - prior work to remove "experimental" in Dash Core: https://github.com/dashpay/dash/pull/7038

## How Has This Been Tested?
 - RPC `createwallet "aha"` succeed, descriptor wallet
 - RPC `createwallet "fail" false false "" false false` failed, because load_on_startup must be specified
 - RPC `createwallet "fail" false false "" false true` failed, because load_on_startup must be specified
 - RPC `createwallet "legacy" false false "" false false false` succeed, created legacy wallet
 - RPC `createwallet "desc" false false "" false true false` succeed, created descriptor wallet
 - created wallet using Qt UI with and without checkbox "descriptors" checked - succeed as expected, type of wallet is matched with checkbox.

## Breaking Changes
Descriptor wallets are now the default wallet type. Newly created wallets will use descriptors unless `descriptors=false` is set during `createwallet`, or the `Descriptor wallet` checkbox is unchecked in the GUI. 

Note that wallet RPC commands like `importmulti` and `dumpprivkey` cannot be used with descriptor wallets, so if your client code relies on these commands without specifying `descriptors=false` during wallet creation, you will need to update your code.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone