### PR TITLE
chore: add more devtools to .gitignore: .claude, perf.data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,7 @@ test/lint/.cppcheck/*
 .cache/*
 
 # Editor and tooling
+.clangd/
 .claude/
 .vscode/
 compile_commands.json


### PR DESCRIPTION
## Issue being fixed or feature implemented

These files always bounces around, and they are always created by unwanted paths. Let's hide them:

    Untracked files:
    (use "git add <file>..." to include in what will be committed)
        .claude/
        perf.data
        perf.data.old


## How Has This Been Tested?
`git status` produce less noise

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
