### PR TITLE
fix: skip collecting block txids during IBD to prevent unbounded memory growth

### DIFF
--- a/src/chainlock/signing.cpp
+++ b/src/chainlock/signing.cpp
@@ -182,6 +182,10 @@ void ChainLockSigner::BlockDisconnected(const std::shared_ptr<const CBlock>& blo
 
 void ChainLockSigner::BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
 {
+    if (!m_mn_sync.IsBlockchainSynced()) {
+        return;
+    }
+
     // We need this information later when we try to sign a new tip, so that we can determine if all included TXs are safe.
     const uint256& hash = pindex->GetBlockHash();
 


### PR DESCRIPTION
## Motivation

`ChainLockSigner` is registered as a `CValidationInterface` and receives `BlockConnected` events during initial block download. It stores all non-coinbase txids for every connected block in `blockTxs`, but `Cleanup()` skips pruning while `!IsBlockchainSynced()`. This causes `blockTxs` to grow with the entire chain's transaction IDs during IBD/reindex, leading to unbounded memory growth.

Since `TrySignChainTip()` already returns early when `!IsBlockchainSynced()`, the collected txids are never used during IBD — they just accumulate until sync completes.

## Fix

Add the same `!IsBlockchainSynced()` guard to `BlockConnected()` that already exists in `TrySignChainTip()` and `Cleanup()`, skipping txid collection entirely during IBD.

## Validation

- Traced `TrySignChainTip()` — confirms it early-returns when not synced, so txids collected during IBD are never consumed
- Traced `Cleanup()` — confirms it also early-returns when not synced, so no pruning happens during IBD
- Traced `GetBlockTxs()` — has a fallback path that reads from disk when txids aren't in `blockTxs`, so post-sync tip signing still works for blocks connected during IBD
- `BlockDisconnected` only handles reorgs (erases single entry), not bulk cleanup

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
