### PR TITLE
fix: serialize TrySignChainTip to prevent concurrent signing race

### DIFF
--- a/src/chainlock/signing.cpp
+++ b/src/chainlock/signing.cpp
@@ -75,6 +75,11 @@ void ChainLockSigner::UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlock
 
 void ChainLockSigner::TrySignChainTip()
 {
+    TRY_LOCK(cs_try_sign, locked);
+    if (!locked) {
+        return;
+    }
+
     if (!m_mn_sync.IsBlockchainSynced()) {
         return;
     }

--- a/src/chainlock/signing.h
+++ b/src/chainlock/signing.h
@@ -44,6 +44,7 @@ private:
     using BlockTxs = std::unordered_map<uint256, std::shared_ptr<Uint256HashSet>, BlockHasher>;
 
 private:
+    mutable Mutex cs_try_sign;
     mutable Mutex cs_signer;
 
     std::unique_ptr<CScheduler> m_scheduler;
@@ -77,7 +78,7 @@ public:
     void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_try_sign, !cs_signer);
 
     [[nodiscard]] MessageProcessingResult HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);
@@ -85,7 +86,7 @@ public:
     void Cleanup() EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);
 
 private:
-    void TrySignChainTip() EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);
+    void TrySignChainTip() EXCLUSIVE_LOCKS_REQUIRED(!cs_try_sign, !cs_signer);
 
     [[nodiscard]] BlockTxs::mapped_type GetBlockTxs(const uint256& blockHash)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);


### PR DESCRIPTION
## Motivation

`TrySignChainTip()` can be called concurrently from two independent threads:

1. The signer's own `m_scheduler` thread (every 5 seconds, via `Start()`)
2. The `CValidationInterface` scheduler thread (via `UpdatedBlockTip()`)

The function only briefly locks `cs_signer` around the `lastSignedHeight` check, then releases it to perform chain tip reads, IS lock checks, and eventually calls `AsyncSignIfMember` — only re-acquiring `cs_signer` to update `lastSignedHeight`/`lastSignedRequestId`/`lastSignedMsgHash` right before signing.

Under competing tips (short reorg between the two reads of `m_chainstate.m_chain.Tip()`), two concurrent calls can both pass the height check with different tips and issue `AsyncSignIfMember` with different block hashes for the same height-based `requestId`. This splits signing shares across different messages and can prevent a chainlock from forming.

## Fix

Add a dedicated `cs_try_sign` mutex that serializes the entire `TrySignChainTip()` function. This ensures only one thread evaluates and signs a tip at a time.

Lock ordering: `cs_try_sign` → `cs_main` → `cs_signer` (no deadlock risk as `cs_try_sign` is only acquired at `TrySignChainTip` entry).

## Validation

- Confirmed the signer's scheduler and `CValidationInterface` scheduler are independent threads with no cross-synchronization for `TrySignChainTip`
- The handler's `tryLockChainTipScheduled` atomic only serializes within the handler scheduler, not across the signer scheduler
- Verified lock ordering: `cs_try_sign` is always acquired first, no other code path acquires it, so no deadlock possible
- Thread safety annotations updated on both `TrySignChainTip()` and `UpdatedBlockTip()` declarations

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
