### PR TITLE
ci: run check-skip on blacksmith with GitHub-hosted fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   check-skip:
     name: Check skip conditions
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
     outputs:
       skip: ${{ steps.skip-check.outputs.skip }}
     steps:


### PR DESCRIPTION
## Issue

The `check-skip` job runs on `ubuntu-latest` (GitHub-hosted only). When all GitHub runners are busy, this lightweight job stalls — blocking the entire CI pipeline since every other job depends on it.

## Fix

Use `vars.RUNNER_AMD64` with a fallback to `ubuntu-24.04`:

```yaml
runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
```

- **dashpay org:** `RUNNER_AMD64` is set to a Blacksmith runner label → uses Blacksmith
- **External forks:** Variable not set → falls back to GitHub-hosted `ubuntu-24.04`

This is the same pattern already used for build jobs in the repo.
