### PR TITLE
fix: properly skip evodb repair on reindex

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2409,6 +2409,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     chainman.m_load_block = std::thread(&util::TraceThread, "loadblk", [=, &args, &chainman, &node] {
+        // ThreadImport can switch fReindex from true to false, fetch its original state here to use later
+        bool skip_evodb_repair_on_reindex = fReindex || fReindexChainState;
         ThreadImport(chainman, vImportFiles, args);
 
         // force UpdatedBlockTip to initialize nCachedBlockHeight for DS, MN payments and budgets
@@ -2430,7 +2432,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             LogPrintf("Filling coin cache with masternode UTXOs: done in %dms\n", Ticks<std::chrono::milliseconds>(SteadyClock::now() - start));
         }
 
-        if (fReindex || fReindexChainState) {
+        if (skip_evodb_repair_on_reindex) {
             LogPrintf("Skipping evodb repair during reindex\n");
             node.dmnman->CompleteRepair();  // Mark as repaired since we're rebuilding fresh
         } else if (node.dmnman->IsRepaired() && !args.GetBoolArg("-forceevodbrepair", false)) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
`ThreadImport` can switch `fReindex` from `true` to `false`, so we can't rely on it later.

Consider backporting in https://github.com/dashpay/dash/pull/7214

## What was done?


## How Has This Been Tested?
Reindex and check logs once all blocks are processed:
develop: "RecalculateAndRepairDiffs ..."
this PR: "Skipping evodb repair during reindex"

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

