### PR TITLE
fix: return removed code for m_dsq to relay Dsq queue

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3643,6 +3643,9 @@ void PeerManagerImpl::PostProcessMessage(MessageProcessingResult&& result, NodeI
     for (const auto& inv : result.m_inventory) {
         RelayInv(inv);
     }
+    for (const auto& dsq : result.m_dsq) {
+        RelayDSQ(dsq);
+    }
 }
 
 MessageProcessingResult PeerManagerImpl::ProcessPlatformBanMessage(NodeId node, std::string_view msg_type, CDataStream& vRecv)


### PR DESCRIPTION
## Issue being fixed or feature implemented
It has been removed too early in #7070, but that still used by CCoinJoinClientQueueManager::ProcessMessage



## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone