### PR TITLE
backport: Bitcoin Core 0.28 backports (batch 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ win32-build
 test/config.ini
 test/cache/*
 test/.mypy_cache/
+test/lint/test_runner/target/
 
 !src/leveldb*/Makefile
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -320,4 +320,4 @@ clean-docs:
 clean-local: clean-docs
 	rm -rf coverage_percent.txt test_dash.coverage/ total.coverage/ fuzz.coverage/ test/tmp/ cache/ $(OSX_APP)
 	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache share/rpcauth/__pycache__
-	rm -rf dist/
+	rm -rf dist/ test/lint/test_runner/target/ test/lint/__pycache__

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -45,6 +45,7 @@ bench_bench_dash_SOURCES = \
   bench/merkle_root.cpp \
   bench/nanobench.cpp \
   bench/nanobench.h \
+  bench/parse_hex.cpp \
   bench/peer_eviction.cpp \
   bench/poly1305.cpp \
   bench/pool.cpp \

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -24,6 +24,8 @@ const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+
 namespace {
 
 void GenerateTemplateResults(const std::vector<ankerl::nanobench::Result>& benchmarkResults, const fs::path& file, const char* tpl)

--- a/src/bench/parse_hex.cpp
+++ b/src/bench/parse_hex.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2024- The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <random.h>
+#include <stddef.h>
+#include <util/strencodings.h>
+#include <cassert>
+#include <optional>
+#include <vector>
+
+std::string generateHexString(size_t length) {
+    const auto hex_digits = "0123456789ABCDEF";
+    FastRandomContext rng(/*fDeterministic=*/true);
+
+    std::string data;
+    while (data.size() < length) {
+        auto digit = hex_digits[rng.randbits(4)];
+        data.push_back(digit);
+    }
+    return data;
+}
+
+static void HexParse(benchmark::Bench& bench)
+{
+    auto data = generateHexString(130); // Generates 678B0EDA0A1FD30904D5A65E3568DB82DB2D918B0AD8DEA18A63FECCB877D07CAD1495C7157584D877420EF38B8DA473A6348B4F51811AC13C786B962BEE5668F9 by default
+
+    bench.batch(data.size()).unit("base16").run([&] {
+        auto result = TryParseHex(data);
+        assert(result != std::nullopt); // make sure we're measuring the successful case
+        ankerl::nanobench::doNotOptimizeAway(result);
+    });
+}
+
+BENCHMARK(HexParse, benchmark::PriorityLevel::HIGH);

--- a/src/logging.h
+++ b/src/logging.h
@@ -257,7 +257,7 @@ std::string SafeStringFormat(const std::string& fmt, const Args&... args)
     }
 }
 
-// Be conservative when using LogPrintf/error or other things which
+// Be conservative when using functions that
 // unconditionally log to debug.log! It should not be the case that an inbound
 // peer can fill up a user's disk with debug.log entries.
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1452,6 +1452,7 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     // download that next block if the window were 1 larger.
     int nWindowEnd = state->pindexLastCommonBlock->nHeight + BLOCK_DOWNLOAD_WINDOW;
     int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
+    bool is_limited_peer = IsLimitedPeer(peer);
     NodeId waitingfor = -1;
     while (pindexWalk->nHeight < nMaxHeight) {
         // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
@@ -1474,26 +1475,41 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
                 // We consider the chain that this peer is on invalid.
                 return;
             }
+
             if (pindex->nStatus & BLOCK_HAVE_DATA || m_chainman.ActiveChain().Contains(pindex)) {
-                if (pindex->HaveTxsDownloaded())
+                if (pindex->HaveTxsDownloaded()) {
                     state->pindexLastCommonBlock = pindex;
-            } else if (!IsBlockRequested(pindex->GetBlockHash())) {
-                // The block is not already downloaded, and not yet in flight.
-                if (pindex->nHeight > nWindowEnd) {
-                    // We reached the end of the window.
-                    if (vBlocks.size() == 0 && waitingfor != peer.m_id) {
-                        // We aren't able to fetch anything, but we would be if the download window was one larger.
-                        nodeStaller = waitingfor;
-                    }
-                    return;
                 }
-                vBlocks.push_back(pindex);
-                if (vBlocks.size() == count) {
-                    return;
+                continue;
+            }
+
+            // Is block in-flight?
+            if (IsBlockRequested(pindex->GetBlockHash())) {
+                if (waitingfor == -1) {
+                    // This is the first already-in-flight block.
+                    waitingfor = mapBlocksInFlight.lower_bound(pindex->GetBlockHash())->second.first;
                 }
-            } else if (waitingfor == -1) {
-                // This is the first already-in-flight block.
-                waitingfor = mapBlocksInFlight[pindex->GetBlockHash()].first;
+                continue;
+            }
+
+            // The block is not already downloaded, and not yet in flight.
+            if (pindex->nHeight > nWindowEnd) {
+                // We reached the end of the window.
+                if (vBlocks.size() == 0 && waitingfor != peer.m_id) {
+                    // We aren't able to fetch anything, but we would be if the download window was one larger.
+                    nodeStaller = waitingfor;
+                }
+                return;
+            }
+
+            // Don't request blocks that go further than what limited peers can provide
+            if (is_limited_peer && (state->pindexBestKnownBlock->nHeight - pindex->nHeight >= static_cast<int>(NODE_NETWORK_LIMITED_MIN_BLOCKS) - 2 /* two blocks buffer for possible races */)) {
+                continue;
+            }
+
+            vBlocks.push_back(pindex);
+            if (vBlocks.size() == count) {
+                return;
             }
         }
     }

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -19,6 +19,8 @@ extern const std::function<std::string(const char*)> G_TRANSLATION_FUN = [](cons
 };
 UrlDecodeFn* const URL_DECODE = urlDecode;
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+
 MAIN_FUNCTION
 {
     return GuiMain(argc, argv);

--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -46,6 +46,17 @@ void OptionTests::migrateSettings()
 
     settings.sync();
 
+    QVERIFY(settings.contains("nDatabaseCache"));
+    QVERIFY(settings.contains("nThreadsScriptVerif"));
+    QVERIFY(settings.contains("fUseUPnP"));
+    QVERIFY(settings.contains("fListen"));
+    QVERIFY(settings.contains("bPrune"));
+    QVERIFY(settings.contains("nPruneSize"));
+    QVERIFY(settings.contains("fUseProxy"));
+    QVERIFY(settings.contains("addrProxy"));
+    QVERIFY(settings.contains("fUseSeparateProxyTor"));
+    QVERIFY(settings.contains("addrSeparateProxyTor"));
+
     OptionsModel options{m_node};
     bilingual_str error;
     QVERIFY(options.Init(error));

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -51,6 +51,8 @@ const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS{};
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+
 // This is all you need to run all the tests
 int main(int argc, char* argv[])
 {

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -10,6 +10,7 @@
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <qt/bitcoin.h>
+#include <qt/guiconstants.h>
 #include <qt/test/apptests.h>
 #include <qt/test/optiontests.h>
 #include <qt/test/rpcnestedtests.h>
@@ -25,6 +26,7 @@
 #include <QApplication>
 #include <QDebug>
 #include <QObject>
+#include <QSettings>
 #include <QTest>
 
 #include <functional>
@@ -81,38 +83,47 @@ int main(int argc, char* argv[])
         setenv("QT_QPA_PLATFORM", "minimal", 0 /* overwrite */);
     #endif
 
-    BitcoinApplication app;
-    app.setApplicationName("Dash-Qt-test");
-    app.createNode(*init);
+
+    QCoreApplication::setOrganizationName(QAPP_ORG_NAME);
+    QCoreApplication::setApplicationName(QAPP_APP_NAME_DEFAULT "-test");
 
     int num_test_failures{0};
 
-    AppTests app_tests(app);
-    num_test_failures += QTest::qExec(&app_tests);
+    {
+        BitcoinApplication app;
+        app.createNode(*init);
 
-    OptionTests options_tests(app.node());
-    num_test_failures += QTest::qExec(&options_tests);
+        AppTests app_tests(app);
+        num_test_failures += QTest::qExec(&app_tests);
 
-    URITests test1;
-    num_test_failures += QTest::qExec(&test1);
+        OptionTests options_tests(app.node());
+        num_test_failures += QTest::qExec(&options_tests);
 
-    RPCNestedTests test3(app.node());
-    num_test_failures += QTest::qExec(&test3);
+        URITests test1;
+        num_test_failures += QTest::qExec(&test1);
+
+        RPCNestedTests test3(app.node());
+        num_test_failures += QTest::qExec(&test3);
 
 #ifdef ENABLE_WALLET
-    WalletTests test5(app.node());
-    num_test_failures += QTest::qExec(&test5);
+        WalletTests test5(app.node());
+        num_test_failures += QTest::qExec(&test5);
 
-    AddressBookTests test6(app.node());
-    num_test_failures += QTest::qExec(&test6);
+        AddressBookTests test6(app.node());
+        num_test_failures += QTest::qExec(&test6);
 #endif
     TrafficGraphDataTests test7;
     num_test_failures += QTest::qExec(&test7);
 
-    if (num_test_failures) {
-        qWarning("\nFailed tests: %d\n", num_test_failures);
-    } else {
-        qDebug("\nAll tests passed.\n");
+        if (num_test_failures) {
+            qWarning("\nFailed tests: %d\n", num_test_failures);
+        } else {
+            qDebug("\nAll tests passed.\n");
+        }
     }
+
+    QSettings settings;
+    settings.clear();
+
     return num_test_failures;
 }

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -42,17 +42,18 @@ test_dash --log_level=all --run_test=getarg_tests
 ```
 
 `log_level` controls the verbosity of the test framework, which logs when a
-test case is entered, for example. `test_dash` also accepts the command
-line arguments accepted by `dashd`. Use `--` to separate both types of
-arguments:
+test case is entered, for example.
+
+`test_dash` also accepts some of the command line arguments accepted by
+`dashd`. Use `--` to separate these sets of arguments:
 
 ```bash
 test_dash --log_level=all --run_test=getarg_tests -- -printtoconsole=1
 ```
 
-The `-printtoconsole=1` after the two dashes redirects the debug log, which
-would normally go to a file in the test datadir
-(`BasicTestingSetup::m_path_root`), to the standard terminal output.
+The `-printtoconsole=1` after the two dashes sends debug logging, which
+normally goes only to `debug.log` within the data directory, also to the
+standard terminal output.
 
 ... or to run just the doubledash test:
 
@@ -60,7 +61,42 @@ would normally go to a file in the test datadir
 test_dash --run_test=getarg_tests/doubledash
 ```
 
-Run `test_dash --help` for the full list.
+`test_dash` creates a temporary working (data) directory with a randomly
+generated pathname within `test_common_Dash Core/`, which in turn is within
+the system's temporary directory (see
+[`temp_directory_path`](https://en.cppreference.com/w/cpp/filesystem/temp_directory_path)).
+This data directory looks like a simplified form of the standard `dashd` data
+directory. Its content will vary depending on the test, but it will always
+have a `debug.log` file, for example.
+
+The location of the temporary data directory can be specified with the
+`-testdatadir` option. This can make debugging easier. The directory
+path used is the argument path appended with
+`/test_common_Dash Core/<test-name>/datadir`.
+The directory path is created if necessary.
+Specifying this argument also causes the data directory
+not to be removed after the last test. This is useful for looking at
+what the test wrote to `debug.log` after it completes, for example.
+(The directory is removed at the start of the next test run,
+so no leftover state is used.)
+
+```bash
+$ test_dash --run_test=getarg_tests/doubledash -- -testdatadir=/somewhere/mydatadir
+Test directory (will not be deleted): "/somewhere/mydatadir/test_common_Dash Core/getarg_tests/doubledash/datadir
+Running 1 test case...
+
+*** No errors detected
+$ ls -l '/somewhere/mydatadir/test_common_Dash Core/getarg_tests/doubledash/datadir'
+total 8
+drwxrwxr-x 2 admin admin 4096 Nov 27 22:45 blocks
+-rw-rw-r-- 1 admin admin 1003 Nov 27 22:45 debug.log
+```
+
+If you run an entire test suite, such as `--run_test=getarg_tests`, or all the test suites
+(by not specifying `--run_test`), a separate directory
+will be created for each individual test.
+
+Run `test_dash --help` for the full list of tests.
 
 ### Adding test cases
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -3,7 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compressor.h>
+#include <script/script.h>
 #include <script/standard.h>
+#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <stdint.h>
@@ -132,6 +134,38 @@ BOOST_AUTO_TEST_CASE(compress_script_to_uncompressed_pubkey_id)
     BOOST_CHECK_EQUAL(out.size(), 33U);
     BOOST_CHECK_EQUAL(memcmp(out.data() + 1, script.data() + 2, 32), 0); // first 32 chars of CPubKey are copied into out[1:]
     BOOST_CHECK_EQUAL(out[0], 0x04 | (script[65] & 0x01)); // least significant bit (lsb) of last char of pubkey is mapped into out[0]
+}
+
+BOOST_AUTO_TEST_CASE(compress_p2pk_scripts_not_on_curve)
+{
+    XOnlyPubKey x_not_on_curve;
+    do {
+        x_not_on_curve = XOnlyPubKey(g_insecure_rand_ctx.randbytes(32));
+    } while (x_not_on_curve.IsFullyValid());
+
+    // Check that P2PK script with uncompressed pubkey [=> OP_PUSH65 <0x04 .....> OP_CHECKSIG]
+    // which is not fully valid (i.e. point is not on curve) can't be compressed
+    std::vector<unsigned char> pubkey_raw(65, 0);
+    pubkey_raw[0] = 4;
+    std::copy(x_not_on_curve.begin(), x_not_on_curve.end(), &pubkey_raw[1]);
+    CPubKey pubkey_not_on_curve(pubkey_raw);
+    assert(pubkey_not_on_curve.IsValid());
+    assert(!pubkey_not_on_curve.IsFullyValid());
+    CScript script = CScript() << ToByteVector(pubkey_not_on_curve) << OP_CHECKSIG;
+    BOOST_CHECK_EQUAL(script.size(), 67U);
+
+    CompressedScript out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, false);
+
+    // Check that compressed P2PK script with uncompressed pubkey that is not fully
+    // valid (i.e. x coordinate of the pubkey is not on curve) can't be decompressed
+    CompressedScript compressed_script(x_not_on_curve.begin(), x_not_on_curve.end());
+    for (unsigned int compression_id : {4, 5}) {
+        CScript uncompressed_script;
+        bool success = DecompressScript(uncompressed_script, compression_id, compressed_script);
+        BOOST_CHECK_EQUAL(success, false);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -5,7 +5,6 @@
 #include <compressor.h>
 #include <script/script.h>
 #include <script/standard.h>
-#include <test/util/random.h>
 #include <test/util/setup_common.h>
 
 #include <stdint.h>
@@ -138,10 +137,19 @@ BOOST_AUTO_TEST_CASE(compress_script_to_uncompressed_pubkey_id)
 
 BOOST_AUTO_TEST_CASE(compress_p2pk_scripts_not_on_curve)
 {
-    XOnlyPubKey x_not_on_curve;
+    // Generate random 32 bytes for x-coordinate that is not on the secp256k1 curve.
+    // Dash does not have XOnlyPubKey (taproot), so we check validity by constructing
+    // a compressed pubkey (0x02 || x) — if IsFullyValid() is false, x has no valid
+    // lift on the curve. ~50% of random x values are invalid, so this terminates fast.
+    std::vector<unsigned char> x_not_on_curve;
     do {
-        x_not_on_curve = XOnlyPubKey(g_insecure_rand_ctx.randbytes(32));
-    } while (x_not_on_curve.IsFullyValid());
+        x_not_on_curve = g_insecure_rand_ctx.randbytes(32);
+        std::vector<unsigned char> compressed_key(33);
+        compressed_key[0] = 0x02;
+        std::copy(x_not_on_curve.begin(), x_not_on_curve.end(), &compressed_key[1]);
+        CPubKey test_key(compressed_key);
+        if (!test_key.IsFullyValid()) break;
+    } while (true);
 
     // Check that P2PK script with uncompressed pubkey [=> OP_PUSH65 <0x04 .....> OP_CHECKSIG]
     // which is not fully valid (i.e. point is not on curve) can't be compressed

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -33,6 +33,8 @@ __AFL_FUZZ_INIT();
 
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
+const std::function<std::string()> G_TEST_GET_FULL_NAME{};
+
 /**
  * A copy of the command line arguments that start with `--`.
  * First `LLVMFuzzerInitialize()` is called, which saves the arguments to `g_args`.

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -39,3 +39,10 @@ const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS = 
     }
     return args;
 };
+
+/**
+ * Retrieve the boost unit test name.
+ */
+const std::function<std::string()> G_TEST_GET_FULL_NAME = []() {
+    return boost::unit_test::framework::current_test_case().full_name();
+};

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -40,7 +40,7 @@
 #include <test/util/net.h>
 #include <test/util/txmempool.h>
 #include <txdb.h>
-#include <util/fs_helpers.h>
+#include <util/system.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/thread.h>
@@ -221,7 +221,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
 
         // Try to obtain the lock; if unsuccessful don't disturb the existing test.
         TryCreateDirectories(m_path_lock);
-        if (util::LockDirectory(m_path_lock, ".lock", /*probe_only=*/false) != util::LockResult::Success) {
+        if (!LockDirectory(m_path_lock, ".lock", /*probe_only=*/false)) {
             ExitFailure("Cannot obtain a lock on test data lock directory " + fs::PathToString(m_path_lock) + '\n' + "The test executable is probably already running.");
         }
 

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -40,6 +40,7 @@
 #include <test/util/net.h>
 #include <test/util/txmempool.h>
 #include <txdb.h>
+#include <util/fs_helpers.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/thread.h>
@@ -156,9 +157,22 @@ void DashChainstateSetupClose(NodeContext& node)
                              Assert(node.mempool.get()));
 }
 
+/** Register test-only arguments */
+static void SetupUnitTestArgs(ArgsManager& argsman)
+{
+    argsman.AddArg("-testdatadir", strprintf("Custom data directory (default: %s<random_string>)", fs::PathToString(fs::temp_directory_path() / "test_common_" PACKAGE_NAME / "")),
+                   ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
+}
+
+/** Test setup failure */
+static void ExitFailure(std::string_view str_err)
+{
+    std::cerr << str_err << std::endl;
+    exit(EXIT_FAILURE);
+}
+
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::vector<const char*>& extra_args)
-    : m_path_root{fs::temp_directory_path() / "test_common_" PACKAGE_NAME / g_insecure_rand_ctx_temp_path.rand256().ToString()},
-      m_args{}
+    : m_args{}
 {
     m_node.args = &gArgs;
     std::vector<const char*> arguments = Cat(
@@ -178,18 +192,49 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
         arguments = Cat(arguments, G_TEST_COMMAND_LINE_ARGUMENTS());
     }
     util::ThreadRename("test");
-    fs::create_directories(m_path_root);
-    m_args.ForceSetArg("-datadir", fs::PathToString(m_path_root));
-    gArgs.ForceSetArg("-datadir", fs::PathToString(m_path_root));
     gArgs.ClearPathCache();
     {
         SetupServerArgs(*m_node.args);
+        SetupUnitTestArgs(*m_node.args);
         std::string error;
         if (!m_node.args->ParseParameters(arguments.size(), arguments.data(), error)) {
             m_node.args->ClearArgs();
             throw std::runtime_error{error};
         }
     }
+
+    if (!m_node.args->IsArgSet("-testdatadir")) {
+        // By default, the data directory has a random name
+        const auto rand_str{g_insecure_rand_ctx_temp_path.rand256().ToString()};
+        m_path_root = fs::temp_directory_path() / "test_common_" PACKAGE_NAME / rand_str;
+        TryCreateDirectories(m_path_root);
+    } else {
+        // Custom data directory
+        m_has_custom_datadir = true;
+        fs::path root_dir{m_node.args->GetPathArg("-testdatadir")};
+        if (root_dir.empty()) ExitFailure("-testdatadir argument is empty, please specify a path");
+
+        root_dir = fs::absolute(root_dir);
+        const std::string test_path{G_TEST_GET_FULL_NAME ? G_TEST_GET_FULL_NAME() : ""};
+        m_path_lock = root_dir / "test_common_" PACKAGE_NAME / fs::PathFromString(test_path);
+        m_path_root = m_path_lock / "datadir";
+
+        // Try to obtain the lock; if unsuccessful don't disturb the existing test.
+        TryCreateDirectories(m_path_lock);
+        if (util::LockDirectory(m_path_lock, ".lock", /*probe_only=*/false) != util::LockResult::Success) {
+            ExitFailure("Cannot obtain a lock on test data lock directory " + fs::PathToString(m_path_lock) + '\n' + "The test executable is probably already running.");
+        }
+
+        // Always start with a fresh data directory; this doesn't delete the .lock file located one level above.
+        fs::remove_all(m_path_root);
+        if (!TryCreateDirectories(m_path_root)) ExitFailure("Cannot create test data directory");
+
+        // Print the test directory name if custom.
+        std::cout << "Test directory (will not be deleted): " << m_path_root << std::endl;
+    }
+    m_args.ForceSetArg("-datadir", fs::PathToString(m_path_root));
+    gArgs.ForceSetArg("-datadir", fs::PathToString(m_path_root));
+
     SelectParams(chainName);
     SeedInsecureRand();
     if (G_TEST_LOG_FUN) LogInstance().PushBackCallback(G_TEST_LOG_FUN);
@@ -250,7 +295,13 @@ BasicTestingSetup::~BasicTestingSetup()
 {
     SetMockTime(0s); // Reset mocktime for following tests
     LogInstance().DisconnectTestLogger();
-    fs::remove_all(m_path_root);
+    if (m_has_custom_datadir) {
+        // Only remove the lock file, preserve the data directory.
+        UnlockDirectory(m_path_lock, ".lock");
+        fs::remove(m_path_lock / ".lock");
+    } else {
+        fs::remove_all(m_path_root);
+    }
     gArgs.ClearArgs();
 
     m_node.evodb.reset();

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -38,6 +38,9 @@ extern const std::function<void(const std::string&)> G_TEST_LOG_FUN;
 /** Retrieve the command line arguments. */
 extern const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS;
 
+/** Retrieve the unit test name. */
+extern const std::function<std::string()> G_TEST_GET_FULL_NAME;
+
 // Enable BOOST_CHECK_EQUAL for enum class types
 namespace std {
 template <typename T>
@@ -107,7 +110,9 @@ struct BasicTestingSetup {
     explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN, const std::vector<const char*>& extra_args = {});
     ~BasicTestingSetup();
 
-    const fs::path m_path_root;
+    fs::path m_path_root;
+    fs::path m_path_lock;
+    bool m_has_custom_datadir{false};
     ArgsManager m_args;
 };
 

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -81,6 +81,8 @@ template <typename Byte>
 std::optional<std::vector<Byte>> TryParseHex(std::string_view str)
 {
     std::vector<Byte> vch;
+    vch.reserve(str.size() / 2); // two hex characters form a single byte
+
     auto it = str.begin();
     while (it != str.end()) {
         if (IsSpace(*it)) {

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -20,7 +20,14 @@ from test_framework.messages import (
 from test_framework.governance import EXPECTED_STDERR_NO_GOV_PRUNE
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    try_rpc
+)
+
+# Minimum blocks required to signal NODE_NETWORK_LIMITED #
+NODE_NETWORK_LIMITED_MIN_BLOCKS = 288
 
 class P2PIgnoreInv(P2PInterface):
     firstAddrnServices = 0
@@ -51,6 +58,63 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
     def setup_network(self):
         self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
+
+    def test_avoid_requesting_historical_blocks(self):
+        self.log.info("Test full node does not request blocks beyond the limited peer threshold")
+        pruned_node = self.nodes[0]
+        miner = self.nodes[1]
+        full_node = self.nodes[2]
+
+        # Connect and generate block to ensure IBD=false
+        self.connect_nodes(1, 0)
+        self.connect_nodes(1, 2)
+        self.generate(miner, 1)
+
+        # Verify peers are out of IBD
+        for node in self.nodes:
+            assert not node.getblockchaininfo()['initialblockdownload']
+
+        # Isolate full_node (the node will remain out of IBD)
+        full_node.setnetworkactive(False)
+        self.wait_until(lambda: len(full_node.getpeerinfo()) == 0)
+
+        # Mine blocks and sync the pruned node. Surpass the NETWORK_NODE_LIMITED threshold.
+        # Blocks deeper than the threshold are considered "historical blocks"
+        num_historial_blocks = 12
+        self.generate(miner, NODE_NETWORK_LIMITED_MIN_BLOCKS + num_historial_blocks, sync_fun=self.no_op)
+        self.sync_blocks([miner, pruned_node])
+
+        # Connect full_node to prune_node and check peers don't disconnect right away.
+        # (they will disconnect if full_node, which is chain-wise behind, request blocks
+        # older than NODE_NETWORK_LIMITED_MIN_BLOCKS)
+        start_height_full_node = full_node.getblockcount()
+        full_node.setnetworkactive(True)
+        self.connect_nodes(2, 0)
+        assert_equal(len(full_node.getpeerinfo()), 1)
+
+        # Wait until the full_node is headers-wise sync
+        best_block_hash = pruned_node.getbestblockhash()
+        self.wait_until(lambda: next(filter(lambda x: x['hash'] == best_block_hash, full_node.getchaintips()))['status'] == "headers-only")
+
+        # Now, since the node aims to download a window of 1024 blocks,
+        # ensure it requests the blocks below the threshold only (with a
+        # 2-block buffer). And also, ensure it does not request any
+        # historical block.
+        tip_height = pruned_node.getblockcount()
+        limit_buffer = 2
+        # Prevent races by waiting for the tip to arrive first
+        self.wait_until(lambda: not try_rpc(-1, "Block not found", full_node.getblock, pruned_node.getbestblockhash()))
+        for height in range(start_height_full_node + 1, tip_height + 1):
+            if height <= tip_height - (NODE_NETWORK_LIMITED_MIN_BLOCKS - limit_buffer):
+                assert_raises_rpc_error(-1, "Block not found on disk", full_node.getblock, pruned_node.getblockhash(height))
+            else:
+                full_node.getblock(pruned_node.getblockhash(height))  # just assert it does not throw an exception
+
+        # Lastly, ensure the full_node is not sync and verify it can get synced by
+        # establishing a connection with another full node capable of providing them.
+        assert_equal(full_node.getblockcount(), start_height_full_node)
+        self.connect_nodes(2, 1)
+        self.sync_blocks([miner, full_node])
 
     def run_test(self):
         node = self.nodes[0].add_p2p_connection(P2PIgnoreInv())
@@ -107,6 +171,8 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.sync_blocks([self.nodes[0], self.nodes[1]])
         self.stop_node(0, expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
 
+
+        self.test_avoid_requesting_historical_blocks()
 
 if __name__ == '__main__':
     NodeNetworkLimitedTest().main()

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -171,6 +171,9 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.sync_blocks([self.nodes[0], self.nodes[1]])
         self.stop_node(0, expected_stderr=EXPECTED_STDERR_NO_GOV_PRUNE)
 
+        # Restart node 0 for the next sub-test (it was stopped above to
+        # verify the Dash-specific governance-prune stderr).
+        self.start_node(0, extra_args=['-prune=550'])
 
         self.test_avoid_requesting_historical_blocks()
 

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -17,6 +17,42 @@ docker run --rm -v $(pwd):/bitcoin -it bitcoin-linter
 After building the container once, you can simply run the last command any time you
 want to lint.
 
+test runner
+===========
+
+To run all the lint checks in the test runner outside the docker you first need
+to install the rust toolchain using your package manager of choice or
+[rustup](https://www.rust-lang.org/tools/install).
+
+Then you can use:
+
+```sh
+( cd ./test/lint/test_runner/ && cargo fmt && cargo clippy && RUST_BACKTRACE=1 cargo run )
+```
+
+#### Dependencies
+
+| Lint test | Dependency |
+|-----------|:----------:|
+| [`lint-python.py`](lint/lint-python.py) | [flake8](https://gitlab.com/pycqa/flake8)
+| [`lint-python.py`](lint/lint-python.py) | [lief](https://github.com/lief-project/LIEF)
+| [`lint-python.py`](lint/lint-python.py) | [mypy](https://github.com/python/mypy)
+| [`lint-python.py`](lint/lint-python.py) | [pyzmq](https://github.com/zeromq/pyzmq)
+| [`lint-python-dead-code.py`](lint/lint-python-dead-code.py) | [vulture](https://github.com/jendrikseipp/vulture)
+| [`lint-shell.py`](lint/lint-shell.py) | [ShellCheck](https://github.com/koalaman/shellcheck)
+| [`lint-spelling.py`](lint/lint-spelling.py) | [codespell](https://github.com/codespell-project/codespell)
+
+In use versions and install instructions are available in the [CI setup](../../ci/lint/04_install.sh).
+
+Please be aware that on Linux distributions all dependencies are usually available as packages, but could be outdated.
+
+#### Running the tests
+
+Individual tests can be run by directly calling the test script, e.g.:
+
+```
+test/lint/lint-files.py
+```
 
 check-doc.py
 ============


### PR DESCRIPTION
## Bitcoin Core Backports (0.28 batch 1)

Backports 7 Bitcoin Core commits to Dash Core:

| Bitcoin PR | Title |
|-----------|-------|
| bitcoin/bitcoin#29633 | log: Remove error() reference |
| bitcoin/bitcoin#29537 | lint: Misc improvements for lint runner |
| bitcoin-core/gui#803 | test: Set organization name |
| bitcoin/bitcoin#26564 | test: test_bitcoin: allow -testdatadir=\<datadir\> |
| bitcoin/bitcoin#28120 | p2p: make block download logic aware of limited peers threshold |
| bitcoin/bitcoin#29458 | refactor: Preallocate result in TryParseHex to avoid resizing |
| bitcoin/bitcoin#28193 | test: add script compression coverage for not-on-curve P2PK outputs |

### Skipped commits (19)
Commits skipped due to: dependency issues (missing infrastructure from not-yet-backported PRs), Bitcoin-specific features (signet, descriptor wallet migration, v3 transactions), CI-only changes specific to Bitcoin's infrastructure, or excessive conflicts requiring manual intervention.

### Process
Automated backporting system. Each commit cherry-picked from `bitcoin` remote with `-m1`, conflicts resolved faithfully preserving Dash-specific features.