### PR TITLE
refactor: remove dead m_dsq client-side relay from MessageProcessingResult

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -142,7 +142,6 @@ MessageProcessingResult CCoinJoinClientQueueManager::ProcessMessage(NodeId from,
             WITH_LOCK(cs_vecqueue, vecCoinJoinQueue.push_back(dsq));
         }
     } // cs_ProcessDSQueue
-    ret.m_dsq.push_back(dsq);
     return ret;
 }
 

--- a/src/instantsend/net_instantsend.h
+++ b/src/instantsend/net_instantsend.h
@@ -15,6 +15,8 @@
 #include <thread>
 #include <vector>
 
+class CChainState;
+
 namespace Consensus {
 struct LLMQParams;
 } // namespace Consensus

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -7,6 +7,7 @@
 
 #include <instantsend/lock.h>
 #include <llmq/signing.h>
+#include <primitives/transaction.h>
 
 #include <optional>
 

--- a/src/msg_result.h
+++ b/src/msg_result.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_MSG_RESULT_H
 #define BITCOIN_MSG_RESULT_H
 
-#include <coinjoin/coinjoin.h>
-
 #include <protocol.h>
 #include <uint256.h>
 
@@ -50,9 +48,6 @@ struct MessageProcessingResult
     //! @m_inventory will relay these inventories to connected peers
     std::vector<CInv> m_inventory;
 
-    //! @m_dsq will relay DSQs to connected peers
-    std::vector<CCoinJoinQueue> m_dsq;
-
     //! @m_transactions will relay transactions to peers which is ready to accept it (some peers does not accept transactions)
     std::vector<uint256> m_transactions;
 
@@ -68,7 +63,7 @@ struct MessageProcessingResult
         m_error(error)
     {}
 
-    bool empty() const { return !m_error.has_value() && m_inventory.empty() && m_dsq.empty() && m_transactions.empty() && !m_to_erase.has_value(); }
+    bool empty() const { return !m_error.has_value() && m_inventory.empty() && m_transactions.empty() && !m_to_erase.has_value(); }
 };
 
 #endif // BITCOIN_MSG_RESULT_H

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -24,6 +24,7 @@
 #include <util/helpers.h>
 
 #include <chainparams.h>
+#include <core_io.h>
 #include <deploymentstatus.h>
 #include <index/txindex.h>
 #include <net_processing.h>

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -23,9 +23,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     # Dash
     "active/context -> active/dkgsessionhandler -> llmq/dkgsessionhandler -> net_processing -> active/context",
     "banman -> common/bloom -> evo/assetlocktx -> llmq/quorumsman -> net -> banman",
-    "chainlock/chainlock -> spork -> msg_result -> coinjoin/coinjoin -> chainlock/chainlock",
     "chainlock/chainlock -> spork -> net -> evo/deterministicmns -> evo/providertx -> validation -> chainlock/chainlock",
-    "coinjoin/coinjoin -> instantsend/instantsend -> spork -> msg_result -> coinjoin/coinjoin",
     "coinjoin/client -> coinjoin/util -> wallet/wallet -> psbt -> node/transaction -> net_processing -> coinjoin/walletman -> coinjoin/client",
     "common/bloom -> evo/assetlocktx -> llmq/commitment -> evo/deterministicmns -> evo/simplifiedmns -> merkleblock -> common/bloom",
     "common/bloom -> evo/assetlocktx -> llmq/quorumsman -> net -> common/bloom",


### PR DESCRIPTION
## Issue being fixed or feature implemented
Client-side DSQ relay was removed in #7070 but the `m_dsq` field and its population in `CCoinJoinClientQueueManager::ProcessMessage` were left behind as dead code. The network has been running without client-side DSQ relay with no issues since masternodes handle DSQ propagation through their own `CCoinJoinServer::ProcessDSQUEUE` path.

Alternative to #7227 

## What was done?
Remove the dead code and fix transitive include dependencies that were masked by msg_result.h pulling in coinjoin/coinjoin.h. This also resolves two circular dependency chains that went through that link.

## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

