### PR TITLE
ci: Revert 26912 backport

### DIFF
--- a/ci/dash/test_integrationtests.sh
+++ b/ci/dash/test_integrationtests.sh
@@ -44,7 +44,7 @@ EXTRA_ARGS="--dashd-arg=-socketevents=$SOCKETEVENTS"
 
 set +e
 # shellcheck disable=SC2086
-LD_LIBRARY_PATH="$DEPENDS_DIR/$HOST/lib" ./test/functional/test_runner.py --ci --attempts=3 --ansi --combinedlogslen=99999999 --timeout-factor="${TEST_RUNNER_TIMEOUT_FACTOR}" ${TEST_RUNNER_EXTRA} --failfast --nocleanup --tmpdir="$(pwd)/testdatadirs" $PASS_ARGS $EXTRA_ARGS
+LD_LIBRARY_PATH="$DEPENDS_DIR/$HOST/lib" ./test/functional/test_runner.py --ci --attempts=3 --ansi --combinedlogslen=4000 --timeout-factor="${TEST_RUNNER_TIMEOUT_FACTOR}" ${TEST_RUNNER_EXTRA} --failfast --nocleanup --tmpdir="$(pwd)/testdatadirs" $PASS_ARGS $EXTRA_ARGS
 RESULT=$?
 set -e
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Logs in CI are kind of broken now - takes quite some time to load it, shows ~40k top (useless) lines and `This step has been truncated due to its large size. View the raw logs from the  menu once the workflow run has completed.`, see https://github.com/dashpay/dash/actions/runs/23136104759/job/67204945809?pr=7229


## What was done?
Revert 26912 backport introduced via #7090

## How Has This Been Tested?


## Breaking Changes


## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

