### PR TITLE
test: fix flaky LLMQ signing recovery timeout

### DIFF
--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -196,9 +196,11 @@ class LLMQSigningTest(DashTestFramework):
             self.wait_until(lambda: mn.get_node(self).getconnectioncount() == self.llmq_size, timeout=10)
             mn.get_node(self).ping()
             self.wait_until(lambda: all('pingwait' not in peer for peer in mn.get_node(self).getpeerinfo()))
-            # Let 2 seconds pass so that the next node is used for recovery, which should succeed
-            self.bump_mocktime(2)
-            wait_for_sigs(True, False, True, 2)
+            # Advance mocktime past the daemon's 5-second signing session
+            # cleanup cadence so recovery responsibility rotates to the next
+            # member. Use 10s to guarantee at least one full cycle completes.
+            self.bump_mocktime(10)
+            wait_for_sigs(True, False, True, 15)
 
 if __name__ == '__main__':
     LLMQSigningTest().main()


### PR DESCRIPTION
## Summary

Fix a flaky timeout in `feature_llmq_signing.py` (lines 200-201).

The `--spork21` reconnect test bumped mocktime by 2 seconds and waited 2 seconds for signature recovery. This was insufficient: the daemon's signing session cleanup cadence is 5 seconds (`CLEANUP_INTERVAL` in `signing_shares.cpp:1194`), so the test's wait window was shorter than one cleanup cycle, meaning recovery responsibility never actually rotated.

**Change:** `bump_mocktime(2)` → `bump_mocktime(10)`, `wait_for_sigs(..., 2)` → `wait_for_sigs(..., 15)`.

The `wait_for_sigs` timeout is a ceiling, not a polling interval — it just allows more time for propagation.

---

The PoSe ban assertion fix (previously bundled here) has been split into #7254 for independent review.