### PR TITLE
backport: bitcoin/bitcoin#24304: [kernel 0/n] Introduce `dash-chainstate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src/dash-gui
 src/dash-node
 src/dash-tx
 src/dash-util
+src/dash-chainstate
 src/dash-wallet
 src/test/fuzz/fuzz
 src/test/test_dash

--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -27,7 +27,7 @@ elif [ "$BUILD_TARGET" = "linux64_fuzz" ]; then
 elif [ "$BUILD_TARGET" = "linux64_multiprocess" ]; then
   source ./ci/test/00_setup_env_native_multiprocess.sh
 elif [ "$BUILD_TARGET" = "linux64_nowallet" ]; then
-  source ./ci/test/00_setup_env_native_nowallet.sh
+  source ./ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
 elif [ "$BUILD_TARGET" = "linux64_sqlite" ]; then
   source ./ci/test/00_setup_env_native_sqlite.sh
 elif [ "$BUILD_TARGET" = "linux64_tsan" ]; then

--- a/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
+++ b/ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh
@@ -6,9 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-export CONTAINER_NAME=ci_native_nowallet
+export CONTAINER_NAME=ci_native_nowallet_libbitcoinkernel
 export HOST=x86_64-pc-linux-gnu
 export PACKAGES="python3-zmq"
 export DEP_OPTS="NO_WALLET=1 CC=gcc-14 CXX=g++-14"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-reduce-exports CC=gcc-14 CXX=g++-14"
+export BITCOIN_CONFIG="--enable-reduce-exports CC=gcc-14 CXX=g++-14 --enable-experimental-util-chainstate"

--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,7 @@ BITCOIN_TEST_NAME=test_dash
 BITCOIN_CLI_NAME=dash-cli
 BITCOIN_TX_NAME=dash-tx
 BITCOIN_UTIL_NAME=dash-util
+BITCOIN_CHAINSTATE_NAME=dash-chainstate
 BITCOIN_WALLET_TOOL_NAME=dash-wallet
 dnl Multi Process
 BITCOIN_MP_NODE_NAME=dash-node
@@ -769,6 +770,13 @@ AC_ARG_ENABLE([util-util],
   [build_bitcoin_util=$enableval],
   [build_bitcoin_util=$build_bitcoin_utils])
 
+AC_ARG_ENABLE([experimental-util-chainstate],
+  [AS_HELP_STRING([--enable-experimental-util-chainstate],
+  [build experimental dash-chainstate executable (default=no)])],
+  [build_bitcoin_chainstate=$enableval],
+  [build_bitcoin_chainstate=no])
+
+
 AC_ARG_WITH([libs],
   [AS_HELP_STRING([--with-libs],
   [build libraries (default=yes)])],
@@ -1443,6 +1451,7 @@ if test "$enable_fuzz" = "yes"; then
   build_bitcoin_cli=no
   build_bitcoin_tx=no
   build_bitcoin_util=no
+  build_bitcoin_chainstate=no
   build_bitcoin_wallet=no
   build_bitcoind=no
   build_bitcoin_libs=no
@@ -1781,6 +1790,10 @@ AC_MSG_CHECKING([whether to build dash-util])
 AM_CONDITIONAL([BUILD_BITCOIN_UTIL], [test $build_bitcoin_util = "yes"])
 AC_MSG_RESULT($build_bitcoin_util)
 
+AC_MSG_CHECKING([whether to build experimental dash-chainstate])
+AM_CONDITIONAL([BUILD_BITCOIN_CHAINSTATE], [test $build_bitcoin_chainstate = "yes"])
+AC_MSG_RESULT($build_bitcoin_chainstate)
+
 AC_MSG_CHECKING([whether to build libraries])
 AM_CONDITIONAL([BUILD_BITCOIN_LIBS], [test $build_bitcoin_libs = "yes"])
 if test "$build_bitcoin_libs" = "yes"; then
@@ -1995,6 +2008,7 @@ AC_SUBST(BITCOIN_TEST_NAME)
 AC_SUBST(BITCOIN_CLI_NAME)
 AC_SUBST(BITCOIN_TX_NAME)
 AC_SUBST(BITCOIN_UTIL_NAME)
+AC_SUBST(BITCOIN_CHAINSTATE_NAME)
 AC_SUBST(BITCOIN_WALLET_TOOL_NAME)
 AC_SUBST(BITCOIN_MP_NODE_NAME)
 AC_SUBST(BITCOIN_MP_GUI_NAME)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1312,7 +1312,8 @@ dash_chainstate_LDADD = \
   $(LIBSECP256K1) \
   $(LIBDASHBLS) \
   $(LIBLEVELDB) \
-  $(LIBMEMENV)
+  $(LIBMEMENV) \
+  $(GMP_LIBS)
 
 # Required for obj/build.h to be generated first.
 # More details: https://www.gnu.org/software/automake/manual/html_node/Built-Sources-Example.html

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1303,7 +1303,7 @@ dash_chainstate_SOURCES = \
   validationinterface.cpp \
   versionbits.cpp \
   warnings.cpp
-dash_chainstate_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+dash_chainstate_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BOOST_CPPFLAGS)
 dash_chainstate_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 dash_chainstate_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS)
 dash_chainstate_LDADD = \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -148,6 +148,10 @@ if BUILD_BITCOIN_UTIL
   bin_PROGRAMS += dash-util
 endif
 
+if BUILD_BITCOIN_CHAINSTATE
+  bin_PROGRAMS += dash-chainstate
+endif
+
 .PHONY: FORCE check-symbols check-security
 # dash core #
 BITCOIN_CORE_H = \
@@ -1156,6 +1160,163 @@ dash_util_LDADD = \
   $(BACKTRACE_LIBS)
 
 dash_util_LDADD += $(BOOST_LIBS)
+
+# dash-chainstate binary #
+dash_chainstate_SOURCES = \
+  bitcoin-chainstate.cpp \
+  addressindex.cpp \
+  arith_uint256.cpp \
+  base58.cpp \
+  batchedlogger.cpp \
+  bech32.cpp \
+  blockfilter.cpp \
+  bls/bls.cpp \
+  bls/bls_worker.cpp \
+  chain.cpp \
+  chainparamsbase.cpp \
+  chainparams.cpp \
+  clientversion.cpp \
+  coins.cpp \
+  compressor.cpp \
+  chainlock/clsig.cpp \
+  chainlock/chainlock.cpp \
+  consensus/merkle.cpp \
+  consensus/tx_check.cpp \
+  consensus/tx_verify.cpp \
+  common/bloom.cpp \
+  core_read.cpp \
+  dbwrapper.cpp \
+  deploymentinfo.cpp \
+  deploymentstatus.cpp \
+  evo/assetlocktx.cpp \
+  evo/cbtx.cpp \
+  evo/creditpool.cpp \
+  evo/chainhelper.cpp \
+  evo/deterministicmns.cpp \
+  evo/dmnstate.cpp \
+  evo/evodb.cpp \
+  evo/netinfo.cpp \
+  evo/mnhftx.cpp \
+  evo/providertx.cpp \
+  evo/simplifiedmns.cpp \
+  evo/smldiff.cpp \
+  evo/specialtx.cpp \
+  evo/specialtx_filter.cpp \
+  evo/specialtxman.cpp \
+  flatfile.cpp \
+  fs.cpp \
+  governance/classes.cpp \
+  governance/common.cpp \
+  governance/exceptions.cpp \
+  governance/governance.cpp \
+  governance/object.cpp \
+  governance/validators.cpp \
+  governance/vote.cpp \
+  governance/votedb.cpp \
+  gsl/assert.cpp \
+  hash.cpp \
+  index/base.cpp \
+  index/blockfilterindex.cpp \
+  index/coinstatsindex.cpp \
+  index/txindex.cpp \
+  instantsend/db.cpp \
+  instantsend/instantsend.cpp \
+  init/common.cpp \
+  key.cpp \
+  key_io.cpp \
+  llmq/blockprocessor.cpp \
+  llmq/commitment.cpp \
+  llmq/context.cpp \
+  llmq/debug.cpp \
+  llmq/dkgsession.cpp \
+  llmq/dkgsessionhandler.cpp \
+  llmq/dkgsessionmgr.cpp \
+  llmq/options.cpp \
+  llmq/quorums.cpp \
+  llmq/quorumsman.cpp \
+  llmq/signhash.cpp \
+  llmq/signing.cpp \
+  llmq/snapshot.cpp \
+  llmq/utils.cpp \
+  logging.cpp \
+  netaddress.cpp \
+  netbase.cpp \
+  node/blockstorage.cpp \
+  node/chainstate.cpp \
+  node/transaction.cpp \
+  kernel/coinstats.cpp \
+  masternode/meta.cpp \
+  masternode/payments.cpp \
+  masternode/sync.cpp \
+  messagesigner.cpp \
+  merkleblock.cpp \
+  node/interface_ui.cpp \
+  policy/feerate.cpp \
+  policy/fees.cpp \
+  policy/packages.cpp \
+  policy/policy.cpp \
+  policy/settings.cpp \
+  pow.cpp \
+  protocol.cpp \
+  primitives/block.cpp \
+  primitives/transaction.cpp \
+  pubkey.cpp \
+  random.cpp \
+  randomenv.cpp \
+  saltedhasher.cpp \
+  scheduler.cpp \
+  script/interpreter.cpp \
+  script/script.cpp \
+  script/script_error.cpp \
+  script/sigcache.cpp \
+  script/standard.cpp \
+  spork.cpp \
+  shutdown.cpp \
+  support/cleanse.cpp \
+  support/lockedpool.cpp \
+  sync.cpp \
+  timedata.cpp \
+  txdb.cpp \
+  txmempool.cpp \
+  uint256.cpp \
+  util/asmap.cpp \
+  util/bytevectorhash.cpp \
+  util/check.cpp \
+  util/getuniquepath.cpp \
+  util/hasher.cpp \
+  util/message.cpp \
+  util/moneystr.cpp \
+  util/ranges_set.cpp \
+  util/serfloat.cpp \
+  util/settings.cpp \
+  util/sock.cpp \
+  util/string.cpp \
+  util/strencodings.cpp \
+  util/syserror.cpp \
+  util/system.cpp \
+  util/thread.cpp \
+  util/threadinterrupt.cpp \
+  util/threadnames.cpp \
+  util/time.cpp \
+  util/tokenpipe.cpp \
+  validation.cpp \
+  validationinterface.cpp \
+  versionbits.cpp \
+  warnings.cpp
+dash_chainstate_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+dash_chainstate_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+dash_chainstate_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS) $(PTHREAD_FLAGS)
+dash_chainstate_LDADD = \
+  $(LIBBITCOIN_CRYPTO) \
+  $(LIBUNIVALUE) \
+  $(LIBSECP256K1) \
+  $(LIBDASHBLS) \
+  $(LIBLEVELDB) \
+  $(LIBMEMENV)
+
+# Required for obj/build.h to be generated first.
+# More details: https://www.gnu.org/software/automake/manual/html_node/Built-Sources-Example.html
+dash_chainstate-clientversion.$(OBJEXT): obj/build.h
 #
 
 # dashconsensus library #

--- a/src/active/dkgsessionhandler.cpp
+++ b/src/active/dkgsessionhandler.cpp
@@ -10,8 +10,10 @@
 #include <llmq/blockprocessor.h>
 #include <llmq/debug.h>
 #include <llmq/dkgsession.h>
+#include <llmq/net_quorum.h>
 #include <llmq/options.h>
 #include <llmq/utils.h>
+#include <masternode/meta.h>
 
 #include <deploymentstatus.h>
 #include <logging.h>
@@ -423,6 +425,50 @@ bool ProcessPendingMessageBatch(const CConnman& connman, CDKGSession& session, C
     return true;
 }
 
+static void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CMasternodeMetaMan& mn_metaman,
+                               const CSporkManager& sporkman, const UtilParameters& util_params,
+                               const CDeterministicMNList& tip_mn_list, const uint256& myProTxHash)
+{
+    assert(mn_metaman.IsValid());
+
+    if (!IsQuorumPoseEnabled(llmqParams.type, sporkman)) {
+        return;
+    }
+
+    auto members = utils::GetAllQuorumMembers(llmqParams.type, util_params);
+    auto curTime = GetTime<std::chrono::seconds>().count();
+
+    Uint256HashSet probeConnections;
+    for (const auto& dmn : members) {
+        if (dmn->proTxHash == myProTxHash) {
+            continue;
+        }
+        auto lastOutbound = mn_metaman.GetLastOutboundSuccess(dmn->proTxHash);
+        if (curTime - lastOutbound < 10 * 60) {
+            // avoid re-probing nodes too often
+            continue;
+        }
+        probeConnections.emplace(dmn->proTxHash);
+    }
+
+    if (!probeConnections.empty()) {
+        if (LogAcceptDebug(BCLog::LLMQ)) {
+            std::string debugMsg = strprintf("%s -- adding masternodes probes for quorum %s:\n", __func__,
+                                             util_params.m_base_index->GetBlockHash().ToString());
+            for (const auto& c : probeConnections) {
+                auto dmn = tip_mn_list.GetValidMN(c);
+                if (!dmn) {
+                    debugMsg += strprintf("  %s (not in valid MN set anymore)\n", c.ToString());
+                } else {
+                    debugMsg += strprintf("  %s (%s)\n", c.ToString(),
+                                          dmn->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
+                }
+            }
+            LogPrint(BCLog::NET_NETCONN, debugMsg.c_str()); /* Continued */
+        }
+        connman.AddPendingProbeConnections(probeConnections);
+    }
+}
 void ActiveDKGSessionHandler::HandleDKGRound(CConnman& connman, PeerManager& peerman)
 {
     WaitForNextPhase(std::nullopt, QuorumPhase::Initialized);
@@ -460,10 +506,10 @@ void ActiveDKGSessionHandler::HandleDKGRound(CConnman& connman, PeerManager& pee
     }
 
     const auto tip_mn_list = m_dmnman.GetListAtChainTip();
-    utils::EnsureQuorumConnections(params, connman, m_sporkman, {m_dmnman, m_qsnapman, m_chainman, pQuorumBaseBlockIndex},
+    llmq::EnsureQuorumConnections(params, connman, m_sporkman, {m_dmnman, m_qsnapman, m_chainman, pQuorumBaseBlockIndex},
                                    tip_mn_list, curSession->ProTx(), /*is_masternode=*/true, m_quorums_watch);
     if (curSession->AreWeMember()) {
-        utils::AddQuorumProbeConnections(params, connman, m_mn_metaman, m_sporkman,
+        AddQuorumProbeConnections(params, connman, m_mn_metaman, m_sporkman,
                                          {m_dmnman, m_qsnapman, m_chainman, pQuorumBaseBlockIndex}, tip_mn_list,
                                          curSession->ProTx());
     }

--- a/src/active/dkgsessionhandler.h
+++ b/src/active/dkgsessionhandler.h
@@ -113,6 +113,7 @@ private:
     void HandleDKGRound(CConnman& connman, PeerManager& peerman) EXCLUSIVE_LOCKS_REQUIRED(!cs_phase_qhash);
     void PhaseHandlerThread(CConnman& connman, PeerManager& peerman) EXCLUSIVE_LOCKS_REQUIRED(!cs_phase_qhash);
 };
+
 } // namespace llmq
 
 #endif // BITCOIN_ACTIVE_DKGSESSIONHANDLER_H

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -1,0 +1,329 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// The bitcoin-chainstate executable serves to surface the dependencies required
+// by a program wishing to use Bitcoin Core's consensus engine as it is right
+// now.
+//
+// DEVELOPER NOTE: Since this is a "demo-only", experimental, etc. executable,
+//                 it may diverge from Bitcoin Core's coding style.
+//
+// It is part of the libbitcoinkernel project.
+
+#include <chainlock/chainlock.h>
+#include <chainparams.h>
+#include <consensus/validation.h>
+#include <core_io.h>
+#include <evo/chainhelper.h>
+#include <evo/deterministicmns.h>
+#include <evo/evodb.h>
+#include <governance/governance.h>
+#include <init/common.h>
+#include <llmq/context.h>
+#include <masternode/meta.h>
+#include <masternode/sync.h>
+#include <node/blockstorage.h>
+#include <node/chainstate.h>
+#include <scheduler.h>
+#include <script/sigcache.h>
+#include <spork.h>
+#include <util/system.h>
+#include <util/thread.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <filesystem>
+#include <functional>
+#include <iosfwd>
+
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
+//----------------
+// symbols g_stats_client, ValueFromAmount, GetPrettyExceptionStr are re-defined
+// here especially for dash-chainstate binary (kernel), because adding sources
+// containing them pulls too many extra dependencies recursively
+#include <stats/client.h>
+std::unique_ptr<StatsdClient> g_stats_client{std::make_unique<StatsdClient>()};
+
+UniValue ValueFromAmount(const CAmount amount)
+{
+    static_assert(COIN > 1);
+    int64_t quotient = amount / COIN;
+    int64_t remainder = amount % COIN;
+    if (amount < 0) {
+        quotient = -quotient;
+        remainder = -remainder;
+    }
+    return UniValue(UniValue::VNUM,
+            strprintf("%s%d.%08d", amount < 0 ? "-" : "", quotient, remainder));
+}
+std::string GetPrettyExceptionStr(const std::exception_ptr& e)
+{
+    try {
+        // rethrow and catch the exception as there is no other way to reliably cast to the real type (not possible with RTTI)
+        std::rethrow_exception(e);
+    } catch (const std::exception& e2) {
+        return e2.what();
+    } catch (...) {
+        throw;
+    }
+}
+//////////////////////
+
+int main(int argc, char* argv[])
+{
+    // SETUP: Argument parsing and handling
+    if (argc != 2) {
+        std::cerr
+            << "Usage: " << argv[0] << " DATADIR" << std::endl
+            << "Display DATADIR information, and process hex-encoded blocks on standard input." << std::endl
+            << std::endl
+            << "IMPORTANT: THIS EXECUTABLE IS EXPERIMENTAL, FOR TESTING ONLY, AND EXPECTED TO" << std::endl
+            << "           BREAK IN FUTURE VERSIONS. DO NOT USE ON YOUR ACTUAL DATADIR." << std::endl;
+        return 1;
+    }
+    std::filesystem::path abs_datadir = std::filesystem::absolute(argv[1]);
+    std::filesystem::create_directories(abs_datadir);
+    gArgs.ForceSetArg("-datadir", abs_datadir.string());
+
+
+    // SETUP: Misc Globals
+    SelectParams(CBaseChainParams::MAIN);
+    const CChainParams& chainparams = Params();
+
+    init::SetGlobals(); // ECC_Start, etc.
+
+    // Necessary for CheckInputScripts (eventually called by ProcessNewBlock),
+    // which will try the script cache first and fall back to actually
+    // performing the check with the signature cache.
+    InitSignatureCache();
+    InitScriptExecutionCache();
+
+
+    // SETUP: Scheduling and Background Signals
+    CScheduler scheduler{};
+    // Start the lightweight task scheduler thread
+    scheduler.m_service_thread = std::thread(util::TraceThread, "scheduler", [&] { scheduler.serviceQueue(); });
+
+    // Gather some entropy once per minute.
+    scheduler.scheduleEvery(RandAddPeriodic, std::chrono::minutes{1});
+
+    GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
+
+
+    // SETUP: Chainstate
+    ChainstateManager chainman{chainparams};
+
+    CMasternodeMetaMan metaman;
+    std::unique_ptr<CEvoDB> evodb;
+    std::unique_ptr<CDeterministicMNManager> dmnman;
+    CMasternodeSync mn_sync{std::make_unique<NullNodeSyncNotifier>()};
+    // govman captures dmnman by const-ref; the unique_ptr is empty here and
+    // filled later inside DashChainstateSetup (called by LoadChainstate).
+    CGovernanceManager govman(metaman, chainman, dmnman, mn_sync);
+    CSporkManager sporkman;
+    chainlock::Chainlocks chainlocks(sporkman);
+
+    std::unique_ptr<LLMQContext> llmq_ctx;
+    std::unique_ptr<CChainstateHelper> chain_helper;
+    auto rv = node::LoadChainstate(/*fReset=*/false,
+                                   std::ref(chainman),
+                                   govman,
+                                   metaman,
+                                   sporkman,
+                                   chainlocks,
+                                   chain_helper,
+                                   dmnman,
+                                   evodb,
+                                   llmq_ctx,
+                                   /*mempool=*/nullptr,
+                                   gArgs.GetDataDirNet(),
+                                   /*fPruneMode=*/false,
+                                   /*is_addrindex_enabled=*/false,
+                                   /*is_spentindex_enabled=*/false,
+                                   /*is_timeindex_enabled=*/false,
+                                   chainparams.GetConsensus(),
+                                   /*fReindexChainState=*/false,
+                                   2 << 20,
+                                   2 << 22,
+                                   (450 << 20) - (2 << 20) - (2 << 22),
+                                   /*block_tree_db_in_memory=*/false,
+                                   /*coins_db_in_memory=*/false,
+                                   /*dash_dbs_in_memory=*/false,
+                                   /*bls_threads=*/1,
+                                   /*worker_count=*/1,
+                                   /*max_recsigs_age=*/1,
+                                   /*shutdown_requested=*/[]() { return false; },
+                                   /*coins_error_cb=*/[]() {});
+    if (rv.has_value()) {
+        std::cerr << "Failed to load Chain state from your datadir." << std::endl;
+        goto epilogue;
+    } else {
+        auto maybe_verify_error = node::VerifyLoadedChainstate(std::ref(chainman),
+                                                               *evodb,
+                                                               false,
+                                                               false,
+                                                               chainparams.GetConsensus(),
+                                                               DEFAULT_CHECKBLOCKS,
+                                                               DEFAULT_CHECKLEVEL,
+                                                               /*get_unix_time_seconds=*/static_cast<int64_t (*)()>(GetTime));
+        if (maybe_verify_error.has_value()) {
+            std::cerr << "Failed to verify loaded Chain state from your datadir." << std::endl;
+            goto epilogue;
+        }
+    }
+
+    for (CChainState* chainstate : WITH_LOCK(::cs_main, return chainman.GetAll())) {
+        BlockValidationState state;
+        if (!chainstate->ActivateBestChain(state, nullptr)) {
+            std::cerr << "Failed to connect best block (" << state.ToString() << ")" << std::endl;
+            goto epilogue;
+        }
+    }
+
+    // Main program logic starts here
+    std::cout
+        << "Hello! I'm going to print out some information about your datadir." << std::endl
+        << "\t" << "Path: " << gArgs.GetDataDirNet() << std::endl
+        << "\t" << "Reindexing: " << std::boolalpha << node::fReindex.load() << std::noboolalpha << std::endl
+        << "\t" << "Snapshot Active: " << std::boolalpha << chainman.IsSnapshotActive() << std::noboolalpha << std::endl
+        << "\t" << "Active Height: " << chainman.ActiveHeight() << std::endl
+        << "\t" << "Active IBD: " << std::boolalpha << chainman.ActiveChainstate().IsInitialBlockDownload() << std::noboolalpha << std::endl;
+    {
+        CBlockIndex* tip = chainman.ActiveTip();
+        if (tip) {
+            std::cout << "\t" << tip->ToString() << std::endl;
+        }
+    }
+
+    for (std::string line; std::getline(std::cin, line);) {
+        if (line.empty()) {
+            std::cerr << "Empty line found" << std::endl;
+            break;
+        }
+
+        std::shared_ptr<CBlock> blockptr = std::make_shared<CBlock>();
+        CBlock& block = *blockptr;
+
+        if (!DecodeHexBlk(block, line)) {
+            std::cerr << "Block decode failed" << std::endl;
+            break;
+        }
+
+        if (block.vtx.empty() || !block.vtx[0]->IsCoinBase()) {
+            std::cerr << "Block does not start with a coinbase" << std::endl;
+            break;
+        }
+
+        uint256 hash = block.GetHash();
+        {
+            LOCK(cs_main);
+            const CBlockIndex* pindex = chainman.m_blockman.LookupBlockIndex(hash);
+            if (pindex) {
+                if (pindex->IsValid(BLOCK_VALID_SCRIPTS)) {
+                    std::cerr << "duplicate" << std::endl;
+                    break;
+                }
+                if (pindex->nStatus & BLOCK_FAILED_MASK) {
+                    std::cerr << "duplicate-invalid" << std::endl;
+                    break;
+                }
+            }
+        }
+
+        // Adapted from rpc/mining.cpp
+        class submitblock_StateCatcher final : public CValidationInterface
+        {
+        public:
+            uint256 hash;
+            bool found;
+            BlockValidationState state;
+
+            explicit submitblock_StateCatcher(const uint256& hashIn) : hash(hashIn), found(false), state() {}
+
+        protected:
+            void BlockChecked(const CBlock& block, const BlockValidationState& stateIn) override
+            {
+                if (block.GetHash() != hash)
+                    return;
+                found = true;
+                state = stateIn;
+            }
+        };
+
+        bool new_block;
+        auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
+        RegisterSharedValidationInterface(sc);
+        bool accepted = chainman.ProcessNewBlock(blockptr, /*force_processing=*/true, /*new_block=*/&new_block);
+        UnregisterSharedValidationInterface(sc);
+        if (!new_block && accepted) {
+            std::cerr << "duplicate" << std::endl;
+            break;
+        }
+        if (!sc->found) {
+            std::cerr << "inconclusive" << std::endl;
+            break;
+        }
+        std::cout << sc->state.ToString() << std::endl;
+        switch (sc->state.GetResult()) {
+        case BlockValidationResult::BLOCK_RESULT_UNSET:
+            std::cerr << "initial value. Block has not yet been rejected" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_CONSENSUS:
+            std::cerr << "invalid by consensus rules (excluding any below reasons)" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_RECENT_CONSENSUS_CHANGE:
+            std::cerr << "Invalid by a change to consensus rules more recent than SegWit." << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_CACHED_INVALID:
+            std::cerr << "this block was cached as being invalid and we didn't store the reason why" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_INVALID_HEADER:
+            std::cerr << "invalid proof of work or time too old" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_MUTATED:
+            std::cerr << "the block's data didn't match the data committed to by the PoW" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_MISSING_PREV:
+            std::cerr << "We don't have the previous block the checked one is built on" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_INVALID_PREV:
+            std::cerr << "A block this one builds on is invalid" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_TIME_FUTURE:
+            std::cerr << "block timestamp was > 2 hours in the future (or our clock is bad)" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_CHECKPOINT:
+            std::cerr << "the block failed to meet one of our checkpoints" << std::endl;
+            break;
+        case BlockValidationResult::BLOCK_CHAINLOCK:
+            std::cerr << "the block conflicts with the ChainLock" << std::endl;
+            break;
+        }
+    }
+
+epilogue:
+    // Without this precise shutdown sequence, there will be a lot of nullptr
+    // dereferencing and UB.
+    scheduler.stop();
+    if (chainman.m_load_block.joinable()) chainman.m_load_block.join();
+    StopScriptCheckWorkerThreads();
+
+    GetMainSignals().FlushBackgroundCallbacks();
+    {
+        LOCK(cs_main);
+        for (CChainState* chainstate : chainman.GetAll()) {
+            if (chainstate->CanFlushToDisk()) {
+                chainstate->ForceFlushStateToDisk();
+                chainstate->ResetCoinsViews();
+            }
+        }
+    }
+    GetMainSignals().UnregisterBackgroundSignalScheduler();
+    // Tear down Dash kernel objects before init::UnsetGlobals().
+    node::DashChainstateSetupClose(chain_helper, dmnman, llmq_ctx, /*mempool=*/nullptr);
+    evodb.reset();
+
+    init::UnsetGlobals();
+}

--- a/src/llmq/net_quorum.cpp
+++ b/src/llmq/net_quorum.cpp
@@ -394,7 +394,7 @@ void NetQuorum::CheckQuorumConnections(const Consensus::LLMQParams& llmqParams,
         std::ranges::any_of(lastQuorums, [&proTxHash](const auto& old_quorum) { return old_quorum->IsMember(proTxHash); });
 
     for (const auto& quorum : lastQuorums) {
-        if (utils::EnsureQuorumConnections(llmqParams, m_connman, m_sporkman,
+        if (EnsureQuorumConnections(llmqParams, m_connman, m_sporkman,
                                            {m_dmnman, m_qsnapman, m_chainman, quorum->m_quorum_base_block_index},
                                            m_dmnman.GetListAtChainTip(), proTxHash,
                                            /*is_masternode=*/is_masternode,
@@ -706,6 +706,77 @@ void NetQuorum::StartCleanupOldQuorumDataThread(gsl::not_null<const CBlockIndex*
 
         LogPrint(BCLog::LLMQ, "NetQuorum::StartCleanupOldQuorumDataThread -- done. time=%d\n", t.count());
     });
+}
+
+bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, const CSporkManager& sporkman,
+                             const UtilParameters& util_params, const CDeterministicMNList& tip_mn_list,
+                             const uint256& myProTxHash, bool is_masternode, bool quorums_watch)
+{
+    if (!is_masternode && !quorums_watch) {
+        return false;
+    }
+
+    auto members = utils::GetAllQuorumMembers(llmqParams.type, util_params);
+    if (members.empty()) {
+        return false;
+    }
+
+    bool isMember = std::ranges::find_if(members, [&](const auto& dmn) { return dmn->proTxHash == myProTxHash; }) !=
+                    members.end();
+
+    if (!isMember && !quorums_watch) {
+        return false;
+    }
+
+    LogPrint(BCLog::NET_NETCONN, "%s -- isMember=%d for quorum %s:\n", __func__, isMember,
+             util_params.m_base_index->GetBlockHash().ToString());
+
+    Uint256HashSet connections;
+    Uint256HashSet relayMembers;
+    if (isMember) {
+        connections = utils::GetQuorumConnections(llmqParams, sporkman, util_params, myProTxHash, /*onlyOutbound=*/true);
+        // If all-members-connected is enabled for this quorum type, leverage the full-mesh
+        // connections for low-latency recovered sig propagation by treating all members as
+        // relay members (instead of the ring-based subset). This ensures peers will send
+        // QSENDRECSIGS to each other across the full mesh and set m_wants_recsigs widely.
+        if (IsAllMembersConnectedEnabled(llmqParams.type, sporkman)) {
+            for (const auto& dmn : members) {
+                if (dmn->proTxHash != myProTxHash) {
+                    relayMembers.emplace(dmn->proTxHash);
+                }
+            }
+        } else {
+            relayMembers = utils::GetQuorumRelayMembers(llmqParams, util_params, myProTxHash, true);
+        }
+    } else {
+        auto cindexes = utils::CalcDeterministicWatchConnections(llmqParams.type, util_params.m_base_index, members.size(), 1);
+        for (auto idx : cindexes) {
+            connections.emplace(members[idx]->proTxHash);
+        }
+        relayMembers = connections;
+    }
+    if (!connections.empty()) {
+        if (!connman.HasMasternodeQuorumNodes(llmqParams.type, util_params.m_base_index->GetBlockHash()) &&
+            LogAcceptDebug(BCLog::LLMQ)) {
+            std::string debugMsg = strprintf("%s -- adding masternodes quorum connections for quorum %s:\n", __func__,
+                                             util_params.m_base_index->GetBlockHash().ToString());
+            for (const auto& c : connections) {
+                auto dmn = tip_mn_list.GetValidMN(c);
+                if (!dmn) {
+                    debugMsg += strprintf("  %s (not in valid MN set anymore)\n", c.ToString());
+                } else {
+                    debugMsg += strprintf("  %s (%s)\n", c.ToString(),
+                                          dmn->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
+                }
+            }
+            LogPrint(BCLog::NET_NETCONN, debugMsg.c_str()); /* Continued */
+        }
+        connman.SetMasternodeQuorumNodes(llmqParams.type, util_params.m_base_index->GetBlockHash(), connections);
+    }
+    if (!relayMembers.empty()) {
+        connman.SetMasternodeQuorumRelayMembers(llmqParams.type, util_params.m_base_index->GetBlockHash(), relayMembers);
+    }
+    return true;
 }
 
 } // namespace llmq

--- a/src/llmq/net_quorum.h
+++ b/src/llmq/net_quorum.h
@@ -32,6 +32,7 @@ namespace llmq {
 class CQuorumManager;
 class CQuorumSnapshotManager;
 class QuorumRole;
+struct UtilParameters;
 } // namespace llmq
 
 namespace llmq {
@@ -122,6 +123,11 @@ private:
     mutable ctpl::thread_pool workerPool;
     mutable CThreadInterrupt quorumThreadInterrupt;
 };
+
+bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, const CSporkManager& sporkman,
+                             const UtilParameters& util_params, const CDeterministicMNList& tip_mn_list,
+                             const uint256& myProTxHash, bool is_masternode, bool quorums_watch);
+
 } // namespace llmq
 
 #endif // BITCOIN_LLMQ_NET_QUORUM_H

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -15,7 +15,6 @@
 
 #include <chainparams.h>
 #include <deploymentstatus.h>
-#include <net.h>
 #include <random.h>
 #include <util/time.h>
 #include <validation.h>
@@ -23,7 +22,6 @@
 #include <atomic>
 #include <map>
 #include <optional>
-#include <ranges>
 
 /**
  * Forward declarations
@@ -777,120 +775,5 @@ std::unordered_set<size_t> CalcDeterministicWatchConnections(Consensus::LLMQType
     return result;
 }
 
-bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, const CSporkManager& sporkman,
-                             const UtilParameters& util_params, const CDeterministicMNList& tip_mn_list,
-                             const uint256& myProTxHash, bool is_masternode, bool quorums_watch)
-{
-    if (!is_masternode && !quorums_watch) {
-        return false;
-    }
-
-    auto members = GetAllQuorumMembers(llmqParams.type, util_params);
-    if (members.empty()) {
-        return false;
-    }
-
-    bool isMember = std::ranges::find_if(members, [&](const auto& dmn) { return dmn->proTxHash == myProTxHash; }) !=
-                    members.end();
-
-    if (!isMember && !quorums_watch) {
-        return false;
-    }
-
-    LogPrint(BCLog::NET_NETCONN, "%s -- isMember=%d for quorum %s:\n", __func__, isMember,
-             util_params.m_base_index->GetBlockHash().ToString());
-
-    Uint256HashSet connections;
-    Uint256HashSet relayMembers;
-    if (isMember) {
-        connections = GetQuorumConnections(llmqParams, sporkman, util_params, myProTxHash, /*onlyOutbound=*/true);
-        // If all-members-connected is enabled for this quorum type, leverage the full-mesh
-        // connections for low-latency recovered sig propagation by treating all members as
-        // relay members (instead of the ring-based subset). This ensures peers will send
-        // QSENDRECSIGS to each other across the full mesh and set m_wants_recsigs widely.
-        if (IsAllMembersConnectedEnabled(llmqParams.type, sporkman)) {
-            for (const auto& dmn : members) {
-                if (dmn->proTxHash != myProTxHash) {
-                    relayMembers.emplace(dmn->proTxHash);
-                }
-            }
-        } else {
-            relayMembers = GetQuorumRelayMembers(llmqParams, util_params, myProTxHash, true);
-        }
-    } else {
-        auto cindexes = CalcDeterministicWatchConnections(llmqParams.type, util_params.m_base_index, members.size(), 1);
-        for (auto idx : cindexes) {
-            connections.emplace(members[idx]->proTxHash);
-        }
-        relayMembers = connections;
-    }
-    if (!connections.empty()) {
-        if (!connman.HasMasternodeQuorumNodes(llmqParams.type, util_params.m_base_index->GetBlockHash()) &&
-            LogAcceptDebug(BCLog::LLMQ)) {
-            std::string debugMsg = strprintf("%s -- adding masternodes quorum connections for quorum %s:\n", __func__,
-                                             util_params.m_base_index->GetBlockHash().ToString());
-            for (const auto& c : connections) {
-                auto dmn = tip_mn_list.GetValidMN(c);
-                if (!dmn) {
-                    debugMsg += strprintf("  %s (not in valid MN set anymore)\n", c.ToString());
-                } else {
-                    debugMsg += strprintf("  %s (%s)\n", c.ToString(),
-                                          dmn->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
-                }
-            }
-            LogPrint(BCLog::NET_NETCONN, debugMsg.c_str()); /* Continued */
-        }
-        connman.SetMasternodeQuorumNodes(llmqParams.type, util_params.m_base_index->GetBlockHash(), connections);
-    }
-    if (!relayMembers.empty()) {
-        connman.SetMasternodeQuorumRelayMembers(llmqParams.type, util_params.m_base_index->GetBlockHash(), relayMembers);
-    }
-    return true;
-}
-
-void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CMasternodeMetaMan& mn_metaman,
-                               const CSporkManager& sporkman, const UtilParameters& util_params,
-                               const CDeterministicMNList& tip_mn_list, const uint256& myProTxHash)
-{
-    assert(mn_metaman.IsValid());
-
-    if (!IsQuorumPoseEnabled(llmqParams.type, sporkman)) {
-        return;
-    }
-
-    auto members = GetAllQuorumMembers(llmqParams.type, util_params);
-    auto curTime = GetTime<std::chrono::seconds>().count();
-
-    Uint256HashSet probeConnections;
-    for (const auto& dmn : members) {
-        if (dmn->proTxHash == myProTxHash) {
-            continue;
-        }
-        auto lastOutbound = mn_metaman.GetLastOutboundSuccess(dmn->proTxHash);
-        if (curTime - lastOutbound < 10 * 60) {
-            // avoid re-probing nodes too often
-            continue;
-        }
-        probeConnections.emplace(dmn->proTxHash);
-    }
-
-    if (!probeConnections.empty()) {
-        if (LogAcceptDebug(BCLog::LLMQ)) {
-            std::string debugMsg = strprintf("%s -- adding masternodes probes for quorum %s:\n", __func__,
-                                             util_params.m_base_index->GetBlockHash().ToString());
-            for (const auto& c : probeConnections) {
-                auto dmn = tip_mn_list.GetValidMN(c);
-                if (!dmn) {
-                    debugMsg += strprintf("  %s (not in valid MN set anymore)\n", c.ToString());
-                } else {
-                    debugMsg += strprintf("  %s (%s)\n", c.ToString(),
-                                          dmn->pdmnState->netInfo->GetPrimary().ToStringAddrPort());
-                }
-            }
-            LogPrint(BCLog::NET_NETCONN, debugMsg.c_str()); /* Continued */
-        }
-        connman.AddPendingProbeConnections(probeConnections);
-    }
-}
 } // namespace utils
 } // namespace llmq

--- a/src/llmq/utils.h
+++ b/src/llmq/utils.h
@@ -20,11 +20,8 @@
 #include <vector>
 
 class CBlockIndex;
-class CConnman;
-class CDeterministicMNList;
 class CDeterministicMNManager;
 class ChainstateManager;
-class CMasternodeMetaMan;
 class CSporkManager;
 namespace llmq {
 class CQuorumSnapshotManager;
@@ -75,14 +72,6 @@ Uint256HashSet GetQuorumConnections(const Consensus::LLMQParams& llmqParams, con
 
 Uint256HashSet GetQuorumRelayMembers(const Consensus::LLMQParams& llmqParams, const UtilParameters& util_params,
                                      const uint256& forMember, bool onlyOutbound);
-
-bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, const CSporkManager& sporkman,
-                             const UtilParameters& util_params, const CDeterministicMNList& tip_mn_list,
-                             const uint256& myProTxHash, bool is_masternode, bool quorums_watch);
-
-void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman, CMasternodeMetaMan& mn_metaman,
-                               const CSporkManager& sporkman, const UtilParameters& util_params,
-                               const CDeterministicMNList& tip_mn_list, const uint256& myProTxHash);
 
 template <typename CacheType>
 inline void InitQuorumsCache(CacheType& cache, const Consensus::Params& consensus_params, bool limit_by_connections = true)


### PR DESCRIPTION
## Issue being fixed or feature implemented

This PR is a first backport of the `libdashkernel` project, see for details: https://github.com/bitcoin/bitcoin/issues/24303

## What was done?

This PR introduces an example/demo dash-chainstate executable using said library which can print out information about a datadir and take in new blocks on stdin.

There are multiple PR that has been extracted from this PR and merged independently:
 - [merged] https://github.com/dashpay/dash/pull/7178
 - [excluded, replaced by NullNodeSyncNotified] ~https://github.com/dashpay/dash/pull/7212~
 - [merged] https://github.com/dashpay/dash/pull/7247
 - [merged] https://github.com/dashpay/dash/pull/7299
 - [merged] https://github.com/dashpay/dash/pull/7303

Beside these PR multiple other PR has been done in the past, such as: #7178, #7070, #7008, #6992, #6959, #7106 (by Udjin), #7065 (by kwvg) and many other PRs.

This PR:

 - new stub implementation NullNodeSyncNotifier of CActiveMaternodeSync  for governance
 - moved network code from llmq/utils to llmq/net_quorum to avoid network dependencies for dash-chainstate
 - backport bitcoin#24304

There are several important notes about implementation:
    
   - UpdateUncommittedBlockStructures is segwit related; omitted from bitcoin-chainstate.cpp
   - call chainman.UnloadBlockIndex is removed by bitcoin#22564, not backported
   - binary name is renamed from bitcoin-chainstate to dash-chainstate. Names of source files and some variables are untouched, but final artefact has the correct dashified name
   - added LIBDASHBLS to list of libraries to link
   - couple functions are reimplemented to avoid balooning dash-chainstate by including extra heavy depenencies
        - ValueFromAmount (reimplemented, core_write.cpp)
        - GetPrettyExceptionStr (reimplemented, stacktrackes.cpp)
        - g_stats_client (redefined)
    
There are several modules that should be removed in the near future from dash-chainstate binary, but out-of-scope of this PR:
    
 - protocol.cpp -- move NetMsgType inline helpers out of chainlock/clsig.h, governance/object.h, evo/simplifiedmns.h into their .cpp files
 - llmq/{dkgsession,dkgsessionhandler,dkgsessionmgr,debug}.cpp and batchedlogger.cpp -- CQuorumManager already null-guards m_qdkgsman; drop once ConnectManagers() is never called on the kernel side
 - llmq/signing.cpp -- split CSigningManager out of LLMQContext into a post-construction Connect() so the context becomes quorum-only
 - governance/*.cpp -- promote the 4 methods used by CMNPaymentsProcessor (IsValid, IsSuperblockTriggered, IsValidSuperblock, GetSuperblockPayments) to a base interface; instantiate a NullGovernanceManager in bitcoin-chainstate.cpp


## How Has This Been Tested?
New binary `dash-chainstate` is produced, functional & unit tests succeed.

Run dash-chainstate:
```
$ src/dash-chainstate /home/knst/.dashcore/
Hello! I'm going to print out some information about your datadir.
        Path: "/home/knst/.dashcore"
        Reindexing: false
        Snapshot Active: false
        Active Height: 2294070
        Active IBD: true
        CBlockIndex(pprev=0x5654a3bdb218, nHeight=2294070, merkle=5c87e557b9e697e9308a4a6bd684e362910fe418ca60e59ae1376e91c487df77, hashBlock=0000000000000010938b2d1c2f1ff08163dae17f4196a41d73b9e6e3c4114cc2)
```



## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

