### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -38,7 +38,7 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -51,10 +51,10 @@ jobs:
           echo "repo=${REPO_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
@@ -82,7 +82,7 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -95,10 +95,10 @@ jobs:
           echo "repo=${REPO_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
@@ -125,15 +125,15 @@ jobs:
     needs: [build-amd64, build-arm64]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -37,7 +37,7 @@ jobs:
       dep-opts: ${{ steps.setup.outputs.DEP_OPTS }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           sparse-checkout: |
@@ -69,7 +69,7 @@ jobs:
 
       - name: Check for cached depends
         id: cache-check
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: depends/built/${{ steps.setup.outputs.HOST }}
           key: ${{ steps.setup.outputs.cache-key }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Cache SDKs
         id: cache-sdk-check
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         if: inputs.build-target == 'mac'
         with:
           path: depends/SDKs
@@ -98,19 +98,19 @@ jobs:
       options: --user root
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Restore depends sources
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: depends/sources
           key: depends-sources-${{ hashFiles('depends/packages/*') }}
           restore-keys: depends-sources-
 
       - name: Restore SDKs cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         if: inputs.build-target == 'mac'
         with:
           path: depends/SDKs
@@ -119,7 +119,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Restore cached depends
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: depends/built/${{ needs.check-cache.outputs.host }}
           key: ${{ needs.check-cache.outputs.cache-key }}
@@ -132,7 +132,7 @@ jobs:
           env ${{ needs.check-cache.outputs.dep-opts }} make -j$(nproc) -C depends
 
       - name: Save depends cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: depends/built/${{ needs.check-cache.outputs.host }}
           key: ${{ needs.check-cache.outputs.cache-key }}

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -44,7 +44,7 @@ jobs:
       options: --user root
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 50
@@ -61,7 +61,7 @@ jobs:
         shell: bash
 
       - name: Restore SDKs cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         if: inputs.build-target == 'mac'
         with:
           path: |
@@ -70,7 +70,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Restore depends cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: depends/built/${{ inputs.depends-host }}
           key: ${{ inputs.depends-key }}
@@ -84,7 +84,7 @@ jobs:
         shell: bash
 
       - name: Restore ccache cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             /cache/ccache
@@ -111,7 +111,7 @@ jobs:
         if: |
           github.event_name == 'push' &&
           github.ref_name == github.event.repository.default_branch
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             /cache/ccache
@@ -119,7 +119,7 @@ jobs:
 
       - name: Restore ctcache cache
         if: inputs.build-target == 'linux64_multiprocess'
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             /cache/ctcache
@@ -141,7 +141,7 @@ jobs:
           inputs.build-target == 'linux64_multiprocess' &&
           github.event_name == 'push' &&
           github.ref_name == github.event.repository.default_branch
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             /cache/ctcache
@@ -165,7 +165,7 @@ jobs:
           echo "key=${BUNDLE_KEY}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ steps.bundle.outputs.key }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Checkout code
         if: ${{ steps.skip-check.outputs.skip == 'false' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Select runners
         id: select-runner

--- a/.github/workflows/cache-depends-sources.yml
+++ b/.github/workflows/cache-depends-sources.yml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ${{ inputs.runs-on || 'ubuntu-24.04-arm' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check for cached sources
         id: cache-check
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: depends/sources
           key: depends-sources-${{ hashFiles('depends/packages/*') }}

--- a/.github/workflows/clang-diff-format.yml
+++ b/.github/workflows/clang-diff-format.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Fetch git
         run: git fetch --no-tags -fu origin develop:develop
       - name: Run Clang-Format-Diff.py

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -25,14 +25,14 @@ jobs:
       repo-name: ${{ steps.prepare.outputs.repo-name }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: dash
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Commit variables
         id: prepare
@@ -46,14 +46,14 @@ jobs:
           echo "repo-name=${REPO_NAME}" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ github.workspace }}/dash
           build-args: |
@@ -84,14 +84,14 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: dash
           fetch-depth: 0
 
       - name: Cache depends sources
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: dash/depends/sources
           key: depends-sources-${{ hashFiles('dash/depends/packages/*') }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Cache Guix and depends
         id: guix-cache-restore
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ${{ github.workspace }}/.cache
@@ -140,13 +140,13 @@ jobs:
           HOSTS=${{ matrix.build_target }} ./dash/contrib/containers/guix/scripts/guix-check ${{ github.workspace }}/dash
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: guix-artifacts-${{ matrix.build_target }}
           path: |
             ${{ github.workspace }}/dash/guix-build*/output/${{ matrix.build_target }}/
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest@v4
         with:
           subject-path: ${{ github.workspace }}/dash/guix-build*/output/${{ matrix.build_target }}/*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       options: --user root
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 50

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
             needs rebase
 
       - name: comment
-        uses: mshick/add-pr-comment@v2
+        uses: mshick/add-pr-comment@v3
         if: failure()
         with:
           message: |

--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ghToken: "${{ secrets.GITHUB_TOKEN }}"
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: validate potential conflicts
         id: validate_conflicts
         run: pip3 install hjson && .github/workflows/handle_potential_conflicts.py "$conflicts"

--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -10,18 +10,18 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       with:
         image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
         echo "build_tag=${TAG#v}" >> $GITHUB_OUTPUT
 
     - name: Set suffix
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       id: suffix
       with:
         result-encoding: string
@@ -49,7 +49,7 @@ jobs:
 
     - name: Set Docker tags and labels
       id: docker_meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v6
       with:
         images: dashpay/dashd
         tags: |
@@ -62,7 +62,7 @@ jobs:
 
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v7
       with:
         context: ./contrib/containers/deploy
         file: ./contrib/containers/deploy/Dockerfile.GitHubActions.Release

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -33,18 +33,18 @@ jobs:
       options: --user root
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.bundle-key }}
 
       - name: Manage releases cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         if: inputs.build-target == 'linux64'
         with:
           path: |
@@ -74,7 +74,7 @@ jobs:
         shell: bash
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: |
           success() || (failure() && steps.test.outcome == 'failure')
           && steps.bundle.outputs.upload-logs == 'true'


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes the Github Actions annotation warnings.

`Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24.`

## What was done?

- Updated all GitHub Actions to latest versions:
  - actions/checkout: v4 → v6
  - actions/cache: v4 → v5
  - actions/cache/restore: v4 → v5
  - actions/cache/save: v4 → v5
  - actions/upload-artifact: v4 → v6
  - actions/download-artifact: v4 → v8
  - docker/setup-buildx-action: v3 → v4
  - docker/login-action: v3 → v4
  - docker/build-push-action: v6 → v7
  - docker/buildx: v4 → v5
  - docker/metadata-action: v6 → v7
  - docker/build-push-action: v6 → v7
  - docker/setup-qemu-action@v3 → v4
  - mshick/add-pr-comment@v2 → v3

- Replaced deprecated actions/attest-build-provenance@v1
  - Now uses actions/attest@v4

As of version 4, actions/attest-build-provenance is simply a wrapper on top of actions/attest.
Existing applications may continue to use the attest-build-provenance action, but new implementations should use actions/attest instead. By default, this generates a [SLSA build provenance](https://slsa.dev/spec/v1.0/provenance) attestation.

More info at: https://github.com/marketplace/actions/attest-build-provenance

## How Has This Been Tested?

Not tested.

## Breaking Changes

Upgrading to `actions/checkout@v6` `actions/github-script@v8` `actions/cache@v5` can break CI on self-hosted labels unless the runner fleet is already updated: checkout v6, cache v5, github-script v8, requires Actions Runner [v2.327.1+](https://github.com/actions/runner/releases/tag/v2.327.1), and actions/checkout@v6 release notes also call out [v2.329.0+](https://github.com/actions/runner/releases/tag/v2.329.0) for persisted-credential access in containerized git scenarios.

## Checklist:
  _Go over all the following points, and put an `x` in all the boxes that apply._
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
