### PR TITLE
docs: update old Transifex URLs in release notes

### DIFF
--- a/doc/release-notes/dash/release-notes-0.11.2.md
+++ b/doc/release-notes/dash/release-notes-0.11.2.md
@@ -107,4 +107,4 @@ Thanks to who contributed to this release, at least:
 - 21E14
 
 As well as the Bitcoin Core developers and everyone that helped translating on
-[Transifex](https://www.transifex.com/projects/p/darkcoin/).
+[Transifex](https://explore.transifex.com/dash/dash/).

--- a/doc/release-notes/dash/release-notes-0.12.0.md
+++ b/doc/release-notes/dash/release-notes-0.12.0.md
@@ -100,4 +100,4 @@ AlexMomo
 snogcel
 bertlebbert
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/dash/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/dash/dash/).

--- a/doc/release-notes/dash/release-notes-0.12.2.2.md
+++ b/doc/release-notes/dash/release-notes-0.12.2.2.md
@@ -223,7 +223,7 @@ Thanks to everyone who directly contributed to this release:
 
 As well as Bitcoin Core Developers and everyone that submitted issues,
 reviewed pull requests or helped translating on
-[Transifex](https://www.transifex.com/projects/p/dash/).
+[Transifex](https://explore.transifex.com/dash/dash/).
 
 
 Older releases

--- a/doc/release-notes/dash/release-notes-0.12.2.3.md
+++ b/doc/release-notes/dash/release-notes-0.12.2.3.md
@@ -107,7 +107,7 @@ Thanks to everyone who directly contributed to this release:
 
 As well as Bitcoin Core Developers and everyone that submitted issues,
 reviewed pull requests or helped translating on
-[Transifex](https://www.transifex.com/projects/p/dash/).
+[Transifex](https://explore.transifex.com/dash/dash/).
 
 
 Older releases

--- a/doc/release-notes/dash/release-notes-0.12.2.md
+++ b/doc/release-notes/dash/release-notes-0.12.2.md
@@ -374,7 +374,7 @@ Thanks to everyone who directly contributed to this release:
 - UdjinM6
 - Will Wray
 
-As well as Bitcoin Core Developers and everyone that submitted issues or helped translating on [Transifex](https://www.transifex.com/projects/p/dash/).
+As well as Bitcoin Core Developers and everyone that submitted issues or helped translating on [Transifex](https://explore.transifex.com/dash/dash/).
 
 
 Older releases

--- a/doc/release-notes/dash/release-notes-0.12.3.1.md
+++ b/doc/release-notes/dash/release-notes-0.12.3.1.md
@@ -461,7 +461,7 @@ Thanks to everyone who directly contributed to this release:
 
 As well as Bitcoin Core Developers and everyone who submitted issues,
 reviewed pull requests or helped translating on
-[Transifex](https://www.transifex.com/projects/p/dash/).
+[Transifex](https://explore.transifex.com/dash/dash/).
 
 
 Older releases

--- a/doc/release-notes/dash/release-notes-0.13.0.md
+++ b/doc/release-notes/dash/release-notes-0.13.0.md
@@ -707,7 +707,7 @@ Thanks to everyone who directly contributed to this release:
 - Anton Suprunchuk
 
 As well as everyone that submitted issues, reviewed pull requests or helped translating on
-[Transifex](https://www.transifex.com/projects/p/dash/).
+[Transifex](https://explore.transifex.com/dash/dash/).
 
 Older releases
 ==============


### PR DESCRIPTION
## Summary

Update the old Transifex project URL (`www.transifex.com/projects/p/dash/`) to the current URL (`app.transifex.com/dash/`) in historical release notes.

## Changes

7 release notes files updated (v0.11.2 through v0.13.0) — these were the only files still referencing the deprecated URL format. The `darkcoin` variant in v0.11.2 was also updated to point to the current Dash project page.

Note: `README.md` and `doc/translation_process.md` already use the current `explore.transifex.com/dash/dash/` URL and required no changes.

## Validation

- Verified no remaining references to `www.transifex.com/projects/p/` in the repo
- Confirmed `https://app.transifex.com/dash/` is the correct current URL
