### PR TITLE
fix: register shareman recovery interface in ActiveContext

### DIFF
--- a/src/active/context.cpp
+++ b/src/active/context.cpp
@@ -70,6 +70,7 @@ void ActiveContext::Start(CConnman& connman, PeerManager& peerman, int16_t worke
     cl_signer->Start();
     cl_signer->RegisterRecoveryInterface();
     is_signer->RegisterRecoveryInterface();
+    shareman->RegisterRecoveryInterface();
 
     RegisterValidationInterface(cl_signer.get());
 }
@@ -78,6 +79,7 @@ void ActiveContext::Stop()
 {
     UnregisterValidationInterface(cl_signer.get());
 
+    shareman->UnregisterRecoveryInterface();
     is_signer->UnregisterRecoveryInterface();
     cl_signer->UnregisterRecoveryInterface();
     cl_signer->Stop();


### PR DESCRIPTION
## Summary

Add missing `shareman->RegisterRecoveryInterface()` call in `ActiveContext::Start()` and corresponding `UnregisterRecoveryInterface()` in `Stop()`.

## Problem

`ActiveContext::Start()` registers recovery interfaces for `cl_signer` and `is_signer` but not `shareman`. Without this, completed sig share sessions are only cleaned up via the 5-second `Cleanup()` interval instead of promptly via `HandleNewRecoveredSig`.

Under CI load with frozen mocktime, this manifests as flaky test failures in `feature_llmq_signing.py` and `interface_zmq_dash.py` where InstantSend locks don't arrive within expected timeouts.

## Root Cause

The registration was likely dropped during the sig share refactoring that split share management into a separate `shareman` object. The `cl_signer` and `is_signer` registrations survived but `shareman` was missed.

## Fix

Two lines:

- `shareman->RegisterRecoveryInterface()` in `Start()` (after `is_signer`)
- `shareman->UnregisterRecoveryInterface()` in `Stop()` (before `is_signer`, maintaining reverse order)

## Validation

- Verified `CSigSharesManager` declares both `RegisterRecoveryInterface()` and `UnregisterRecoveryInterface()` in `src/llmq/signing_shares.h`
- Confirmed `shareman` is a `unique_ptr<CSigSharesManager>` in `ActiveContext`
- `Stop()` unregisters in reverse order of `Start()` registration (LIFO)

Closes #7243
