### PR TITLE
refactor: remove BlockAssembler from friends of CChainstateHelper

### DIFF
--- a/src/evo/chainhelper.h
+++ b/src/evo/chainhelper.h
@@ -35,19 +35,13 @@ class CQuorumBlockProcessor;
 class CQuorumManager;
 class CQuorumSnapshotManager;
 } // namespace llmq
-namespace node {
-class BlockAssembler;
-} // namespace node
-
 class CChainstateHelper
 {
-    friend class node::BlockAssembler;
-
 private:
     llmq::CInstantSendManager& isman;
-    const std::unique_ptr<CCreditPoolManager> credit_pool_manager;
 
 public:
+    const std::unique_ptr<CCreditPoolManager> credit_pool_manager;
     const chainlock::Chainlocks& m_chainlocks;
     const std::unique_ptr<CMNHFManager> ehf_manager;
     const std::unique_ptr<CMNPaymentsProcessor> mn_payments;


### PR DESCRIPTION
## Issue being fixed or feature implemented
CHainstateHelper and BlockAssembler no need to be friends

## What was done?
See commit, changes are trivial

## How Has This Been Tested?
Run unit & functional tests

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone