### PR TITLE
refactor: replace usages of MessageProcessingResult in HandleNewRecoveredSig to variant

### DIFF
--- a/src/chainlock/signing.cpp
+++ b/src/chainlock/signing.cpp
@@ -260,10 +260,10 @@ ChainLockSigner::BlockTxs::mapped_type ChainLockSigner::GetBlockTxs(const uint25
     return ret;
 }
 
-MessageProcessingResult ChainLockSigner::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
+llmq::RecoveredSigResult ChainLockSigner::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
 {
     if (!m_chainlocks.IsEnabled()) {
-        return {};
+        return std::monostate{};
     }
 
     ChainLockSig clsig;
@@ -272,16 +272,22 @@ MessageProcessingResult ChainLockSigner::HandleNewRecoveredSig(const llmq::CReco
 
         if (recoveredSig.getId() != lastSignedRequestId || recoveredSig.getMsgHash() != lastSignedMsgHash) {
             // this is not what we signed, so lets not create a CLSIG for it
-            return {};
+            return std::monostate{};
         }
         if (m_chainlocks.GetBestChainLockHeight() >= lastSignedHeight) {
             // already got the same or a better CLSIG through the CLSIG message
-            return {};
+            return std::monostate{};
         }
 
         clsig = ChainLockSig(lastSignedHeight, lastSignedMsgHash, recoveredSig.sig.Get());
     }
-    return m_clhandler.ProcessNewChainLock(-1, clsig, m_qman, ::SerializeHash(clsig));
+    // TODO: split ProcessNewChainLock into network and non-network variants; when no peer
+    // is specified (node == -1), only m_inventory is ever populated
+    auto clresult = m_clhandler.ProcessNewChainLock(-1, clsig, m_qman, ::SerializeHash(clsig));
+    if (!clresult.m_inventory.empty()) {
+        return clresult.m_inventory.front();
+    }
+    return std::monostate{};
 }
 
 void ChainLockSigner::Cleanup()

--- a/src/chainlock/signing.h
+++ b/src/chainlock/signing.h
@@ -13,7 +13,6 @@
 
 class CScheduler;
 class CMasternodeSync;
-struct MessageProcessingResult;
 namespace llmq {
 class CInstantSendManager;
 class CRecoveredSig;
@@ -80,7 +79,7 @@ public:
     void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_try_sign, !cs_signer);
 
-    [[nodiscard]] MessageProcessingResult HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig) override
+    [[nodiscard]] llmq::RecoveredSigResult HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);
 
     void Cleanup() EXCLUSIVE_LOCKS_REQUIRED(!cs_signer);

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -73,14 +73,14 @@ void InstantSendSigner::ClearLockFromQueue(const InstantSendLockPtr& islock)
     txToCreatingInstantSendLocks.erase(islock->txid);
 }
 
-MessageProcessingResult InstantSendSigner::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
+llmq::RecoveredSigResult InstantSendSigner::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
 {
     if (!m_isman.IsInstantSendEnabled()) {
-        return {};
+        return std::monostate{};
     }
 
     if (Params().GetConsensus().llmqTypeDIP0024InstantSend == Consensus::LLMQType::LLMQ_NONE) {
-        return {};
+        return std::monostate{};
     }
 
     uint256 txid;
@@ -92,7 +92,7 @@ MessageProcessingResult InstantSendSigner::HandleNewRecoveredSig(const llmq::CRe
     } else if (/*isInstantSendLock=*/WITH_LOCK(cs_creating, return creatingInstantSendLocks.count(recoveredSig.getId()))) {
         HandleNewInstantSendLockRecoveredSig(recoveredSig);
     }
-    return {};
+    return std::monostate{};
 }
 
 bool InstantSendSigner::IsInstantSendMempoolSigningEnabled() const

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -14,7 +14,6 @@
 class CMasternodeSync;
 class CSporkManager;
 class CTxMemPool;
-struct MessageProcessingResult;
 
 namespace Consensus {
 struct Params;
@@ -93,7 +92,7 @@ public:
     void ClearLockFromQueue(const InstantSendLockPtr& islock)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_creating);
 
-    [[nodiscard]] MessageProcessingResult HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig) override
+    [[nodiscard]] llmq::RecoveredSigResult HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_creating, !cs_input_requests);
 
     void ProcessPendingRetryLockTxs(const std::vector<CTransactionRef>& retryTxs)

--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -81,7 +81,7 @@ void CEHFSignalsHandler::trySignEHFSignal(int bit, const CBlockIndex* const pind
     shareman.AsyncSignIfMember(llmqType, sigman, requestId, msgHash, quorum->qc->quorumHash, false, true);
 }
 
-MessageProcessingResult CEHFSignalsHandler::HandleNewRecoveredSig(const CRecoveredSig& recoveredSig)
+RecoveredSigResult CEHFSignalsHandler::HandleNewRecoveredSig(const CRecoveredSig& recoveredSig)
 {
     if (g_txindex) {
         g_txindex->BlockUntilSyncedToCurrentChain();
@@ -89,7 +89,7 @@ MessageProcessingResult CEHFSignalsHandler::HandleNewRecoveredSig(const CRecover
 
     if (WITH_LOCK(cs, return ids.find(recoveredSig.getId()) == ids.end())) {
         // Do nothing, it's not for this handler
-        return {};
+        return std::monostate{};
     }
 
     const auto ehfSignals = m_chainman.ActiveChainstate().ChainHelper().ehf_manager->GetSignalsStage(
@@ -118,14 +118,12 @@ MessageProcessingResult CEHFSignalsHandler::HandleNewRecoveredSig(const CRecover
         LOCK(::cs_main);
         const MempoolAcceptResult result = m_chainman.ProcessTransaction(tx_to_sent);
         if (result.m_result_type == MempoolAcceptResult::ResultType::VALID) {
-            MessageProcessingResult ret;
-            ret.m_transactions.push_back(tx_to_sent->GetHash());
-            return ret;
+            return tx_to_sent;
         }
         LogPrintf("CEHFSignalsHandler::HandleNewRecoveredSig -- AcceptToMemoryPool failed: %s\n",
                   result.m_state.ToString());
-        return {};
+        return std::monostate{};
     }
-    return {};
+    return std::monostate{};
 }
 } // namespace llmq

--- a/src/llmq/ehf_signals.h
+++ b/src/llmq/ehf_signals.h
@@ -6,7 +6,6 @@
 #define BITCOIN_LLMQ_EHF_SIGNALS_H
 
 #include <llmq/signing.h>
-#include <msg_result.h>
 #include <saltedhasher.h>
 
 #include <set>
@@ -44,7 +43,7 @@ public:
      */
     void UpdatedBlockTip(const CBlockIndex* const pindexNew) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
-    [[nodiscard]] MessageProcessingResult HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) override
+    [[nodiscard]] RecoveredSigResult HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
 private:

--- a/src/llmq/net_signing.cpp
+++ b/src/llmq/net_signing.cpp
@@ -166,7 +166,12 @@ void NetSigning::ProcessRecoveredSig(std::shared_ptr<const CRecoveredSig> recove
 
     auto listeners = m_sig_manager.GetListeners();
     for (auto& l : listeners) {
-        m_peer_manager->PeerPostProcessMessage(l->HandleNewRecoveredSig(*recovered_sig));
+        auto result = l->HandleNewRecoveredSig(*recovered_sig);
+        if (const auto* inv = std::get_if<CInv>(&result)) {
+            m_peer_manager->PeerRelayInv(*inv);
+        } else if (const auto* tx_ref = std::get_if<CTransactionRef>(&result)) {
+            m_peer_manager->PeerRelayTransaction((*tx_ref)->GetHash());
+        }
     }
 
     // TODO refactor to use a better abstraction analogous to IsAllMembersConnectedEnabled

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -8,7 +8,6 @@
 #include <bls/bls.h>
 #include <llmq/params.h>
 #include <llmq/types.h>
-#include <msg_result.h>
 #include <net_types.h>
 #include <random.h>
 #include <saltedhasher.h>
@@ -18,20 +17,26 @@
 #include <memory>
 #include <string_view>
 #include <unordered_map>
+#include <variant>
 
 class CChainState;
 class CDataStream;
 class CDBBatch;
 class CDBWrapper;
 class CInv;
+class CTransaction;
 struct RPCResult;
 namespace util {
 struct DbWrapperParams;
 } // namespace util
 
 class UniValue;
+using CTransactionRef = std::shared_ptr<const CTransaction>;
 
 namespace llmq {
+
+using RecoveredSigResult = std::variant<std::monostate, CInv, CTransactionRef>;
+
 class CQuorumManager;
 class CSigSharesManager;
 class SignHash;
@@ -151,8 +156,7 @@ class CRecoveredSigsListener
 public:
     virtual ~CRecoveredSigsListener() = default;
 
-    // TODO: simplify returned type to std::variant<CInv, CTransaction, std::monostate>
-    [[nodiscard]] virtual MessageProcessingResult HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) = 0;
+    [[nodiscard]] virtual RecoveredSigResult HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) = 0;
 };
 
 class CSigningManager

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -13,11 +13,9 @@
 #include <llmq/quorumsman.h>
 #include <llmq/signhash.h>
 #include <llmq/signing.h>
-#include <msg_result.h>
+#include <netmessagemaker.h>
 #include <util/helpers.h>
 #include <util/std23.h>
-
-#include <netmessagemaker.h>
 #include <util/thread.h>
 #include <util/time.h>
 #include <validation.h>
@@ -1535,11 +1533,11 @@ void CSigSharesManager::ForceReAnnouncement(const CQuorum& quorum, Consensus::LL
     }
 }
 
-MessageProcessingResult CSigSharesManager::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
+RecoveredSigResult CSigSharesManager::HandleNewRecoveredSig(const llmq::CRecoveredSig& recoveredSig)
 {
     auto signHash = recoveredSig.buildSignHash().Get();
     LOCK(cs);
     RemoveSigSharesForSession(signHash);
-    return {};
+    return std::monostate{};
 }
 } // namespace llmq

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -33,7 +33,6 @@ class ChainstateManager;
 class CNode;
 class CConnman;
 class CSporkManager;
-struct MessageProcessingResult;
 
 namespace llmq
 {
@@ -434,7 +433,7 @@ public:
     void ForceReAnnouncement(const CQuorum& quorum, Consensus::LLMQType llmqType, const uint256& id,
                              const uint256& msgHash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
-    [[nodiscard]] MessageProcessingResult HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) override
+    [[nodiscard]] RecoveredSigResult HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     static CDeterministicMNCPtr SelectMemberForRecovery(const CQuorum& quorum, const uint256& id, int attempt);


### PR DESCRIPTION
## Issue being fixed or feature implemented

The public interface `HandleNewRecoveredSig` which is widely used on develop returns `MessageProcessingResult`

Using MessageProcessingResult is incorrect using here; because `HandleNewRecoveredSig` may return only CInv or CTransactionRef.

Using MessageProcessingResult here spreads including of heavy `msg_result.h` all over codebase; it makes dependency of llmq/ code on network code.

This PR is a direct dependency for kernel / dash-chainstate project, see https://github.com/dashpay/dash/pull/7234

## What was done?
Replaced MessageProcessingResult to std::variant<CInv, CTransactionRef, std::monostate>.

Potentially, even CTransactionRef is overhead and should be replaced to special case of CInv, but it's out-of-scope of this refactoring.
Also, `m_clhandler.ProcessNewChainLock` should be refactored and split to network and non-network part and avoid leaking `MessageProcessingResult` abstraction here too, but I kept it out-of-scope of this refactoring too.

## How Has This Been Tested?
Run unit tests & functional tests.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone