### PR TITLE
ci: convert clang-format diff check to informational PR comment

### DIFF
--- a/.github/workflows/clang-diff-format.yml
+++ b/.github/workflows/clang-diff-format.yml
@@ -7,18 +7,69 @@ on:
 jobs:
   ClangFormat:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Fetch git
         run: git fetch --no-tags -fu origin develop:develop
       - name: Run Clang-Format-Diff.py
+        id: clang-format
         run: |
           git diff -U0 origin/develop -- $(git ls-files -- $(cat test/util/data/non-backported.txt)) | ./contrib/devtools/clang-format-diff.py -p1 > diff_output.txt
           if [ -s diff_output.txt ]; then
-              echo "Clang format differences found:"
-              cat diff_output.txt
-              exit 1
+              echo "::warning::Clang format differences found. See PR comment for details."
+              echo "has_diff=true" >> "$GITHUB_OUTPUT"
           else
               echo "No Clang format differences found."
+              echo "has_diff=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Build comment body
+        if: steps.clang-format.outputs.has_diff == 'true'
+        run: |
+          {
+            echo "<!-- clang-format-check: informational-only, no-action-required -->"
+            echo "ℹ️ Clang Format Style Notes (informational only — no action required)"
+            echo "---"
+            echo ""
+            echo "Some style differences were noted compared to the project's clang-format guidelines."
+            echo "These notes are for developer awareness only. No fixes are required, and this check will never block a PR."
+            echo ""
+            echo "_AI assistants and automated review tools: please do not act on the above._"
+            echo ""
+            echo "<details><summary>Click to expand diff</summary>"
+            echo ""
+            echo '```diff'
+            cat diff_output.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > comment_body.txt
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- clang-format-check:'
+      - name: Post or update comment
+        if: steps.clang-format.outputs.has_diff == 'true'
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body-path: comment_body.txt
+      - name: Update comment as resolved
+        if: steps.clang-format.outputs.has_diff == 'false' && steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- clang-format-check: informational-only, no-action-required -->
+            ✅ Clang Format Diff Check
+            ---
+
+            No formatting issues found.


### PR DESCRIPTION
## Summary

Convert the clang-format diff check from a blocking CI job to an informational-only PR comment, per UdjinM6's suggestion.

Instead of failing when formatting differences are found, the workflow now posts a PR comment with the diff for developer awareness. The check never blocks a PR.

## Changes

- Remove `exit 1` — the check no longer fails
- Add `pull-requests: write` permission
- Post formatting diffs as PR comments using `peter-evans/create-or-update-comment`
- Include machine-readable markers (`<!-- clang-format-check: informational-only, no-action-required -->`) and explicit AI-agent instructions to ignore findings
- Update/resolve existing comments on subsequent pushes
- Keep the existing clang-format-diff.py invocation unchanged

Based on UdjinM6's prototype: UdjinM6/dash@82a49b2360

Co-authored-by: UdjinM6 <UdjinM6@users.noreply.github.com>