### PR TITLE
test: fix wait_for_instantlock calls in test_instantsend_after_restart

### DIFF
--- a/test/functional/p2p_instantsend.py
+++ b/test/functional/p2p_instantsend.py
@@ -139,10 +139,7 @@ class InstantSendTest(DashTestFramework):
         receiver = self.nodes[self.receiver_idx]
         sender_addr = sender.getnewaddress()
         fund_id = self.nodes[0].sendtoaddress(sender_addr, 1)
-        self.bump_mocktime(30)
-        self.sync_mempools()
-        for node in self.nodes:
-            self.wait_for_instantlock(fund_id, node)
+        self.wait_for_instantlock(fund_id)
         tip = self.generate(self.nodes[0], 2)[-1]
         self.bump_mocktime(30)
         self.wait_for_chainlocked_block_all_nodes(tip)
@@ -199,10 +196,7 @@ class InstantSendTest(DashTestFramework):
 
         # send a TX — needs IS lock from all restarted MNs, no new blocks mined
         is_id = sender.sendtoaddress(receiver_addr, 0.5)
-        self.bump_mocktime(30)
-        self.sync_mempools()
-        for node in self.nodes:
-            self.wait_for_instantlock(is_id, node)
+        self.wait_for_instantlock(is_id)
         self.log.info("InstantSend lock succeeded after full restart")
 
         # clean up


### PR DESCRIPTION
## Summary

Fix two broken `wait_for_instantlock` call sites in `test_instantsend_after_restart` that were missed during the merge of #7240 and #7241.

## Problem

The merge of #7240 (added `test_instantsend_after_restart` with old-style calls) and #7241 (refactored `wait_for_instantlock(txid, node)` → `wait_for_instantlock(*txids, nodes=None)`) left two call sites using the old positional signature:

```python
for node in self.nodes:
    self.wait_for_instantlock(txid, node)  # node consumed as second *txid
```

The `node` object gets silently swallowed into `*txids` as a second "txid", causing `getrawtransaction(node_object, True)` to fail and the wait to time out after ~282 seconds. This breaks `p2p_instantsend.py` on every CI run.

## Fix

Replace both loops with the new consolidated API which handles mempool sync and checks all nodes by default:

```python
self.wait_for_instantlock(txid)
```