### PR TITLE
refactor: remove deadcode with RegisterListener

### DIFF
--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -195,16 +195,6 @@ CSigSharesManager::CSigSharesManager(CConnman& connman, const ChainstateManager&
 
 CSigSharesManager::~CSigSharesManager() = default;
 
-void CSigSharesManager::RegisterRecoveryInterface()
-{
-    sigman.RegisterRecoveredSigsListener(this);
-}
-
-void CSigSharesManager::UnregisterRecoveryInterface()
-{
-    sigman.UnregisterRecoveredSigsListener(this);
-}
-
 bool CSigSharesManager::ProcessMessageSigSesAnn(const CNode& pfrom, const CSigSesAnn& ann)
 {
     auto llmqType = ann.getLlmqType();

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -424,9 +424,6 @@ public:
                                const CSporkManager& sporkman);
     ~CSigSharesManager() override;
 
-    void RegisterRecoveryInterface() EXCLUSIVE_LOCKS_REQUIRED(!cs);
-    void UnregisterRecoveryInterface() EXCLUSIVE_LOCKS_REQUIRED(!cs);
-
     void AsyncSign(CQuorumCPtr quorum, const uint256& id, const uint256& msgHash)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingSigns, !cs);
     std::optional<CSigShare> CreateSigShare(const CQuorum& quorum, const uint256& id, const uint256& msgHash) const


### PR DESCRIPTION
## Issue being fixed or feature implemented
Resolves https://github.com/dashpay/dash/issues/7243


Recovered Signatures now are delivered to shareman over CValidationInterface (over NetHandler)

Call is done async over GetMainSignals().NotifyRecoveredSig()

It's a follow-up for https://github.com/dashpay/dash/pull/7115/
It's a replacement for https://github.com/dashpay/dash/pull/7244

## What was done?
Removed dead code


## How Has This Been Tested?
Run unit & functional tests

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

