### PR TITLE
test: fix flaky PoSe ban assertion in feature_llmq_simplepose

### DIFF
--- a/test/functional/feature_llmq_simplepose.py
+++ b/test/functional/feature_llmq_simplepose.py
@@ -203,7 +203,7 @@ class LLMQSimplePoSeTest(DashTestFramework):
                     if check_banned(self.nodes[0], mn):
                         break
 
-            assert check_banned(self.nodes[0], mn)
+            self.wait_until(lambda: check_banned(self.nodes[0], mn), timeout=10)
 
             if not went_offline:
                 # we do not include PoSe banned mns in quorums, so the next one should have 1 contributor less


### PR DESCRIPTION
## Summary

Fix a flaky assertion in `feature_llmq_simplepose.py` (line 206).

After 6 quorum rounds of penalty accumulation, the test used a bare `assert check_banned()` without polling. Under CPU contention, the PoSe ban state update (which happens during block validation) may not be visible via RPC immediately after `mine_quorum()` returns.

**Change:** `assert check_banned(...)` → `self.wait_until(lambda: check_banned(...), timeout=10)`

This is a classic polling fix — the assertion logic is identical, it just retries for up to 10 seconds instead of failing on the first check.

Split from #7233 to allow independent review.