### PR TITLE
fix: dangling point to cj client

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -502,7 +502,6 @@ libbitcoin_node_a_SOURCES = \
   chainlock/signing.cpp \
   coinjoin/coinjoin.cpp \
   coinjoin/server.cpp \
-  coinjoin/walletman.cpp \
   consensus/tx_verify.cpp \
   dbwrapper.cpp \
   deploymentstatus.cpp \
@@ -659,6 +658,7 @@ libbitcoin_wallet_a_SOURCES = \
   coinjoin/client.cpp \
   coinjoin/interfaces.cpp \
   coinjoin/util.cpp \
+  coinjoin/walletman.cpp \
   wallet/bip39.cpp \
   wallet/coinjoin.cpp \
   wallet/coincontrol.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -506,7 +506,6 @@ libbitcoin_node_a_SOURCES = \
   chainlock/signing.cpp \
   coinjoin/coinjoin.cpp \
   coinjoin/server.cpp \
-  coinjoin/walletman.cpp \
   consensus/tx_verify.cpp \
   dbwrapper.cpp \
   deploymentstatus.cpp \
@@ -665,6 +664,7 @@ libbitcoin_wallet_a_SOURCES = \
   coinjoin/client.cpp \
   coinjoin/interfaces.cpp \
   coinjoin/util.cpp \
+  coinjoin/walletman.cpp \
   wallet/bip39.cpp \
   wallet/coinjoin.cpp \
   wallet/coincontrol.cpp \

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -61,8 +61,8 @@ void CCoinJoinClientManager::ProcessMessage(CNode& peer, CChainState& active_cha
     if (!m_mn_sync.IsBlockchainSynced()) return;
 
     if (!CheckDiskSpace(gArgs.GetDataDirNet())) {
-        ResetPool();
-        StopMixing();
+        resetPool();
+        stopMixing();
         WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::ProcessMessage -- Not enough disk space, disabling CoinJoin.\n");
         return;
     }
@@ -137,16 +137,16 @@ void CCoinJoinClientSession::ProcessMessage(CNode& peer, CChainState& active_cha
     }
 }
 
-bool CCoinJoinClientManager::StartMixing() {
+bool CCoinJoinClientManager::startMixing() {
     bool expected{false};
     return fMixing.compare_exchange_strong(expected, true);
 }
 
-void CCoinJoinClientManager::StopMixing() {
+void CCoinJoinClientManager::stopMixing() {
     fMixing = false;
 }
 
-bool CCoinJoinClientManager::IsMixing() const
+bool CCoinJoinClientManager::isMixing() const
 {
     return fMixing;
 }
@@ -159,7 +159,7 @@ void CCoinJoinClientSession::ResetPool()
     WITH_LOCK(cs_coinjoin, SetNull());
 }
 
-void CCoinJoinClientManager::ResetPool()
+void CCoinJoinClientManager::resetPool()
 {
     nCachedLastSuccessBlock = 0;
     AssertLockNotHeld(cs_deqsessions);
@@ -241,7 +241,7 @@ bilingual_str CCoinJoinClientSession::GetStatus(bool fWaitForBlock) const
     }
 }
 
-std::vector<std::string> CCoinJoinClientManager::GetStatuses() const
+std::vector<std::string> CCoinJoinClientManager::getSessionStatuses() const
 {
     AssertLockNotHeld(cs_deqsessions);
 
@@ -255,7 +255,7 @@ std::vector<std::string> CCoinJoinClientManager::GetStatuses() const
     return ret;
 }
 
-std::string CCoinJoinClientManager::GetSessionDenoms()
+std::string CCoinJoinClientManager::getSessionDenoms() const
 {
     std::string strSessionDenoms;
 
@@ -328,7 +328,7 @@ void CCoinJoinClientManager::CheckTimeout()
 {
     AssertLockNotHeld(cs_deqsessions);
 
-    if (!CCoinJoinClientOptions::IsEnabled() || !IsMixing()) return;
+    if (!CCoinJoinClientOptions::IsEnabled() || !isMixing()) return;
 
     LOCK(cs_deqsessions);
     for (auto& session : deqSessions) {
@@ -605,7 +605,7 @@ bool CCoinJoinClientManager::WaitForAnotherBlock() const
 
 bool CCoinJoinClientManager::CheckAutomaticBackup()
 {
-    if (!CCoinJoinClientOptions::IsEnabled() || !IsMixing()) return false;
+    if (!CCoinJoinClientOptions::IsEnabled() || !isMixing()) return false;
 
     // We don't need auto-backups for descriptor wallets
     if (!m_wallet->IsLegacy()) return true;
@@ -614,7 +614,7 @@ bool CCoinJoinClientManager::CheckAutomaticBackup()
     case 0:
         strAutoDenomResult = _("Automatic backups disabled") + Untranslated(", ") + _("no mixing available.");
         WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::CheckAutomaticBackup -- %s\n", strAutoDenomResult.original);
-        StopMixing();
+        stopMixing();
         m_wallet->nKeysLeftSinceAutoBackup = 0; // no backup, no "keys since last backup"
         return false;
     case -1:
@@ -640,7 +640,7 @@ bool CCoinJoinClientManager::CheckAutomaticBackup()
                                        m_wallet->nKeysLeftSinceAutoBackup);
         WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::CheckAutomaticBackup -- %s\n", strAutoDenomResult.original);
         // It's getting really dangerous, stop mixing
-        StopMixing();
+        stopMixing();
         return false;
     } else if (m_wallet->nKeysLeftSinceAutoBackup < COINJOIN_KEYS_THRESHOLD_WARNING) {
         // Low number of keys left, but it's still more or less safe to continue
@@ -862,7 +862,7 @@ bool CCoinJoinClientSession::DoAutomaticDenominating(ChainstateManager& chainman
 bool CCoinJoinClientManager::DoAutomaticDenominating(ChainstateManager& chainman, CConnman& connman,
                                                      const CTxMemPool& mempool, bool fDryRun)
 {
-    if (!CCoinJoinClientOptions::IsEnabled() || !IsMixing()) return false;
+    if (!CCoinJoinClientOptions::IsEnabled() || !isMixing()) return false;
 
     if (!m_mn_sync.IsBlockchainSynced()) {
         strAutoDenomResult = _("Can't mix while sync in progress.");
@@ -1765,10 +1765,10 @@ void CCoinJoinClientSession::GetJsonInfo(UniValue& obj) const
     obj.pushKV("entries_count", GetEntriesCount());
 }
 
-void CCoinJoinClientManager::GetJsonInfo(UniValue& obj) const
+UniValue CCoinJoinClientManager::getJsonInfo() const
 {
-    assert(obj.isObject());
-    obj.pushKV("running", IsMixing());
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("running", isMixing());
 
     UniValue arrSessions(UniValue::VARR);
     AssertLockNotHeld(cs_deqsessions);
@@ -1781,5 +1781,6 @@ void CCoinJoinClientManager::GetJsonInfo(UniValue& obj) const
         }
     }
     obj.pushKV("sessions", arrSessions);
+    return obj;
 }
 

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -138,6 +138,10 @@ void CCoinJoinClientSession::ProcessMessage(CNode& peer, CChainState& active_cha
 }
 
 bool CCoinJoinClientManager::startMixing() {
+    // Refuse to start mixing on a wallet that is locked for mixing
+    if (m_wallet->IsLocked(/*fForMixing=*/true)) {
+        return false;
+    }
     bool expected{false};
     return fMixing.compare_exchange_strong(expected, true);
 }

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -138,21 +138,16 @@ void CCoinJoinClientSession::ProcessMessage(CNode& peer, CChainState& active_cha
 }
 
 bool CCoinJoinClientManager::startMixing() {
-    // Refuse to start mixing on a wallet that is locked for mixing
-    if (m_wallet->IsLocked(/*fForMixing=*/true)) {
-        return false;
-    }
-    bool expected{false};
-    return fMixing.compare_exchange_strong(expected, true);
+    return m_wallet->StartMixing();
 }
 
 void CCoinJoinClientManager::stopMixing() {
-    fMixing = false;
+    m_wallet->StopMixing();
 }
 
 bool CCoinJoinClientManager::isMixing() const
 {
-    return fMixing;
+    return m_wallet->IsMixing();
 }
 
 void CCoinJoinClientSession::ResetPool()

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -179,15 +179,15 @@ private:
     // Keep track of current block height
     int nCachedBlockHeight{0};
 
+    int nCachedNumBlocks{std::numeric_limits<int>::max()};    // used for the overview screen
+    bool fCreateAutoBackups{true}; // builtin support for automatic backups
+
     bool WaitForAnotherBlock() const;
 
     // Make sure we have enough keys since last backup
     bool CheckAutomaticBackup();
 
 public:
-    int nCachedNumBlocks{std::numeric_limits<int>::max()};    // used for the overview screen
-    bool fCreateAutoBackups{true}; // builtin support for automatic backups
-
     CCoinJoinClientManager() = delete;
     CCoinJoinClientManager(const CCoinJoinClientManager&) = delete;
     CCoinJoinClientManager& operator=(const CCoinJoinClientManager&) = delete;

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -8,6 +8,7 @@
 #include <coinjoin/coinjoin.h>
 #include <coinjoin/util.h>
 #include <evo/types.h>
+#include <interfaces/coinjoin.h>
 #include <util/translation.h>
 
 #include <atomic>
@@ -154,7 +155,7 @@ public:
 
 /** Used to keep track of current status of mixing pool
  */
-class CCoinJoinClientManager
+class CCoinJoinClientManager : public interfaces::CoinJoin::Client
 {
 private:
     const std::shared_ptr<wallet::CWallet> m_wallet;
@@ -230,6 +231,19 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
 
     void GetJsonInfo(UniValue& obj) const EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
+
+    // interfaces::CoinJoin::Client overrides
+    void resetCachedBlocks() override { nCachedNumBlocks = std::numeric_limits<int>::max(); }
+    void resetPool() override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions) { ResetPool(); }
+    int getCachedBlocks() override { return nCachedNumBlocks; }
+    void getJsonInfo(UniValue& obj) override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions) { GetJsonInfo(obj); }
+    std::vector<std::string> getSessionStatuses() override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions) { return GetStatuses(); }
+    std::string getSessionDenoms() override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions) { return GetSessionDenoms(); }
+    void setCachedBlocks(int nCachedBlocks) override { nCachedNumBlocks = nCachedBlocks; }
+    void disableAutobackups() override { fCreateAutoBackups = false; }
+    bool isMixing() override { return IsMixing(); }
+    bool startMixing() override { return StartMixing(); }
+    void stopMixing() override { StopMixing(); }
 };
 
 #endif // BITCOIN_COINJOIN_CLIENT_H

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -198,14 +198,6 @@ public:
 
     void ProcessMessage(CNode& peer, CChainState& active_chainstate, CConnman& connman, const CTxMemPool& mempool, std::string_view msg_type, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
 
-    bool StartMixing();
-    void StopMixing();
-    bool IsMixing() const;
-    void ResetPool() EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
-
-    std::vector<std::string> GetStatuses() const EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
-    std::string GetSessionDenoms() EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
-
     bool GetMixingMasternodesInfo(std::vector<CDeterministicMNCPtr>& vecDmnsRet) const EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
 
     /// Passively run mixing in the background according to the configuration in settings
@@ -230,20 +222,18 @@ public:
     void DoMaintenance(ChainstateManager& chainman, CConnman& connman, const CTxMemPool& mempool)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
 
-    void GetJsonInfo(UniValue& obj) const EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
-
     // interfaces::CoinJoin::Client overrides
     void resetCachedBlocks() override { nCachedNumBlocks = std::numeric_limits<int>::max(); }
-    void resetPool() override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions) { ResetPool(); }
-    int getCachedBlocks() override { return nCachedNumBlocks; }
-    void getJsonInfo(UniValue& obj) override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions) { GetJsonInfo(obj); }
-    std::vector<std::string> getSessionStatuses() override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions) { return GetStatuses(); }
-    std::string getSessionDenoms() override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions) { return GetSessionDenoms(); }
+    int getCachedBlocks() const override { return nCachedNumBlocks; }
     void setCachedBlocks(int nCachedBlocks) override { nCachedNumBlocks = nCachedBlocks; }
     void disableAutobackups() override { fCreateAutoBackups = false; }
-    bool isMixing() override { return IsMixing(); }
-    bool startMixing() override { return StartMixing(); }
-    void stopMixing() override { StopMixing(); }
+    void resetPool() override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
+    UniValue getJsonInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
+    std::vector<std::string> getSessionStatuses() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
+    std::string getSessionDenoms() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
+    bool isMixing() const override;
+    bool startMixing() override;
+    void stopMixing() override;
 };
 
 #endif // BITCOIN_COINJOIN_CLIENT_H

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -11,7 +11,6 @@
 #include <interfaces/coinjoin.h>
 #include <util/translation.h>
 
-#include <atomic>
 #include <deque>
 #include <memory>
 #include <ranges>
@@ -169,8 +168,6 @@ private:
     mutable Mutex cs_deqsessions;
     // TODO: or map<denom, CCoinJoinClientSession> ??
     std::deque<CCoinJoinClientSession> deqSessions GUARDED_BY(cs_deqsessions);
-
-    std::atomic<bool> fMixing{false};
 
     int nCachedLastSuccessBlock{0};
     int nMinBlocksToWait{1}; // how many blocks to wait for after one successful mixing tx in non-multisession mode

--- a/src/coinjoin/interfaces.cpp
+++ b/src/coinjoin/interfaces.cpp
@@ -20,60 +20,6 @@ using wallet::CWallet;
 namespace coinjoin {
 namespace {
 
-class CoinJoinClientImpl : public interfaces::CoinJoin::Client
-{
-    CCoinJoinClientManager& m_clientman;
-
-public:
-    explicit CoinJoinClientImpl(CCoinJoinClientManager& clientman)
-        : m_clientman(clientman) {}
-
-    void resetCachedBlocks() override
-    {
-        m_clientman.nCachedNumBlocks = std::numeric_limits<int>::max();
-    }
-    void resetPool() override
-    {
-        m_clientman.ResetPool();
-    }
-    void disableAutobackups() override
-    {
-        m_clientman.fCreateAutoBackups = false;
-    }
-    int getCachedBlocks() override
-    {
-        return m_clientman.nCachedNumBlocks;
-    }
-    void getJsonInfo(UniValue& obj) override
-    {
-        return m_clientman.GetJsonInfo(obj);
-    }
-    std::string getSessionDenoms() override
-    {
-        return m_clientman.GetSessionDenoms();
-    }
-    std::vector<std::string> getSessionStatuses() override
-    {
-        return m_clientman.GetStatuses();
-    }
-    void setCachedBlocks(int nCachedBlocks) override
-    {
-       m_clientman.nCachedNumBlocks = nCachedBlocks;
-    }
-    bool isMixing() override
-    {
-        return m_clientman.IsMixing();
-    }
-    bool startMixing() override
-    {
-        return m_clientman.StartMixing();
-    }
-    void stopMixing() override
-    {
-        m_clientman.StopMixing();
-    }
-};
-
 class CoinJoinLoaderImpl : public interfaces::CoinJoin::Loader
 {
 private:
@@ -109,10 +55,9 @@ public:
     {
         manager().flushWallet(name);
     }
-    std::unique_ptr<interfaces::CoinJoin::Client> GetClient(const std::string& name) override
+    interfaces::CoinJoin::Client* GetClient(const std::string& name) override
     {
-        auto clientman = manager().getClient(name);
-        return clientman ? std::make_unique<CoinJoinClientImpl>(*clientman) : nullptr;
+        return manager().getClient(name);
     }
 
     NodeContext& m_node;

--- a/src/coinjoin/interfaces.cpp
+++ b/src/coinjoin/interfaces.cpp
@@ -28,11 +28,6 @@ private:
         return *Assert(m_node.cj_walletman);
     }
 
-    interfaces::WalletLoader& wallet_loader()
-    {
-        return *Assert(m_node.wallet_loader);
-    }
-
 public:
     explicit CoinJoinLoaderImpl(NodeContext& node) :
         m_node(node)
@@ -44,12 +39,13 @@ public:
     void AddWallet(const std::shared_ptr<CWallet>& wallet) override
     {
         manager().addWallet(wallet);
-        g_wallet_init_interface.InitCoinJoinSettings(*this, wallet_loader());
+        manager().doForClient(wallet->GetName(), [](CCoinJoinClientManager& mgr) {
+            g_wallet_init_interface.InitCoinJoinSettings(mgr);
+        });
     }
     void RemoveWallet(const std::string& name) override
     {
         manager().removeWallet(name);
-        g_wallet_init_interface.InitCoinJoinSettings(*this, wallet_loader());
     }
     void FlushWallet(const std::string& name) override
     {

--- a/src/coinjoin/interfaces.cpp
+++ b/src/coinjoin/interfaces.cpp
@@ -51,7 +51,7 @@ public:
     {
         manager().flushWallet(name);
     }
-    bool WithClient(const std::string& name, std::function<void(interfaces::CoinJoin::Client&)> func) override
+    bool WithClient(const std::string& name, const std::function<void(interfaces::CoinJoin::Client&)>& func) override
     {
         return manager().doForClient(name, [&](CCoinJoinClientManager& mgr) { func(mgr); });
     }

--- a/src/coinjoin/interfaces.cpp
+++ b/src/coinjoin/interfaces.cpp
@@ -32,13 +32,13 @@ public:
     explicit CoinJoinLoaderImpl(NodeContext& node) :
         m_node(node)
     {
-        // Enablement will be re-evaluated when a wallet is added or removed
-        CCoinJoinClientOptions::SetEnabled(false);
+        CCoinJoinClientOptions::SetEnabled(gArgs.GetBoolArg("-enablecoinjoin", true));
     }
 
     void AddWallet(const std::shared_ptr<CWallet>& wallet) override
     {
         manager().addWallet(wallet);
+        if (!CCoinJoinClientOptions::IsEnabled()) return;
         manager().doForClient(wallet->GetName(), [](CCoinJoinClientManager& mgr) {
             g_wallet_init_interface.InitCoinJoinSettings(mgr);
         });

--- a/src/coinjoin/interfaces.cpp
+++ b/src/coinjoin/interfaces.cpp
@@ -55,9 +55,9 @@ public:
     {
         manager().flushWallet(name);
     }
-    interfaces::CoinJoin::Client* GetClient(const std::string& name) override
+    bool WithClient(const std::string& name, std::function<void(interfaces::CoinJoin::Client&)> func) override
     {
-        return manager().getClient(name);
+        return manager().doForClient(name, [&](CCoinJoinClientManager& mgr) { func(mgr); });
     }
 
     NodeContext& m_node;

--- a/src/coinjoin/walletman.cpp
+++ b/src/coinjoin/walletman.cpp
@@ -314,6 +314,6 @@ std::unique_ptr<CJWalletManager> CJWalletManager::make(ChainstateManager& chainm
     return std::make_unique<CJWalletManagerImpl>(chainman, dmnman, mn_metaman, mempool, mn_sync, isman, relay_txes);
 #else
     // Cannot be constructed if wallet support isn't built
-    return nullptr;
+    assert(false);
 #endif // ENABLE_WALLET
 }

--- a/src/coinjoin/walletman.cpp
+++ b/src/coinjoin/walletman.cpp
@@ -39,7 +39,7 @@ public:
 
 public:
     bool hasQueue(const uint256& hash) const override;
-    CCoinJoinClientManager* getClient(const std::string& name) override EXCLUSIVE_LOCKS_REQUIRED(!cs_wallet_manager_map);
+    bool doForClient(const std::string& name, const std::function<void(CCoinJoinClientManager&)>& func) override EXCLUSIVE_LOCKS_REQUIRED(!cs_wallet_manager_map);
     MessageProcessingResult processMessage(CNode& peer, CChainState& chainstate, CConnman& connman, CTxMemPool& mempool,
                                            std::string_view msg_type, CDataStream& vRecv) override EXCLUSIVE_LOCKS_REQUIRED(!cs_ProcessDSQueue, !cs_wallet_manager_map);
     std::optional<CCoinJoinQueue> getQueueFromHash(const uint256& hash) const override;
@@ -140,11 +140,13 @@ bool CJWalletManagerImpl::hasQueue(const uint256& hash) const
     return false;
 }
 
-CCoinJoinClientManager* CJWalletManagerImpl::getClient(const std::string& name)
+bool CJWalletManagerImpl::doForClient(const std::string& name, const std::function<void(CCoinJoinClientManager&)>& func)
 {
     LOCK(cs_wallet_manager_map);
     auto it = m_wallet_manager_map.find(name);
-    return (it != m_wallet_manager_map.end()) ? it->second.get() : nullptr;
+    if (it == m_wallet_manager_map.end()) return false;
+    func(*it->second);
+    return true;
 }
 
 std::optional<CCoinJoinQueue> CJWalletManagerImpl::getQueueFromHash(const uint256& hash) const
@@ -180,9 +182,10 @@ void CJWalletManagerImpl::addWallet(const std::shared_ptr<wallet::CWallet>& wall
 
 void CJWalletManagerImpl::flushWallet(const std::string& name)
 {
-    auto* clientman = Assert(getClient(name));
-    clientman->ResetPool();
-    clientman->StopMixing();
+    doForClient(name, [](CCoinJoinClientManager& clientman) {
+        clientman.ResetPool();
+        clientman.StopMixing();
+    });
 }
 
 void CJWalletManagerImpl::removeWallet(const std::string& name)

--- a/src/coinjoin/walletman.cpp
+++ b/src/coinjoin/walletman.cpp
@@ -183,8 +183,8 @@ void CJWalletManagerImpl::addWallet(const std::shared_ptr<wallet::CWallet>& wall
 void CJWalletManagerImpl::flushWallet(const std::string& name)
 {
     doForClient(name, [](CCoinJoinClientManager& clientman) {
-        clientman.ResetPool();
-        clientman.StopMixing();
+        clientman.resetPool();
+        clientman.stopMixing();
     });
 }
 

--- a/src/coinjoin/walletman.cpp
+++ b/src/coinjoin/walletman.cpp
@@ -306,17 +306,12 @@ MessageProcessingResult CJWalletManagerImpl::ProcessDSQueue(NodeId from, CConnma
     } // cs_ProcessDSQueue
     return ret;
 }
-#endif // ENABLE_WALLET
 
 std::unique_ptr<CJWalletManager> CJWalletManager::make(ChainstateManager& chainman, CDeterministicMNManager& dmnman,
                                                        CMasternodeMetaMan& mn_metaman, CTxMemPool& mempool,
                                                        const CMasternodeSync& mn_sync,
                                                        const llmq::CInstantSendManager& isman, bool relay_txes)
 {
-#ifdef ENABLE_WALLET
     return std::make_unique<CJWalletManagerImpl>(chainman, dmnman, mn_metaman, mempool, mn_sync, isman, relay_txes);
-#else
-    // Cannot be constructed if wallet support isn't built
-    assert(false);
-#endif // ENABLE_WALLET
 }
+#endif // ENABLE_WALLET

--- a/src/coinjoin/walletman.h
+++ b/src/coinjoin/walletman.h
@@ -10,6 +10,7 @@
 
 #include <validationinterface.h>
 
+#include <functional>
 #include <optional>
 #include <string_view>
 
@@ -47,7 +48,9 @@ public:
 
 public:
     virtual bool hasQueue(const uint256& hash) const = 0;
-    virtual CCoinJoinClientManager* getClient(const std::string& name) = 0;
+    //! Execute func under the wallet manager lock for the client identified by name.
+    //! Returns true if the client was found and func was called, false otherwise.
+    virtual bool doForClient(const std::string& name, const std::function<void(CCoinJoinClientManager&)>& func) = 0;
     virtual MessageProcessingResult processMessage(CNode& peer, CChainState& chainstate, CConnman& connman,
                                                    CTxMemPool& mempool, std::string_view msg_type, CDataStream& vRecv) = 0;
     virtual std::optional<CCoinJoinQueue> getQueueFromHash(const uint256& hash) const = 0;

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -34,7 +34,7 @@ public:
 
     // Dash Specific WalletInitInterface InitCoinJoinSettings
     void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const override {}
-    void InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const override {}
+    void InitCoinJoinSettings(CCoinJoinClientManager& mgr) const override {}
     void InitAutoBackup() const override {}
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2223,7 +2223,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         node.peerman->AddExtraHandler(std::move(cj_server));
     } else {
         assert(!node.cj_walletman);
-        // Can return nullptr if built without wallet support, must check before use
+        // Only constructed in wallet-enabled builds; stays null otherwise, must check before use
 #ifdef ENABLE_WALLET
         node.cj_walletman = CJWalletManager::make(chainman, *node.dmnman, *node.mn_metaman, *node.mempool, *node.mn_sync,
                                                   *node.llmq_ctx->isman, !ignores_incoming_txs);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2224,8 +2224,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     } else {
         assert(!node.cj_walletman);
         // Can return nullptr if built without wallet support, must check before use
+#ifdef ENABLE_WALLET
         node.cj_walletman = CJWalletManager::make(chainman, *node.dmnman, *node.mn_metaman, *node.mempool, *node.mn_sync,
                                                   *node.llmq_ctx->isman, !ignores_incoming_txs);
+#endif
     }
 
     if (node.cj_walletman) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2264,8 +2264,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     } else {
         assert(!node.cj_walletman);
         // Can return nullptr if built without wallet support, must check before use
+#ifdef ENABLE_WALLET
         node.cj_walletman = CJWalletManager::make(chainman, *node.dmnman, *node.mn_metaman, *node.mempool, *node.mn_sync,
                                                   *node.llmq_ctx->isman, !ignores_incoming_txs);
+#endif
     }
 
     if (node.cj_walletman) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2263,7 +2263,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         node.peerman->AddExtraHandler(std::move(cj_server));
     } else {
         assert(!node.cj_walletman);
-        // Can return nullptr if built without wallet support, must check before use
+        // Only constructed in wallet-enabled builds; stays null otherwise, must check before use
 #ifdef ENABLE_WALLET
         node.cj_walletman = CJWalletManager::make(chainman, *node.dmnman, *node.mn_metaman, *node.mempool, *node.mn_sync,
                                                   *node.llmq_ctx->isman, !ignores_incoming_txs);

--- a/src/interfaces/coinjoin.h
+++ b/src/interfaces/coinjoin.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_INTERFACES_COINJOIN_H
 #define BITCOIN_INTERFACES_COINJOIN_H
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -46,7 +47,9 @@ public:
     //! Remove wallet from CoinJoin client manager
     virtual void RemoveWallet(const std::string&) = 0;
     virtual void FlushWallet(const std::string&) = 0;
-    virtual Client* GetClient(const std::string&) = 0;
+    //! Execute a callback with the CoinJoin client for the given wallet, under the wallet manager lock.
+    //! Returns false if the wallet was not found.
+    virtual bool WithClient(const std::string& name, std::function<void(Client&)> func) = 0;
 };
 } // namespace CoinJoin
 

--- a/src/interfaces/coinjoin.h
+++ b/src/interfaces/coinjoin.h
@@ -46,7 +46,7 @@ public:
     //! Remove wallet from CoinJoin client manager
     virtual void RemoveWallet(const std::string&) = 0;
     virtual void FlushWallet(const std::string&) = 0;
-    virtual std::unique_ptr<CoinJoin::Client> GetClient(const std::string&) = 0;
+    virtual Client* GetClient(const std::string&) = 0;
 };
 } // namespace CoinJoin
 

--- a/src/interfaces/coinjoin.h
+++ b/src/interfaces/coinjoin.h
@@ -28,13 +28,13 @@ public:
     virtual ~Client() {}
     virtual void resetCachedBlocks() = 0;
     virtual void resetPool() = 0;
-    virtual int getCachedBlocks() = 0;
-    virtual void getJsonInfo(UniValue& obj) = 0;
-    virtual std::vector<std::string> getSessionStatuses() = 0;
-    virtual std::string getSessionDenoms() = 0;
+    virtual int getCachedBlocks() const = 0;
+    virtual UniValue getJsonInfo() const = 0;
+    virtual std::vector<std::string> getSessionStatuses() const = 0;
+    virtual std::string getSessionDenoms() const = 0;
     virtual void setCachedBlocks(int nCachedBlocks) = 0;
     virtual void disableAutobackups() = 0;
-    virtual bool isMixing() = 0;
+    virtual bool isMixing() const = 0;
     virtual bool startMixing() = 0;
     virtual void stopMixing() = 0;
 };

--- a/src/interfaces/coinjoin.h
+++ b/src/interfaces/coinjoin.h
@@ -49,7 +49,7 @@ public:
     virtual void FlushWallet(const std::string&) = 0;
     //! Execute a callback with the CoinJoin client for the given wallet, under the wallet manager lock.
     //! Returns false if the wallet was not found.
-    virtual bool WithClient(const std::string& name, std::function<void(Client&)> func) = 0;
+    virtual bool WithClient(const std::string& name, const std::function<void(Client&)>& func) = 0;
 };
 } // namespace CoinJoin
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1597,7 +1597,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QStri
 #ifdef ENABLE_WALLET
     if (enableWallet) {
         for (const auto& wallet : m_node.walletLoader().getWallets()) {
-            disableAppNap |= m_node.coinJoinLoader()->GetClient(wallet->getWalletName())->isMixing();
+            m_node.coinJoinLoader()->WithClient(wallet->getWalletName(), [&](auto& client) { disableAppNap |= client.isMixing(); });
         }
     }
 #endif // ENABLE_WALLET

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1608,7 +1608,7 @@ void BitcoinGUI::setNumBlocks(int count, const QDateTime& blockDate, const QStri
 #ifdef ENABLE_WALLET
     if (enableWallet) {
         for (const auto& wallet : m_node.walletLoader().getWallets()) {
-            disableAppNap |= m_node.coinJoinLoader()->GetClient(wallet->getWalletName())->isMixing();
+            m_node.coinJoinLoader()->WithClient(wallet->getWalletName(), [&](auto& client) { disableAppNap |= client.isMixing(); });
         }
     }
 #endif // ENABLE_WALLET

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -465,7 +465,7 @@ void OptionsDialog::on_okButton_clicked()
 #ifdef ENABLE_WALLET
     if (m_enable_wallet) {
         for (auto& wallet : model->node().walletLoader().getWallets()) {
-            model->node().coinJoinLoader()->GetClient(wallet->getWalletName())->resetCachedBlocks();
+            model->node().coinJoinLoader()->WithClient(wallet->getWalletName(), [](auto& client) { client.resetCachedBlocks(); });
             wallet->markDirty();
         }
     }

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -459,7 +459,7 @@ void OptionsDialog::on_okButton_clicked()
 #ifdef ENABLE_WALLET
     if (m_enable_wallet) {
         for (auto& wallet : model->node().walletLoader().getWallets()) {
-            model->node().coinJoinLoader()->GetClient(wallet->getWalletName())->resetCachedBlocks();
+            model->node().coinJoinLoader()->WithClient(wallet->getWalletName(), [](auto& client) { client.resetCachedBlocks(); });
             wallet->markDirty();
         }
     }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -337,7 +337,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         // Disable coinJoinClient builtin support for automatic backups while we are in GUI,
         // we'll handle automatic backups and user warnings in coinJoinStatus()
-        walletModel->coinJoin()->disableAutobackups();
+        walletModel->withCoinJoin([](auto& client) { client.disableAutobackups(); });
 
         connect(ui->toggleCoinJoin, &QPushButton::clicked, this, &OverviewPage::toggleCoinJoin);
 
@@ -578,7 +578,11 @@ void OverviewPage::coinJoinStatus(bool fForce)
     int nBestHeight = clientModel->node().getNumBlocks();
 
     // We are processing more than 1 block per second, we'll just leave
-    if (nBestHeight > walletModel->coinJoin()->getCachedBlocks() && GetTime() - nLastDSProgressBlockTime <= 1) return;
+    bool tooFast{false};
+    walletModel->withCoinJoin([&](auto& client) {
+        tooFast = nBestHeight > client.getCachedBlocks() && GetTime() - nLastDSProgressBlockTime <= 1;
+    });
+    if (tooFast) return;
     nLastDSProgressBlockTime = GetTime();
 
     QString strKeysLeftText(tr("keys left: %1").arg(walletModel->getKeysLeftSinceAutoBackup()));
@@ -592,12 +596,15 @@ void OverviewPage::coinJoinStatus(bool fForce)
     ui->labelCoinJoinEnabled->setToolTip(strKeysLeftText);
 
     QString strCoinJoinName = QString::fromStdString(gCoinJoinName);
-    if (!walletModel->coinJoin()->isMixing()) {
-        if (nBestHeight != walletModel->coinJoin()->getCachedBlocks()) {
-            walletModel->coinJoin()->setCachedBlocks(nBestHeight);
+    bool notMixing{false};
+    walletModel->withCoinJoin([&](auto& client) {
+        notMixing = !client.isMixing();
+        if (notMixing && nBestHeight != client.getCachedBlocks()) {
+            client.setCachedBlocks(nBestHeight);
             updateCoinJoinProgress();
         }
-
+    });
+    if (notMixing) {
         setWidgetsVisible(false);
         ui->toggleCoinJoin->setText(tr("Start %1").arg(strCoinJoinName));
 
@@ -655,7 +662,8 @@ void OverviewPage::coinJoinStatus(bool fForce)
         }
     }
 
-    QString strEnabled = walletModel->coinJoin()->isMixing() ? tr("Enabled") : tr("Disabled");
+    QString strEnabled;
+    walletModel->withCoinJoin([&](auto& client) { strEnabled = client.isMixing() ? tr("Enabled") : tr("Disabled"); });
     // Show how many keys left in advanced PS UI mode only
     if(fShowAdvancedCJUI && !strKeysLeftText.isEmpty()) strEnabled += ", " + strKeysLeftText;
     ui->labelCoinJoinEnabled->setText(strEnabled);
@@ -679,15 +687,16 @@ void OverviewPage::coinJoinStatus(bool fForce)
     }
 
     // check coinjoin status and unlock if needed
-    if(nBestHeight != walletModel->coinJoin()->getCachedBlocks()) {
-        // Balance and number of transactions might have changed
-        walletModel->coinJoin()->setCachedBlocks(nBestHeight);
-        updateCoinJoinProgress();
-    }
+    walletModel->withCoinJoin([&](auto& client) {
+        if (nBestHeight != client.getCachedBlocks()) {
+            // Balance and number of transactions might have changed
+            client.setCachedBlocks(nBestHeight);
+            updateCoinJoinProgress();
+        }
+        ui->labelSubmittedDenom->setText(m_privacy ? "####" : QString(client.getSessionDenoms().c_str()));
+    });
 
     setWidgetsVisible(true);
-
-    ui->labelSubmittedDenom->setText(m_privacy ? "####" : QString(walletModel->coinJoin()->getSessionDenoms().c_str()));
 }
 
 void OverviewPage::toggleCoinJoin(){
@@ -702,7 +711,9 @@ void OverviewPage::toggleCoinJoin(){
         settings.setValue("hasMixed", "hasMixed");
     }
 
-    if (!walletModel->coinJoin()->isMixing()) {
+    bool mixing{false};
+    walletModel->withCoinJoin([&](auto& client) { mixing = client.isMixing(); });
+    if (!mixing) {
         auto& options = walletModel->node().coinJoinOptions();
         const CAmount nMinAmount = options.getSmallestDenomination() + options.getMaxCollateralAmount();
         if(m_balances.balance < nMinAmount) {
@@ -720,7 +731,7 @@ void OverviewPage::toggleCoinJoin(){
             if(!ctx.isValid())
             {
                 //unlock was cancelled
-                walletModel->coinJoin()->resetCachedBlocks();
+                walletModel->withCoinJoin([](auto& client) { client.resetCachedBlocks(); });
                 QMessageBox::warning(this, strCoinJoinName,
                     tr("Wallet is locked and user declined to unlock. Disabling %1.").arg(strCoinJoinName),
                     QMessageBox::Ok, QMessageBox::Ok);
@@ -731,16 +742,17 @@ void OverviewPage::toggleCoinJoin(){
 
     }
 
-    walletModel->coinJoin()->resetCachedBlocks();
-
-    if (walletModel->coinJoin()->isMixing()) {
-        ui->toggleCoinJoin->setText(tr("Start %1").arg(strCoinJoinName));
-        walletModel->coinJoin()->resetPool();
-        walletModel->coinJoin()->stopMixing();
-    } else {
-        ui->toggleCoinJoin->setText(tr("Stop %1").arg(strCoinJoinName));
-        walletModel->coinJoin()->startMixing();
-    }
+    walletModel->withCoinJoin([&](auto& client) {
+        client.resetCachedBlocks();
+        if (client.isMixing()) {
+            ui->toggleCoinJoin->setText(tr("Start %1").arg(strCoinJoinName));
+            client.resetPool();
+            client.stopMixing();
+        } else {
+            ui->toggleCoinJoin->setText(tr("Stop %1").arg(strCoinJoinName));
+            client.startMixing();
+        }
+    });
 }
 
 void OverviewPage::SetupTransactionList(int nNumItems)
@@ -779,5 +791,5 @@ void OverviewPage::DisableCoinJoinCompletely()
     if (nWalletBackups <= 0) {
         ui->labelCoinJoinEnabled->setText("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>(" + tr("Disabled") + ")</span>");
     }
-    walletModel->coinJoin()->stopMixing();
+    walletModel->withCoinJoin([](auto& client) { client.stopMixing(); });
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -597,13 +597,15 @@ void OverviewPage::coinJoinStatus(bool fForce)
 
     QString strCoinJoinName = QString::fromStdString(gCoinJoinName);
     bool notMixing{false};
+    bool refreshProgress{false};
     walletModel->withCoinJoin([&](auto& client) {
         notMixing = !client.isMixing();
         if (notMixing && nBestHeight != client.getCachedBlocks()) {
             client.setCachedBlocks(nBestHeight);
-            updateCoinJoinProgress();
+            refreshProgress = true;
         }
     });
+    if (refreshProgress) updateCoinJoinProgress();
     if (notMixing) {
         setWidgetsVisible(false);
         ui->toggleCoinJoin->setText(tr("Start %1").arg(strCoinJoinName));
@@ -687,14 +689,16 @@ void OverviewPage::coinJoinStatus(bool fForce)
     }
 
     // check coinjoin status and unlock if needed
+    bool refreshProgressTail{false};
     walletModel->withCoinJoin([&](auto& client) {
         if (nBestHeight != client.getCachedBlocks()) {
             // Balance and number of transactions might have changed
             client.setCachedBlocks(nBestHeight);
-            updateCoinJoinProgress();
+            refreshProgressTail = true;
         }
         ui->labelSubmittedDenom->setText(m_privacy ? "####" : QString(client.getSessionDenoms().c_str()));
     });
+    if (refreshProgressTail) updateCoinJoinProgress();
 
     setWidgetsVisible(true);
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -596,13 +596,15 @@ void OverviewPage::coinJoinStatus(bool fForce)
 
     QString strCoinJoinName = QString::fromStdString(gCoinJoinName);
     bool notMixing{false};
+    bool refreshProgress{false};
     walletModel->withCoinJoin([&](auto& client) {
         notMixing = !client.isMixing();
         if (notMixing && nBestHeight != client.getCachedBlocks()) {
             client.setCachedBlocks(nBestHeight);
-            updateCoinJoinProgress();
+            refreshProgress = true;
         }
     });
+    if (refreshProgress) updateCoinJoinProgress();
     if (notMixing) {
         setWidgetsVisible(false);
         ui->toggleCoinJoin->setText(tr("Start %1").arg(strCoinJoinName));
@@ -686,14 +688,16 @@ void OverviewPage::coinJoinStatus(bool fForce)
     }
 
     // check coinjoin status and unlock if needed
+    bool refreshProgressTail{false};
     walletModel->withCoinJoin([&](auto& client) {
         if (nBestHeight != client.getCachedBlocks()) {
             // Balance and number of transactions might have changed
             client.setCachedBlocks(nBestHeight);
-            updateCoinJoinProgress();
+            refreshProgressTail = true;
         }
         ui->labelSubmittedDenom->setText(m_privacy ? "####" : QString(client.getSessionDenoms().c_str()));
     });
+    if (refreshProgressTail) updateCoinJoinProgress();
 
     setWidgetsVisible(true);
 }

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -336,7 +336,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         // Disable coinJoinClient builtin support for automatic backups while we are in GUI,
         // we'll handle automatic backups and user warnings in coinJoinStatus()
-        walletModel->coinJoin()->disableAutobackups();
+        walletModel->withCoinJoin([](auto& client) { client.disableAutobackups(); });
 
         connect(ui->toggleCoinJoin, &QPushButton::clicked, this, &OverviewPage::toggleCoinJoin);
 
@@ -577,7 +577,11 @@ void OverviewPage::coinJoinStatus(bool fForce)
     int nBestHeight = clientModel->node().getNumBlocks();
 
     // We are processing more than 1 block per second, we'll just leave
-    if (nBestHeight > walletModel->coinJoin()->getCachedBlocks() && GetTime() - nLastDSProgressBlockTime <= 1) return;
+    bool tooFast{false};
+    walletModel->withCoinJoin([&](auto& client) {
+        tooFast = nBestHeight > client.getCachedBlocks() && GetTime() - nLastDSProgressBlockTime <= 1;
+    });
+    if (tooFast) return;
     nLastDSProgressBlockTime = GetTime();
 
     QString strKeysLeftText(tr("keys left: %1").arg(walletModel->getKeysLeftSinceAutoBackup()));
@@ -591,12 +595,15 @@ void OverviewPage::coinJoinStatus(bool fForce)
     ui->labelCoinJoinEnabled->setToolTip(strKeysLeftText);
 
     QString strCoinJoinName = QString::fromStdString(gCoinJoinName);
-    if (!walletModel->coinJoin()->isMixing()) {
-        if (nBestHeight != walletModel->coinJoin()->getCachedBlocks()) {
-            walletModel->coinJoin()->setCachedBlocks(nBestHeight);
+    bool notMixing{false};
+    walletModel->withCoinJoin([&](auto& client) {
+        notMixing = !client.isMixing();
+        if (notMixing && nBestHeight != client.getCachedBlocks()) {
+            client.setCachedBlocks(nBestHeight);
             updateCoinJoinProgress();
         }
-
+    });
+    if (notMixing) {
         setWidgetsVisible(false);
         ui->toggleCoinJoin->setText(tr("Start %1").arg(strCoinJoinName));
 
@@ -654,7 +661,8 @@ void OverviewPage::coinJoinStatus(bool fForce)
         }
     }
 
-    QString strEnabled = walletModel->coinJoin()->isMixing() ? tr("Enabled") : tr("Disabled");
+    QString strEnabled;
+    walletModel->withCoinJoin([&](auto& client) { strEnabled = client.isMixing() ? tr("Enabled") : tr("Disabled"); });
     // Show how many keys left in advanced PS UI mode only
     if(fShowAdvancedCJUI && !strKeysLeftText.isEmpty()) strEnabled += ", " + strKeysLeftText;
     ui->labelCoinJoinEnabled->setText(strEnabled);
@@ -678,15 +686,16 @@ void OverviewPage::coinJoinStatus(bool fForce)
     }
 
     // check coinjoin status and unlock if needed
-    if(nBestHeight != walletModel->coinJoin()->getCachedBlocks()) {
-        // Balance and number of transactions might have changed
-        walletModel->coinJoin()->setCachedBlocks(nBestHeight);
-        updateCoinJoinProgress();
-    }
+    walletModel->withCoinJoin([&](auto& client) {
+        if (nBestHeight != client.getCachedBlocks()) {
+            // Balance and number of transactions might have changed
+            client.setCachedBlocks(nBestHeight);
+            updateCoinJoinProgress();
+        }
+        ui->labelSubmittedDenom->setText(m_privacy ? "####" : QString(client.getSessionDenoms().c_str()));
+    });
 
     setWidgetsVisible(true);
-
-    ui->labelSubmittedDenom->setText(m_privacy ? "####" : QString(walletModel->coinJoin()->getSessionDenoms().c_str()));
 }
 
 void OverviewPage::toggleCoinJoin(){
@@ -701,7 +710,9 @@ void OverviewPage::toggleCoinJoin(){
         settings.setValue("hasMixed", "hasMixed");
     }
 
-    if (!walletModel->coinJoin()->isMixing()) {
+    bool mixing{false};
+    walletModel->withCoinJoin([&](auto& client) { mixing = client.isMixing(); });
+    if (!mixing) {
         auto& options = walletModel->node().coinJoinOptions();
         const CAmount nMinAmount = options.getSmallestDenomination() + options.getMaxCollateralAmount();
         if(m_balances.balance < nMinAmount) {
@@ -719,7 +730,7 @@ void OverviewPage::toggleCoinJoin(){
             if(!ctx.isValid())
             {
                 //unlock was cancelled
-                walletModel->coinJoin()->resetCachedBlocks();
+                walletModel->withCoinJoin([](auto& client) { client.resetCachedBlocks(); });
                 QMessageBox::warning(this, strCoinJoinName,
                     tr("Wallet is locked and user declined to unlock. Disabling %1.").arg(strCoinJoinName),
                     QMessageBox::Ok, QMessageBox::Ok);
@@ -730,16 +741,17 @@ void OverviewPage::toggleCoinJoin(){
 
     }
 
-    walletModel->coinJoin()->resetCachedBlocks();
-
-    if (walletModel->coinJoin()->isMixing()) {
-        ui->toggleCoinJoin->setText(tr("Start %1").arg(strCoinJoinName));
-        walletModel->coinJoin()->resetPool();
-        walletModel->coinJoin()->stopMixing();
-    } else {
-        ui->toggleCoinJoin->setText(tr("Stop %1").arg(strCoinJoinName));
-        walletModel->coinJoin()->startMixing();
-    }
+    walletModel->withCoinJoin([&](auto& client) {
+        client.resetCachedBlocks();
+        if (client.isMixing()) {
+            ui->toggleCoinJoin->setText(tr("Start %1").arg(strCoinJoinName));
+            client.resetPool();
+            client.stopMixing();
+        } else {
+            ui->toggleCoinJoin->setText(tr("Stop %1").arg(strCoinJoinName));
+            client.startMixing();
+        }
+    });
 }
 
 void OverviewPage::SetupTransactionList(int nNumItems)
@@ -778,5 +790,5 @@ void OverviewPage::DisableCoinJoinCompletely()
     if (nWalletBackups <= 0) {
         ui->labelCoinJoinEnabled->setText("<span style='" + GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR) + "'>(" + tr("Disabled") + ")</span>");
     }
-    walletModel->coinJoin()->stopMixing();
+    walletModel->withCoinJoin([](auto& client) { client.stopMixing(); });
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -87,9 +87,9 @@ void WalletModel::setClientModel(ClientModel* client_model)
     if (!m_client_model) timer->stop();
 }
 
-bool WalletModel::withCoinJoin(std::function<void(interfaces::CoinJoin::Client&)> func) const
+bool WalletModel::withCoinJoin(const std::function<void(interfaces::CoinJoin::Client&)>& func) const
 {
-    return m_node.coinJoinLoader()->WithClient(m_wallet->getWalletName(), std::move(func));
+    return m_node.coinJoinLoader()->WithClient(m_wallet->getWalletName(), func);
 }
 
 void WalletModel::updateStatus()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -87,9 +87,9 @@ void WalletModel::setClientModel(ClientModel* client_model)
     if (!m_client_model) timer->stop();
 }
 
-interfaces::CoinJoin::Client* WalletModel::coinJoin() const
+bool WalletModel::withCoinJoin(std::function<void(interfaces::CoinJoin::Client&)> func) const
 {
-    return m_node.coinJoinLoader()->GetClient(m_wallet->getWalletName());
+    return m_node.coinJoinLoader()->WithClient(m_wallet->getWalletName(), std::move(func));
 }
 
 void WalletModel::updateStatus()

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -87,7 +87,7 @@ void WalletModel::setClientModel(ClientModel* client_model)
     if (!m_client_model) timer->stop();
 }
 
-std::unique_ptr<interfaces::CoinJoin::Client> WalletModel::coinJoin() const
+interfaces::CoinJoin::Client* WalletModel::coinJoin() const
 {
     return m_node.coinJoinLoader()->GetClient(m_wallet->getWalletName());
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -154,7 +154,7 @@ public:
     interfaces::Node& node() const { return m_node; }
     interfaces::Wallet& wallet() const { return *m_wallet; }
     void setClientModel(ClientModel* client_model);
-    bool withCoinJoin(std::function<void(interfaces::CoinJoin::Client&)> func) const;
+    bool withCoinJoin(const std::function<void(interfaces::CoinJoin::Client&)>& func) const;
 
     QString getWalletName() const;
     QString getDisplayName() const;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -153,7 +153,7 @@ public:
     interfaces::Node& node() const { return m_node; }
     interfaces::Wallet& wallet() const { return *m_wallet; }
     void setClientModel(ClientModel* client_model);
-    std::unique_ptr<interfaces::CoinJoin::Client> coinJoin() const;
+    interfaces::CoinJoin::Client* coinJoin() const;
 
     QString getWalletName() const;
     QString getDisplayName() const;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -17,6 +17,7 @@
 #include <interfaces/wallet.h>
 #include <support/allocators/secure.h>
 
+#include <functional>
 #include <vector>
 
 #include <QObject>
@@ -153,7 +154,7 @@ public:
     interfaces::Node& node() const { return m_node; }
     interfaces::Wallet& wallet() const { return *m_wallet; }
     void setClientModel(ClientModel* client_model);
-    interfaces::CoinJoin::Client* coinJoin() const;
+    bool withCoinJoin(std::function<void(interfaces::CoinJoin::Client&)> func) const;
 
     QString getWalletName() const;
     QString getDisplayName() const;

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -487,7 +487,7 @@ static RPCHelpMan getcoinjoininfo()
     }
 
     CHECK_NONFATAL(CHECK_NONFATAL(node.coinjoin_loader)->WithClient(wallet->GetName(), [&](auto& client) {
-        client.getJsonInfo(obj);
+        obj.pushKVs(client.getJsonInfo());
     }));
 
     std::string warning_msg;

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -93,8 +93,9 @@ static RPCHelpMan coinjoin_reset()
 
     ValidateCoinJoinArguments();
 
-    auto cj_clientman = CHECK_NONFATAL(node.coinjoin_loader)->GetClient(wallet->GetName());
-    CHECK_NONFATAL(cj_clientman)->resetPool();
+    CHECK_NONFATAL(CHECK_NONFATAL(node.coinjoin_loader)->WithClient(wallet->GetName(), [](auto& client) {
+        client.resetPool();
+    }));
 
     return "Mixing was reset";
 },
@@ -133,10 +134,11 @@ static RPCHelpMan coinjoin_start()
             throw JSONRPCError(RPC_WALLET_UNLOCK_NEEDED, "Error: Please unlock wallet for mixing with walletpassphrase first.");
     }
 
-    auto cj_clientman = CHECK_NONFATAL(CHECK_NONFATAL(node.coinjoin_loader)->GetClient(wallet->GetName()));
-    if (!cj_clientman->startMixing()) {
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing has been started already.");
-    }
+    CHECK_NONFATAL(CHECK_NONFATAL(node.coinjoin_loader)->WithClient(wallet->GetName(), [](auto& client) {
+        if (!client.startMixing()) {
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "Mixing has been started already.");
+        }
+    }));
 
     return "Mixing requested";
 },
@@ -168,15 +170,15 @@ static RPCHelpMan coinjoin_status()
 
     ValidateCoinJoinArguments();
 
-    auto cj_clientman = CHECK_NONFATAL(node.coinjoin_loader)->GetClient(wallet->GetName());
-    if (!CHECK_NONFATAL(cj_clientman)->isMixing()) {
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "No ongoing mix session");
-    }
-
     UniValue ret(UniValue::VARR);
-    for (const auto& str_status : cj_clientman->getSessionStatuses()) {
-        ret.push_back(str_status);
-    }
+    CHECK_NONFATAL(CHECK_NONFATAL(node.coinjoin_loader)->WithClient(wallet->GetName(), [&](auto& client) {
+        if (!client.isMixing()) {
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "No ongoing mix session");
+        }
+        for (const auto& str_status : client.getSessionStatuses()) {
+            ret.push_back(str_status);
+        }
+    }));
     return ret;
 },
     };
@@ -207,14 +209,12 @@ static RPCHelpMan coinjoin_stop()
 
     ValidateCoinJoinArguments();
 
-    CHECK_NONFATAL(node.coinjoin_loader);
-    auto cj_clientman = node.coinjoin_loader->GetClient(wallet->GetName());
-
-    CHECK_NONFATAL(cj_clientman);
-    if (!cj_clientman->isMixing()) {
-        throw JSONRPCError(RPC_INTERNAL_ERROR, "No mix session to stop");
-    }
-    cj_clientman->stopMixing();
+    CHECK_NONFATAL(CHECK_NONFATAL(node.coinjoin_loader)->WithClient(wallet->GetName(), [](auto& client) {
+        if (!client.isMixing()) {
+            throw JSONRPCError(RPC_INTERNAL_ERROR, "No mix session to stop");
+        }
+        client.stopMixing();
+    }));
 
     return "Mixing was stopped";
 },
@@ -278,11 +278,12 @@ static RPCHelpMan coinjoinsalt_generate()
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if (node.coinjoin_loader != nullptr) {
-        auto cj_clientman = node.coinjoin_loader->GetClient(wallet->GetName());
-        if (cj_clientman != nullptr && cj_clientman->isMixing()) {
-            throw JSONRPCError(RPC_WALLET_ERROR,
-                               strprintf("Wallet \"%s\" is currently mixing, cannot change salt!", str_wallet));
-        }
+        node.coinjoin_loader->WithClient(wallet->GetName(), [&](auto& client) {
+            if (client.isMixing()) {
+                throw JSONRPCError(RPC_WALLET_ERROR,
+                                   strprintf("Wallet \"%s\" is currently mixing, cannot change salt!", str_wallet));
+            }
+        });
     }
 
     const auto wallet_balance{GetBalance(*wallet)};
@@ -380,11 +381,12 @@ static RPCHelpMan coinjoinsalt_set()
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
     if (node.coinjoin_loader != nullptr) {
-        auto cj_clientman = node.coinjoin_loader->GetClient(wallet->GetName());
-        if (cj_clientman != nullptr && cj_clientman->isMixing()) {
-            throw JSONRPCError(RPC_WALLET_ERROR,
-                               strprintf("Wallet \"%s\" is currently mixing, cannot change salt!", str_wallet));
-        }
+        node.coinjoin_loader->WithClient(wallet->GetName(), [&](auto& client) {
+            if (client.isMixing()) {
+                throw JSONRPCError(RPC_WALLET_ERROR,
+                                   strprintf("Wallet \"%s\" is currently mixing, cannot change salt!", str_wallet));
+            }
+        });
     }
 
     const auto wallet_balance{GetBalance(*wallet)};
@@ -484,8 +486,9 @@ static RPCHelpMan getcoinjoininfo()
         return obj;
     }
 
-    auto cj_clientman = CHECK_NONFATAL(node.coinjoin_loader)->GetClient(wallet->GetName());
-    CHECK_NONFATAL(cj_clientman)->getJsonInfo(obj);
+    CHECK_NONFATAL(CHECK_NONFATAL(node.coinjoin_loader)->WithClient(wallet->GetName(), [&](auto& client) {
+        client.getJsonInfo(obj);
+    }));
 
     std::string warning_msg;
     if (wallet->IsLegacy()) {

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -51,7 +51,7 @@ public:
 
     // Dash Specific Wallet Init
     void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const override;
-    void InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const override;
+    void InitCoinJoinSettings(CCoinJoinClientManager& mgr) const override;
     void InitAutoBackup() const override;
 };
 
@@ -201,24 +201,15 @@ void WalletInit::AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_
     }
 }
 
-void WalletInit::InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const
+void WalletInit::InitCoinJoinSettings(CCoinJoinClientManager& mgr) const
 {
-    const auto& wallets{wallet_loader.getWallets()};
-    CCoinJoinClientOptions::SetEnabled(!wallets.empty() ? gArgs.GetBoolArg("-enablecoinjoin", true) : false);
+    CCoinJoinClientOptions::SetEnabled(gArgs.GetBoolArg("-enablecoinjoin", true));
     if (!CCoinJoinClientOptions::IsEnabled()) {
         return;
     }
     bool fAutoStart = gArgs.GetBoolArg("-coinjoinautostart", DEFAULT_COINJOIN_AUTOSTART);
-    for (auto& wallet : wallets) {
-        coinjoin_loader.WithClient(wallet->getWalletName(), [&](auto& client) {
-            if (wallet->isLocked(/*fForMixing=*/false)) {
-                client.stopMixing();
-                LogPrintf("CoinJoin: Mixing stopped for locked wallet \"%s\"\n", wallet->getWalletName());
-            } else if (fAutoStart) {
-                client.startMixing();
-                LogPrintf("CoinJoin: Automatic mixing started for wallet \"%s\"\n", wallet->getWalletName());
-            }
-        });
+    if (fAutoStart) {
+        mgr.startMixing();
     }
     LogPrintf("CoinJoin: autostart=%d, multisession=%d," /* Continued */
               "sessions=%d, rounds=%d, amount=%d, denoms_goal=%d, denoms_hardcap=%d\n",

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -210,14 +210,15 @@ void WalletInit::InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loa
     }
     bool fAutoStart = gArgs.GetBoolArg("-coinjoinautostart", DEFAULT_COINJOIN_AUTOSTART);
     for (auto& wallet : wallets) {
-        auto manager = Assert(coinjoin_loader.GetClient(wallet->getWalletName()));
-        if (wallet->isLocked(/*fForMixing=*/false)) {
-            manager->stopMixing();
-            LogPrintf("CoinJoin: Mixing stopped for locked wallet \"%s\"\n", wallet->getWalletName());
-        } else if (fAutoStart) {
-            manager->startMixing();
-            LogPrintf("CoinJoin: Automatic mixing started for wallet \"%s\"\n", wallet->getWalletName());
-        }
+        coinjoin_loader.WithClient(wallet->getWalletName(), [&](auto& client) {
+            if (wallet->isLocked(/*fForMixing=*/false)) {
+                client.stopMixing();
+                LogPrintf("CoinJoin: Mixing stopped for locked wallet \"%s\"\n", wallet->getWalletName());
+            } else if (fAutoStart) {
+                client.startMixing();
+                LogPrintf("CoinJoin: Automatic mixing started for wallet \"%s\"\n", wallet->getWalletName());
+            }
+        });
     }
     LogPrintf("CoinJoin: autostart=%d, multisession=%d," /* Continued */
               "sessions=%d, rounds=%d, amount=%d, denoms_goal=%d, denoms_hardcap=%d\n",

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -203,10 +203,6 @@ void WalletInit::AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_
 
 void WalletInit::InitCoinJoinSettings(CCoinJoinClientManager& mgr) const
 {
-    CCoinJoinClientOptions::SetEnabled(gArgs.GetBoolArg("-enablecoinjoin", true));
-    if (!CCoinJoinClientOptions::IsEnabled()) {
-        return;
-    }
     bool fAutoStart = gArgs.GetBoolArg("-coinjoinautostart", DEFAULT_COINJOIN_AUTOSTART);
     if (fAutoStart) {
         mgr.startMixing();

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -200,10 +200,6 @@ void WalletInit::AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_
 
 void WalletInit::InitCoinJoinSettings(CCoinJoinClientManager& mgr) const
 {
-    CCoinJoinClientOptions::SetEnabled(gArgs.GetBoolArg("-enablecoinjoin", true));
-    if (!CCoinJoinClientOptions::IsEnabled()) {
-        return;
-    }
     bool fAutoStart = gArgs.GetBoolArg("-coinjoinautostart", DEFAULT_COINJOIN_AUTOSTART);
     if (fAutoStart) {
         mgr.startMixing();

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -51,7 +51,7 @@ public:
 
     // Dash Specific Wallet Init
     void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const override;
-    void InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const override;
+    void InitCoinJoinSettings(CCoinJoinClientManager& mgr) const override;
     void InitAutoBackup() const override;
 };
 
@@ -198,24 +198,15 @@ void WalletInit::AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_
     }
 }
 
-void WalletInit::InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const
+void WalletInit::InitCoinJoinSettings(CCoinJoinClientManager& mgr) const
 {
-    const auto& wallets{wallet_loader.getWallets()};
-    CCoinJoinClientOptions::SetEnabled(!wallets.empty() ? gArgs.GetBoolArg("-enablecoinjoin", true) : false);
+    CCoinJoinClientOptions::SetEnabled(gArgs.GetBoolArg("-enablecoinjoin", true));
     if (!CCoinJoinClientOptions::IsEnabled()) {
         return;
     }
     bool fAutoStart = gArgs.GetBoolArg("-coinjoinautostart", DEFAULT_COINJOIN_AUTOSTART);
-    for (auto& wallet : wallets) {
-        coinjoin_loader.WithClient(wallet->getWalletName(), [&](auto& client) {
-            if (wallet->isLocked(/*fForMixing=*/false)) {
-                client.stopMixing();
-                LogPrintf("CoinJoin: Mixing stopped for locked wallet \"%s\"\n", wallet->getWalletName());
-            } else if (fAutoStart) {
-                client.startMixing();
-                LogPrintf("CoinJoin: Automatic mixing started for wallet \"%s\"\n", wallet->getWalletName());
-            }
-        });
+    if (fAutoStart) {
+        mgr.startMixing();
     }
     LogPrintf("CoinJoin: autostart=%d, multisession=%d," /* Continued */
               "sessions=%d, rounds=%d, amount=%d, denoms_goal=%d, denoms_hardcap=%d\n",

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -207,14 +207,15 @@ void WalletInit::InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loa
     }
     bool fAutoStart = gArgs.GetBoolArg("-coinjoinautostart", DEFAULT_COINJOIN_AUTOSTART);
     for (auto& wallet : wallets) {
-        auto manager = Assert(coinjoin_loader.GetClient(wallet->getWalletName()));
-        if (wallet->isLocked(/*fForMixing=*/false)) {
-            manager->stopMixing();
-            LogPrintf("CoinJoin: Mixing stopped for locked wallet \"%s\"\n", wallet->getWalletName());
-        } else if (fAutoStart) {
-            manager->startMixing();
-            LogPrintf("CoinJoin: Automatic mixing started for wallet \"%s\"\n", wallet->getWalletName());
-        }
+        coinjoin_loader.WithClient(wallet->getWalletName(), [&](auto& client) {
+            if (wallet->isLocked(/*fForMixing=*/false)) {
+                client.stopMixing();
+                LogPrintf("CoinJoin: Mixing stopped for locked wallet \"%s\"\n", wallet->getWalletName());
+            } else if (fAutoStart) {
+                client.startMixing();
+                LogPrintf("CoinJoin: Automatic mixing started for wallet \"%s\"\n", wallet->getWalletName());
+            }
+        });
     }
     LogPrintf("CoinJoin: autostart=%d, multisession=%d," /* Continued */
               "sessions=%d, rounds=%d, amount=%d, denoms_goal=%d, denoms_hardcap=%d\n",

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -10,7 +10,9 @@
 #include <coinjoin/options.h>
 #include <coinjoin/util.h>
 #include <consensus/amount.h>
+#include <interfaces/coinjoin.h>
 #include <node/context.h>
+#include <util/system.h>
 #include <util/translation.h>
 #include <policy/settings.h>
 #include <validation.h>
@@ -25,6 +27,9 @@ BOOST_FIXTURE_TEST_SUITE(coinjoin_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(coinjoin_options_tests)
 {
+    gArgs.ForceSetArg("-enablecoinjoin", "0");
+    const auto loader{interfaces::MakeCoinJoinLoader(m_node)};
+
     BOOST_CHECK_EQUAL(CCoinJoinClientOptions::GetSessions(), DEFAULT_COINJOIN_SESSIONS);
     BOOST_CHECK_EQUAL(CCoinJoinClientOptions::GetRounds(), DEFAULT_COINJOIN_ROUNDS);
     BOOST_CHECK_EQUAL(CCoinJoinClientOptions::GetRandomRounds(), COINJOIN_RANDOM_ROUNDS);

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -226,13 +226,14 @@ public:
 
 BOOST_FIXTURE_TEST_CASE(coinjoin_manager_start_stop_tests, CTransactionBuilderTestSetup)
 {
-    auto& cj_man = *Assert(m_node.cj_walletman->getClient(""));
-    BOOST_CHECK_EQUAL(cj_man.IsMixing(), false);
-    BOOST_CHECK_EQUAL(cj_man.StartMixing(), true);
-    BOOST_CHECK_EQUAL(cj_man.IsMixing(), true);
-    BOOST_CHECK_EQUAL(cj_man.StartMixing(), false);
-    cj_man.StopMixing();
-    BOOST_CHECK_EQUAL(cj_man.IsMixing(), false);
+    BOOST_CHECK(m_node.cj_walletman->doForClient("", [](auto& cj_man) {
+        BOOST_CHECK_EQUAL(cj_man.IsMixing(), false);
+        BOOST_CHECK_EQUAL(cj_man.StartMixing(), true);
+        BOOST_CHECK_EQUAL(cj_man.IsMixing(), true);
+        BOOST_CHECK_EQUAL(cj_man.StartMixing(), false);
+        cj_man.StopMixing();
+        BOOST_CHECK_EQUAL(cj_man.IsMixing(), false);
+    }));
 }
 
 BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -227,12 +227,12 @@ public:
 BOOST_FIXTURE_TEST_CASE(coinjoin_manager_start_stop_tests, CTransactionBuilderTestSetup)
 {
     BOOST_CHECK(m_node.cj_walletman->doForClient("", [](auto& cj_man) {
-        BOOST_CHECK_EQUAL(cj_man.IsMixing(), false);
-        BOOST_CHECK_EQUAL(cj_man.StartMixing(), true);
-        BOOST_CHECK_EQUAL(cj_man.IsMixing(), true);
-        BOOST_CHECK_EQUAL(cj_man.StartMixing(), false);
-        cj_man.StopMixing();
-        BOOST_CHECK_EQUAL(cj_man.IsMixing(), false);
+        BOOST_CHECK_EQUAL(cj_man.isMixing(), false);
+        BOOST_CHECK_EQUAL(cj_man.startMixing(), true);
+        BOOST_CHECK_EQUAL(cj_man.isMixing(), true);
+        BOOST_CHECK_EQUAL(cj_man.startMixing(), false);
+        cj_man.stopMixing();
+        BOOST_CHECK_EQUAL(cj_man.isMixing(), false);
     }));
 }
 

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -236,11 +236,7 @@ BOOST_FIXTURE_TEST_CASE(coinjoin_manager_start_stop_tests, CTransactionBuilderTe
     }));
 }
 
-// End-to-end check that NewKeyPool() stops mixing via NewKeyPoolCallback() ->
-// WithClient() while cs_wallet is held, which exercises the
-// cs_wallet -> cs_wallet_manager_map lock order. The reverse order (and thus
-// the full lock-order cycle) is not seeded in this binary; the deterministic
-// -DDEBUG_LOCKORDER regression for it lives in test/functional/rpc_coinjoin.py.
+// End-to-end check that NewKeyPool() stops mixing
 BOOST_FIXTURE_TEST_CASE(coinjoin_newkeypool_stops_mixing_tests, CTransactionBuilderTestSetup)
 {
     BOOST_CHECK(m_node.cj_walletman->doForClient("", [](auto& cj_man) {

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -236,6 +236,26 @@ BOOST_FIXTURE_TEST_CASE(coinjoin_manager_start_stop_tests, CTransactionBuilderTe
     }));
 }
 
+// End-to-end check that NewKeyPool() stops mixing via NewKeyPoolCallback() ->
+// WithClient() while cs_wallet is held, which exercises the
+// cs_wallet -> cs_wallet_manager_map lock order. The reverse order (and thus
+// the full lock-order cycle) is not seeded in this binary; the deterministic
+// -DDEBUG_LOCKORDER regression for it lives in test/functional/rpc_coinjoin.py.
+BOOST_FIXTURE_TEST_CASE(coinjoin_newkeypool_stops_mixing_tests, CTransactionBuilderTestSetup)
+{
+    BOOST_CHECK(m_node.cj_walletman->doForClient("", [](auto& cj_man) {
+        BOOST_REQUIRE(cj_man.startMixing());
+        BOOST_CHECK_EQUAL(cj_man.isMixing(), true);
+    }));
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_REQUIRE(wallet->GetLegacyScriptPubKeyMan()->NewKeyPool());
+    }
+    BOOST_CHECK(m_node.cj_walletman->doForClient("", [](auto& cj_man) {
+        BOOST_CHECK_EQUAL(cj_man.isMixing(), false);
+    }));
+}
+
 BOOST_FIXTURE_TEST_CASE(CTransactionBuilderTest, CTransactionBuilderTestSetup)
 {
     // NOTE: Mock wallet version is FEATURE_BASE which means that it uses uncompressed pubkeys

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1670,10 +1670,10 @@ void CWallet::UnsetBlankWalletFlag(WalletBatch& batch)
 
 void CWallet::NewKeyPoolCallback()
 {
-    // Note: GetClient(*this) can return nullptr when this wallet is in the middle of its creation.
+    // Note: WithClient may not find this wallet when it is in the middle of its creation.
     // Skipping stopMixing() is fine in this case.
-    if (auto* coinjoin_client = coinjoin_available() ? coinjoin_loader().GetClient(GetName()) : nullptr) {
-        coinjoin_client->stopMixing();
+    if (coinjoin_available()) {
+        coinjoin_loader().WithClient(GetName(), [](auto& client) { client.stopMixing(); });
     }
     nKeysLeftSinceAutoBackup = 0;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1672,7 +1672,7 @@ void CWallet::NewKeyPoolCallback()
 {
     // Note: GetClient(*this) can return nullptr when this wallet is in the middle of its creation.
     // Skipping stopMixing() is fine in this case.
-    if (std::unique_ptr<interfaces::CoinJoin::Client> coinjoin_client = coinjoin_available() ? coinjoin_loader().GetClient(GetName()) : nullptr) {
+    if (auto* coinjoin_client = coinjoin_available() ? coinjoin_loader().GetClient(GetName()) : nullptr) {
         coinjoin_client->stopMixing();
     }
     nKeysLeftSinceAutoBackup = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1682,13 +1682,19 @@ void CWallet::UnsetBlankWalletFlag(WalletBatch& batch)
     UnsetWalletFlagWithDB(batch, WALLET_FLAG_BLANK_WALLET);
 }
 
+bool CWallet::StartMixing()
+{
+    // Refuse to start mixing on a wallet that is locked for mixing
+    if (IsLocked(/*fForMixing=*/true)) {
+        return false;
+    }
+    bool expected{false};
+    return m_mixing.compare_exchange_strong(expected, true);
+}
+
 void CWallet::NewKeyPoolCallback()
 {
-    // Note: WithClient may not find this wallet when it is in the middle of its creation.
-    // Skipping stopMixing() is fine in this case.
-    if (coinjoin_available()) {
-        coinjoin_loader().WithClient(GetName(), [](auto& client) { client.stopMixing(); });
-    }
+    StopMixing();
     nKeysLeftSinceAutoBackup = 0;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1686,7 +1686,7 @@ void CWallet::NewKeyPoolCallback()
 {
     // Note: GetClient(*this) can return nullptr when this wallet is in the middle of its creation.
     // Skipping stopMixing() is fine in this case.
-    if (std::unique_ptr<interfaces::CoinJoin::Client> coinjoin_client = coinjoin_available() ? coinjoin_loader().GetClient(GetName()) : nullptr) {
+    if (auto* coinjoin_client = coinjoin_available() ? coinjoin_loader().GetClient(GetName()) : nullptr) {
         coinjoin_client->stopMixing();
     }
     nKeysLeftSinceAutoBackup = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1684,10 +1684,10 @@ void CWallet::UnsetBlankWalletFlag(WalletBatch& batch)
 
 void CWallet::NewKeyPoolCallback()
 {
-    // Note: GetClient(*this) can return nullptr when this wallet is in the middle of its creation.
+    // Note: WithClient may not find this wallet when it is in the middle of its creation.
     // Skipping stopMixing() is fine in this case.
-    if (auto* coinjoin_client = coinjoin_available() ? coinjoin_loader().GetClient(GetName()) : nullptr) {
-        coinjoin_client->stopMixing();
+    if (coinjoin_available()) {
+        coinjoin_loader().WithClient(GetName(), [](auto& client) { client.stopMixing(); });
     }
     nKeysLeftSinceAutoBackup = 0;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -422,6 +422,9 @@ private:
      */
     void InitCJSaltFromDb();
 
+    //! Whether the CoinJoin client is mixing with this wallet
+    std::atomic<bool> m_mixing{false};
+
     /** Height of last block processed is used by wallet to know depth of transactions
      * without relying on Chain interface beyond asynchronous updates. For safety, we
      * initialize it to -1. Height is a pointer on node's tip and doesn't imply
@@ -472,6 +475,12 @@ public:
      * is the responsibility of the caller.
      **/
     bool SetCoinJoinSalt(const uint256& cj_salt);
+
+    /** Mark the wallet as mixing, see m_mixing. Returns false if the wallet
+     *  is locked for mixing or was mixing already. */
+    bool StartMixing();
+    void StopMixing() { m_mixing = false; }
+    bool IsMixing() const { return m_mixing; }
 
     // Map from governance object hash to governance object, they are added by gobject_prepare.
     std::map<uint256, Governance::Object> m_gobjects;

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -6,11 +6,9 @@
 #define BITCOIN_WALLETINITINTERFACE_H
 
 class ArgsManager;
+class CCoinJoinClientManager;
 namespace interfaces {
 class WalletLoader;
-namespace CoinJoin {
-class Loader;
-} // namespace CoinJoin
 } // namespace interfaces
 namespace node {
 struct NodeContext;
@@ -29,7 +27,7 @@ public:
 
     // Dash Specific WalletInitInterface
     virtual void AutoLockMasternodeCollaterals(interfaces::WalletLoader& wallet_loader) const = 0;
-    virtual void InitCoinJoinSettings(interfaces::CoinJoin::Loader& coinjoin_loader, interfaces::WalletLoader& wallet_loader) const = 0;
+    virtual void InitCoinJoinSettings(CCoinJoinClientManager& mgr) const = 0;
     virtual void InitAutoBackup() const = 0;
 
     virtual ~WalletInitInterface() {}

--- a/test/functional/rpc_coinjoin.py
+++ b/test/functional/rpc_coinjoin.py
@@ -15,6 +15,7 @@ from test_framework.util import (
     assert_equal,
     assert_is_hex_string,
     assert_raises_rpc_error,
+    force_finish_mnsync,
 )
 
 # See coinjoin/options.h
@@ -30,12 +31,16 @@ class CoinJoinTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 1
+        # The framework's keypool=1 and -createwalletbackups=0 defaults would
+        # trip CheckAutomaticBackup() and stop mixing before the maintenance
+        # thread gets to mix (see test_newkeypool_stops_mixing)
+        self.extra_args = [['-keypool=200', '-createwalletbackups=10']]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
     def setup_nodes(self):
-        self.add_nodes(self.num_nodes)
+        self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
 
     def run_test(self):
@@ -53,6 +58,10 @@ class CoinJoinTest(BitcoinTestFramework):
         if not self.options.descriptors:
             node.createwallet(wallet_name='w_keypool', blank=False, disable_private_keys=False)
             w_keypool = node.get_wallet_rpc('w_keypool')
+            # Leave IBD and advance the tip so WaitForAnotherBlock() lets the
+            # mixing maintenance thread proceed
+            self.generate(self.nodes[0], 2)
+            force_finish_mnsync(self.nodes[0])
             self.test_newkeypool_stops_mixing(w_keypool)
             w_keypool.unloadwallet()
         else:
@@ -95,8 +104,15 @@ class CoinJoinTest(BitcoinTestFramework):
 
     def test_newkeypool_stops_mixing(self, node):
         self.log.info('"newkeypool" should stop mixing')
-        node.coinjoin('start')
-        assert_equal(node.getcoinjoininfo()['running'], True)
+        # Wait until the scheduler thread runs a mixing attempt for the wallet:
+        # "Not enough funds to mix." is logged while it holds cs_wallet. Before
+        # the wallet manager lock-order fix that happened under
+        # cs_wallet_manager_map, so the newkeypool call below, which acquires
+        # cs_wallet_manager_map while holding cs_wallet, would abort
+        # -DDEBUG_LOCKORDER builds with a potential-deadlock error.
+        with self.nodes[0].wait_for_debug_log([b'Not enough funds to mix.']):
+            node.coinjoin('start')
+            assert_equal(node.getcoinjoininfo()['running'], True)
         node.newkeypool()
         assert_equal(node.getcoinjoininfo()['running'], False)
 

--- a/test/functional/rpc_coinjoin.py
+++ b/test/functional/rpc_coinjoin.py
@@ -50,6 +50,14 @@ class CoinJoinTest(BitcoinTestFramework):
         self.test_coinjoinsalt(w1)
         w1.unloadwallet()
 
+        if not self.options.descriptors:
+            node.createwallet(wallet_name='w_keypool', blank=False, disable_private_keys=False)
+            w_keypool = node.get_wallet_rpc('w_keypool')
+            self.test_newkeypool_stops_mixing(w_keypool)
+            w_keypool.unloadwallet()
+        else:
+            self.log.info('Skip "newkeypool" mixing test, command is incompatible with descriptor wallets')
+
         node.createwallet(wallet_name='w2', blank=True, disable_private_keys=True)
         w2 = node.get_wallet_rpc('w2')
         self.test_coinjoinsalt_disabled(w2)
@@ -84,6 +92,13 @@ class CoinJoinTest(BitcoinTestFramework):
 
         # Reset mix session
         assert_equal(node.coinjoin('reset'), "Mixing was reset")
+
+    def test_newkeypool_stops_mixing(self, node):
+        self.log.info('"newkeypool" should stop mixing')
+        node.coinjoin('start')
+        assert_equal(node.getcoinjoininfo()['running'], True)
+        node.newkeypool()
+        assert_equal(node.getcoinjoininfo()['running'], False)
 
     def test_setcoinjoinamount(self, node):
         self.log.info('"setcoinjoinamount" should update mixing target')


### PR DESCRIPTION
## Issue being fixed or feature implemented
Hold lock during flush operations to prevent TOCTOU race condition.

getClient() releases cs_wallet_manager_map before returning the raw pointer. If another thread calls removeWallet() concurrently, the unique_ptr is destroyed while flushWallet() still holds a reference, leading to use-after-free. This is inconsistent with removeWallet() which safely erases under the lock.


Discovered here https://github.com/dashpay/dash/pull/7248#discussion_r2981412759

## What was done?
Use `doWithClient(name, [](){...})` instead of `getClient(name)->...`

Mutex `cs_wallet_manager_map` should not be ever locked under `cs_wallet`.

## How Has This Been Tested?
Run unit & functional tests


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone