### PR TITLE
ci: use pull_request_target for clang-format comment permissions

### DIFF
--- a/.github/workflows/clang-diff-format.yml
+++ b/.github/workflows/clang-diff-format.yml
@@ -1,7 +1,7 @@
 name: Clang Diff Format Check
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - develop
 jobs:
@@ -10,14 +10,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout base branch
         uses: actions/checkout@v6
-      - name: Fetch git
-        run: git fetch --no-tags -fu origin develop:develop
+      - name: Fetch PR head
+        run: git fetch --no-tags -f origin ${{ github.event.pull_request.head.sha }}
       - name: Run Clang-Format-Diff.py
         id: clang-format
         run: |
-          git diff -U0 origin/develop -- $(git ls-files -- $(cat test/util/data/non-backported.txt)) | ./contrib/devtools/clang-format-diff.py -p1 > diff_output.txt
+          git diff -U0 HEAD...${{ github.event.pull_request.head.sha }} -- $(git ls-files -- $(cat test/util/data/non-backported.txt)) | ./contrib/devtools/clang-format-diff.py -p1 > diff_output.txt
           if [ -s diff_output.txt ]; then
               echo "::warning::Clang format differences found. See PR comment for details."
               echo "has_diff=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/clang-diff-format.yml
+++ b/.github/workflows/clang-diff-format.yml
@@ -8,16 +8,19 @@ jobs:
   ClangFormat:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 50
       - name: Fetch PR head
         run: git fetch --no-tags -f origin ${{ github.event.pull_request.head.sha }}
       - name: Run Clang-Format-Diff.py
         id: clang-format
         run: |
-          git diff -U0 HEAD...${{ github.event.pull_request.head.sha }} -- $(git ls-files -- $(cat test/util/data/non-backported.txt)) | ./contrib/devtools/clang-format-diff.py -p1 > diff_output.txt
+          git diff -U0 HEAD...${{ github.event.pull_request.head.sha }} -- $(cat test/util/data/non-backported.txt) | ./contrib/devtools/clang-format-diff.py -p1 > diff_output.txt
           if [ -s diff_output.txt ]; then
               echo "::warning::Clang format differences found. See PR comment for details."
               echo "has_diff=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Issue being fixed or feature implemented
Looks like codex bot was right https://github.com/dashpay/dash/pull/7251#discussion_r3013395627 -
https://github.com/dashpay/dash/actions/runs/23818749792/job/69425275349?pr=7101

#7251 follow-up

## What was done?
Switch from `pull_request` to `pull_request_target` so the workflow gets a write-capable `GITHUB_TOKEN` for posting PR comments, including on fork PRs. The base branch is checked out (keeping `clang-format-diff.py` trusted) and only the PR head SHA is fetched for diffing.

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

