### PR TITLE
fix: prevent self-reinforcing Blacksmith runner selection loop

### DIFF
--- a/.github/workflows/select_dynamic_runner.py
+++ b/.github/workflows/select_dynamic_runner.py
@@ -22,6 +22,9 @@ DEFAULT_STATUSES = ("queued", "in_progress")
 DEFAULT_RUNNER_AMD64 = "ubuntu-24.04"
 DEFAULT_RUNNER_ARM64 = "ubuntu-24.04-arm"
 REQUEST_TIMEOUT_SECONDS = 10
+# Prefixes — any label starting with one of these indicates a non-GitHub-hosted runner
+NON_GITHUB_HOSTED_RUNNER_PREFIXES = ("blacksmith-",)
+SELF_HOSTED_LABEL = "self-hosted"
 
 
 def parse_next_link(link_header: str) -> Optional[str]:
@@ -78,6 +81,19 @@ def iter_pages(
         next_url = parse_next_link(headers.get("Link", ""))
 
 
+def targets_github_hosted_runner(job: Dict) -> bool:
+    """Return True if the job targets GitHub-hosted runners, not Blacksmith or self-hosted."""
+    for label in job.get("labels", []):
+        if not isinstance(label, str):
+            continue
+        if label == SELF_HOSTED_LABEL:
+            return False
+        for prefix in NON_GITHUB_HOSTED_RUNNER_PREFIXES:
+            if label.startswith(prefix):
+                return False
+    return True
+
+
 def count_queued_jobs(
     fetch_json: Callable[[str], Tuple[Dict, Dict[str, str]]],
     repos: Sequence[str],
@@ -104,7 +120,7 @@ def count_queued_jobs(
             ).format(repo, run_id)
             for payload in iter_pages(fetch_json, jobs_url):
                 for job in payload.get("jobs", []):
-                    if job.get("status") == "queued":
+                    if job.get("status") == "queued" and targets_github_hosted_runner(job):
                         queued_jobs += 1
 
     return queued_jobs

--- a/.github/workflows/test_select_dynamic_runner.py
+++ b/.github/workflows/test_select_dynamic_runner.py
@@ -29,9 +29,9 @@ class SelectDynamicRunnerTest(unittest.TestCase):
             jobs_url: (
                 {
                     "jobs": [
-                        {"status": "queued"},
-                        {"status": "queued"},
-                        {"status": "in_progress"},
+                        {"status": "queued", "labels": ["ubuntu-24.04"]},
+                        {"status": "queued", "labels": ["ubuntu-24.04"]},
+                        {"status": "in_progress", "labels": ["ubuntu-24.04"]},
                     ]
                 },
                 {},
@@ -42,6 +42,39 @@ class SelectDynamicRunnerTest(unittest.TestCase):
             return responses[url]
 
         self.assertEqual(MODULE.count_queued_jobs(fetch_json, [repo]), 2)
+
+    def test_count_queued_jobs_excludes_blacksmith_jobs(self):
+        repo = "dashpay/dash"
+        queued_url = (
+            "https://api.github.com/repos/{}/actions/runs?status=queued&per_page=100"
+        ).format(repo)
+        in_progress_url = (
+            "https://api.github.com/repos/{}/actions/runs?status=in_progress&per_page=100"
+        ).format(repo)
+        jobs_url = (
+            "https://api.github.com/repos/{}/actions/runs/101/jobs?per_page=100"
+        ).format(repo)
+
+        responses = {
+            queued_url: ({"workflow_runs": [{"id": 101}]}, {}),
+            in_progress_url: ({"workflow_runs": []}, {}),
+            jobs_url: (
+                {
+                    "jobs": [
+                        {"status": "queued", "labels": ["ubuntu-24.04"]},
+                        {"status": "queued", "labels": ["blacksmith-4vcpu-ubuntu-2404"]},
+                        {"status": "queued", "labels": ["blacksmith-4vcpu-ubuntu-2404-arm"]},
+                        {"status": "queued", "labels": ["self-hosted", "linux"]},
+                    ]
+                },
+                {},
+            ),
+        }
+
+        def fetch_json(url):
+            return responses[url]
+
+        self.assertEqual(MODULE.count_queued_jobs(fetch_json, [repo]), 1)
 
     def test_label_override_selects_blacksmith_even_with_low_backlog(self):
         outputs = MODULE.select_runners(
@@ -74,7 +107,7 @@ class SelectDynamicRunnerTest(unittest.TestCase):
         responses = {
             queued_url: ({"workflow_runs": [{"id": 101}]}, {}),
             in_progress_url: ({"workflow_runs": []}, {}),
-            jobs_url: ({"jobs": [{"status": "queued"}] * 11}, {}),
+            jobs_url: ({"jobs": [{"status": "queued", "labels": ["ubuntu-24.04"]}] * 11}, {}),
         }
 
         outputs = MODULE.select_runners(


### PR DESCRIPTION
## Summary
- `count_queued_jobs` was counting ALL queued jobs regardless of runner type, including jobs already routed to Blacksmith
- This created a feedback loop: once Blacksmith was selected, its queued jobs inflated the backlog count, causing subsequent runs to also select Blacksmith while GitHub-hosted runners sat idle
- Added `targets_github_hosted_runner()` filter to exclude `blacksmith-*` and `self-hosted` labeled jobs from the backlog count

## Test plan
- [ ] Verify `test_select_dynamic_runner.py` passes (6 tests including new `test_count_queued_jobs_excludes_blacksmith_jobs`)
- [ ] Monitor runner usage after merge to confirm GitHub-hosted runners are utilized when backlog is low
- [ ] Verify Blacksmith is still selected when GitHub runner backlog genuinely exceeds threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)