### PR TITLE
perf: pass pre-computed block hash through reindex path to avoid redundant X11 computations

### DIFF
--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -745,42 +745,44 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
     return true;
 }
 
-bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams, uint256* hash_out)
+std::optional<uint256> ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
 {
     block.SetNull();
 
     // Open history file to read
     CAutoFile filein(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
     if (filein.IsNull()) {
-        return error("ReadBlockFromDisk: OpenBlockFile failed for %s", pos.ToString());
+        error("ReadBlockFromDisk: OpenBlockFile failed for %s", pos.ToString());
+        return std::nullopt;
     }
 
     // Read block
     try {
         filein >> block;
     } catch (const std::exception& e) {
-        return error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());
+        error("%s: Deserialize or I/O error - %s at %s", __func__, e.what(), pos.ToString());
+        return std::nullopt;
     }
 
     // Check the header
     const uint256 hash{block.GetHash()};
     if (!CheckProofOfWork(hash, block.nBits, consensusParams)) {
-        return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
+        error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
+        return std::nullopt;
     }
-    if (hash_out) *hash_out = hash;
 
-    return true;
+    return hash;
 }
 
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
     const FlatFilePos block_pos{WITH_LOCK(cs_main, return pindex->GetBlockPos())};
 
-    uint256 hash;
-    if (!ReadBlockFromDisk(block, block_pos, consensusParams, &hash)) {
+    const auto hash{ReadBlockFromDisk(block, block_pos, consensusParams)};
+    if (!hash) {
         return false;
     }
-    if (hash != pindex->GetBlockHash()) {
+    if (*hash != pindex->GetBlockHash()) {
         return error("ReadBlockFromDisk(CBlock&, CBlockIndex*): GetHash() doesn't match index for %s at %s",
                      pindex->ToString(), block_pos.ToString());
     }

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -745,7 +745,7 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
     return true;
 }
 
-bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
+bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams, uint256* hash_out)
 {
     block.SetNull();
 
@@ -763,9 +763,11 @@ bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::P
     }
 
     // Check the header
-    if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams)) {
+    const uint256 hash{block.GetHash()};
+    if (!CheckProofOfWork(hash, block.nBits, consensusParams)) {
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
     }
+    if (hash_out) *hash_out = hash;
 
     return true;
 }
@@ -774,10 +776,11 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
 {
     const FlatFilePos block_pos{WITH_LOCK(cs_main, return pindex->GetBlockPos())};
 
-    if (!ReadBlockFromDisk(block, block_pos, consensusParams)) {
+    uint256 hash;
+    if (!ReadBlockFromDisk(block, block_pos, consensusParams, &hash)) {
         return false;
     }
-    if (block.GetHash() != pindex->GetBlockHash()) {
+    if (hash != pindex->GetBlockHash()) {
         return error("ReadBlockFromDisk(CBlock&, CBlockIndex*): GetHash() doesn't match index for %s at %s",
                      pindex->ToString(), block_pos.ToString());
     }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -221,7 +221,7 @@ fs::path GetBlockPosFilename(const FlatFilePos& pos);
 void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
+bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams, uint256* hash_out = nullptr);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 
 bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -13,6 +13,7 @@
 #include <txdb.h>
 
 #include <cstdint>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -221,7 +222,7 @@ fs::path GetBlockPosFilename(const FlatFilePos& pos);
 void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams, uint256* hash_out = nullptr);
+std::optional<uint256> ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 
 bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -203,8 +203,9 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
 }
 
 /**
- * Test that CheckBlock and AcceptBlock work correctly when a pre-computed
- * known_hash is supplied (the reindex optimization path).
+ * Test that AcceptBlock works correctly when a pre-computed known_hash is
+ * supplied, exercising the reindex optimization path through AcceptBlockHeader
+ * and CheckBlock.
  */
 BOOST_AUTO_TEST_CASE(checkblock_accept_known_hash)
 {
@@ -214,17 +215,11 @@ BOOST_AUTO_TEST_CASE(checkblock_accept_known_hash)
 
     auto good = GoodBlock(Params().GenesisBlock().GetHash());
     const uint256 hash{good->GetHash()};
-    const CChainParams& chainparams = Params();
 
-    // CheckBlock with correct known_hash should succeed
-    {
-        BlockValidationState state;
-        BOOST_CHECK(CheckBlock(*good, state, chainparams.GetConsensus(),
-                               /*fCheckPOW=*/true, /*fCheckMerkleRoot=*/true, &hash));
-        BOOST_CHECK(state.IsValid());
-    }
-
-    // AcceptBlock with correct known_hash should succeed
+    // AcceptBlock with correct known_hash should succeed.
+    // Do not call CheckBlock beforehand: that would set fChecked=true,
+    // causing AcceptBlock's internal CheckBlock to short-circuit and skip
+    // the known_hash path. Keeping fChecked=false mirrors the reindex flow.
     {
         LOCK(::cs_main);
         BlockValidationState state;

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -203,6 +203,44 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
 }
 
 /**
+ * Test that CheckBlock and AcceptBlock work correctly when a pre-computed
+ * known_hash is supplied (the reindex optimization path).
+ */
+BOOST_AUTO_TEST_CASE(checkblock_accept_known_hash)
+{
+    bool ignored;
+    BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(
+        std::make_shared<CBlock>(Params().GenesisBlock()), true, &ignored));
+
+    auto good = GoodBlock(Params().GenesisBlock().GetHash());
+    const uint256 hash{good->GetHash()};
+    const CChainParams& chainparams = Params();
+
+    // CheckBlock with correct known_hash should succeed
+    {
+        BlockValidationState state;
+        BOOST_CHECK(CheckBlock(*good, state, chainparams.GetConsensus(),
+                               /*fCheckPOW=*/true, /*fCheckMerkleRoot=*/true, &hash));
+        BOOST_CHECK(state.IsValid());
+    }
+
+    // AcceptBlock with correct known_hash should succeed
+    {
+        LOCK(::cs_main);
+        BlockValidationState state;
+        CBlockIndex* pindex = nullptr;
+        bool newblock = false;
+        BOOST_REQUIRE(m_node.chainman->ActiveChainstate().AcceptBlock(
+            good, state, &pindex, /*fRequested=*/true,
+            /*dbp=*/nullptr, &newblock, &hash));
+        BOOST_REQUIRE(state.IsValid());
+        BOOST_REQUIRE(newblock);
+        BOOST_REQUIRE(pindex != nullptr);
+        BOOST_CHECK_EQUAL(pindex->GetBlockHash(), hash);
+    }
+}
+
+/**
  * Test that mempool updates happen atomically with reorgs.
  *
  * This prevents RPC clients, among others, from retrieving immediately-out-of-date mempool data

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3977,7 +3977,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
 
     auto start = Now<SteadyMicroseconds>();
 
-    assert(!known_hash || *known_hash == block.GetHash());
+    ASSERT_IF_DEBUG(!known_hash || *known_hash == block.GetHash());
 
     if (block.fChecked)
         return true;
@@ -4189,7 +4189,7 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
 {
     AssertLockHeld(cs_main);
 
-    assert(hash == block.GetHash());
+    ASSERT_IF_DEBUG(hash == block.GetHash());
 
     // TODO : ENABLE BLOCK CACHE IN SPECIFIC CASES
     BlockMap::iterator miSelf{m_blockman.m_block_index.find(hash)};
@@ -4358,7 +4358,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
     CBlockIndex *pindexDummy = nullptr;
     CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
 
-    assert(!known_hash || *known_hash == block.GetHash());
+    ASSERT_IF_DEBUG(!known_hash || *known_hash == block.GetHash());
 
     const uint256 hash{known_hash ? *known_hash : block.GetHash()};
     bool accepted_header{m_chainman.AcceptBlockHeader(block, state, &pindex, hash)};

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3977,12 +3977,15 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
 
     auto start = Now<SteadyMicroseconds>();
 
+    assert(!known_hash || *known_hash == block.GetHash());
+
     if (block.fChecked)
         return true;
 
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
-    if (!CheckBlockHeader(block, known_hash ? *known_hash : block.GetHash(), state, consensusParams, fCheckPOW))
+    const uint256 hash{known_hash ? *known_hash : block.GetHash()};
+    if (!CheckBlockHeader(block, hash, state, consensusParams, fCheckPOW))
         return false;
 
     // Check the merkle root.
@@ -4186,6 +4189,8 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
 {
     AssertLockHeld(cs_main);
 
+    assert(hash == block.GetHash());
+
     // TODO : ENABLE BLOCK CACHE IN SPECIFIC CASES
     BlockMap::iterator miSelf{m_blockman.m_block_index.find(hash)};
     if (hash != GetConsensus().hashGenesisBlock) {
@@ -4352,6 +4357,8 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
 
     CBlockIndex *pindexDummy = nullptr;
     CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
+
+    assert(!known_hash || *known_hash == block.GetHash());
 
     const uint256 hash{known_hash ? *known_hash : block.GetHash()};
     bool accepted_header{m_chainman.AcceptBlockHeader(block, state, &pindex, hash)};

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5185,8 +5185,8 @@ void CChainState::LoadExternalBlockFile(
                     while (range.first != range.second) {
                         std::multimap<uint256, FlatFilePos>::iterator it = range.first;
                         std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
-                        uint256 blockhash;
-                        if (ReadBlockFromDisk(*pblockrecursive, it->second, m_params.GetConsensus(), &blockhash)) {
+                        if (auto opt_hash{ReadBlockFromDisk(*pblockrecursive, it->second, m_params.GetConsensus())}) {
+                            const uint256& blockhash = *opt_hash;
                             LogPrint(BCLog::REINDEX, "%s: Processing out of order child %s of %s\n", __func__, blockhash.ToString(),
                                     head.ToString());
                             LOCK(cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3971,7 +3971,7 @@ static bool CheckBlockHeader(const CBlockHeader& block, const uint256& hash, Blo
     return true;
 }
 
-bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot)
+bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW, bool fCheckMerkleRoot, const uint256* known_hash)
 {
     // These are checks that are independent of context.
 
@@ -3982,7 +3982,7 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
 
     // Check that the header is valid (particularly PoW).  This is mostly
     // redundant with the call in AcceptBlockHeader.
-    if (!CheckBlockHeader(block, block.GetHash(), state, consensusParams, fCheckPOW))
+    if (!CheckBlockHeader(block, known_hash ? *known_hash : block.GetHash(), state, consensusParams, fCheckPOW))
         return false;
 
     // Check the merkle root.
@@ -4182,11 +4182,9 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     return true;
 }
 
-bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValidationState& state, CBlockIndex** ppindex)
+bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValidationState& state, CBlockIndex** ppindex, const uint256& hash)
 {
     AssertLockHeld(cs_main);
-    // Check for duplicate
-    uint256 hash = block.GetHash();
 
     // TODO : ENABLE BLOCK CACHE IN SPECIFIC CASES
     BlockMap::iterator miSelf{m_blockman.m_block_index.find(hash)};
@@ -4320,7 +4318,7 @@ bool ChainstateManager::ProcessNewBlockHeaders(const std::vector<CBlockHeader>& 
         LOCK(cs_main);
         for (const CBlockHeader& header : headers) {
             CBlockIndex *pindex = nullptr; // Use a temp pindex instead of ppindex to avoid a const_cast
-            bool accepted{AcceptBlockHeader(header, state, &pindex)};
+            bool accepted{AcceptBlockHeader(header, state, &pindex, header.GetHash())};
             ActiveChainstate().CheckBlockIndex();
 
             if (!accepted) {
@@ -4343,7 +4341,7 @@ bool ChainstateManager::ProcessNewBlockHeaders(const std::vector<CBlockHeader>& 
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock)
+bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, const uint256* known_hash)
 {
     auto start = Now<SteadyMicroseconds>();
 
@@ -4355,7 +4353,8 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
     CBlockIndex *pindexDummy = nullptr;
     CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
 
-    bool accepted_header{m_chainman.AcceptBlockHeader(block, state, &pindex)};
+    const uint256 hash{known_hash ? *known_hash : block.GetHash()};
+    bool accepted_header{m_chainman.AcceptBlockHeader(block, state, &pindex, hash)};
     CheckBlockIndex();
 
     if (!accepted_header)
@@ -4394,7 +4393,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
         if (pindex->nChainWork < nMinimumChainWork) return true;
     }
 
-    if (!CheckBlock(block, state, m_params.GetConsensus()) ||
+    if (!CheckBlock(block, state, m_params.GetConsensus(), true, true, &hash) ||
         !ContextualCheckBlock(block, state, m_chainman, pindex->pprev)) {
         if (state.IsInvalid() && state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
@@ -5146,7 +5145,7 @@ void CChainState::LoadExternalBlockFile(
                         nRewind = blkdat.GetPos();
 
                         BlockValidationState state;
-                        if (AcceptBlock(pblock, state, nullptr, true, dbp, nullptr)) {
+                        if (AcceptBlock(pblock, state, nullptr, true, dbp, nullptr, &hash)) {
                             nLoaded++;
                         }
                         if (state.IsError()) {
@@ -5179,14 +5178,15 @@ void CChainState::LoadExternalBlockFile(
                     while (range.first != range.second) {
                         std::multimap<uint256, FlatFilePos>::iterator it = range.first;
                         std::shared_ptr<CBlock> pblockrecursive = std::make_shared<CBlock>();
-                        if (ReadBlockFromDisk(*pblockrecursive, it->second, m_params.GetConsensus())) {
-                            LogPrint(BCLog::REINDEX, "%s: Processing out of order child %s of %s\n", __func__, pblockrecursive->GetHash().ToString(),
+                        uint256 blockhash;
+                        if (ReadBlockFromDisk(*pblockrecursive, it->second, m_params.GetConsensus(), &blockhash)) {
+                            LogPrint(BCLog::REINDEX, "%s: Processing out of order child %s of %s\n", __func__, blockhash.ToString(),
                                     head.ToString());
                             LOCK(cs_main);
                             BlockValidationState dummy;
-                            if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr)) {
+                            if (AcceptBlock(pblockrecursive, dummy, nullptr, true, &it->second, nullptr, &blockhash)) {
                                 nLoaded++;
-                                queue.push_back(pblockrecursive->GetHash());
+                                queue.push_back(blockhash);
                             }
                         }
                         range.first++;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4358,6 +4358,9 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
     CBlockIndex *pindexDummy = nullptr;
     CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
 
+    // If the caller supplies a pre-computed hash, verify it in debug builds.
+    // In release builds a wrong hash is still caught: AcceptBlockHeader calls
+    // CheckBlockHeader which runs CheckProofOfWork against the header's nBits.
     ASSERT_IF_DEBUG(!known_hash || *known_hash == block.GetHash());
 
     const uint256 hash{known_hash ? *known_hash : block.GetHash()};

--- a/src/validation.h
+++ b/src/validation.h
@@ -371,7 +371,7 @@ void InitScriptExecutionCache();
 /** Functions for validating blocks and updating the block tree */
 
 /** Context-independent validity checks */
-bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
+bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensus::Params& consensusParams, bool fCheckPOW = true, bool fCheckMerkleRoot = true, const uint256* known_hash = nullptr);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block) */
 bool TestBlockValidity(BlockValidationState& state,
@@ -705,7 +705,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(::cs_main);
 
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock, const uint256* known_hash = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -915,7 +915,8 @@ private:
     bool AcceptBlockHeader(
         const CBlockHeader& block,
         BlockValidationState& state,
-        CBlockIndex** ppindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+        CBlockIndex** ppindex,
+        const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     friend CChainState;
 
 public:


### PR DESCRIPTION
## Issue being fixed or feature implemented
During reindex, the X11 block header hash was computed multiple times for the same block: once in `LoadExternalBlockFile`, again in `AcceptBlockHeader`, again in `CheckBlock`, and more for out-of-order blocks. 

See #6610 for more info.

## What was done?
Thread the already-computed hash through `AcceptBlock`, `AcceptBlockHeader`, `CheckBlock`, and `ReadBlockFromDisk` to eliminate redundant X11 computations (from 3-5 per block down to 1).

## How Has This Been Tested?
Reindexed on testnet with `--stopatheight=1` to confirm performance is on par with #6610. Then competed reindex on testnet with no issues. Tests are green too.

## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

