### PR TITLE
feat: new RPC migratewallet to migrate legacy wallets to backport wallets

### DIFF
--- a/doc/managing-wallets.md
+++ b/doc/managing-wallets.md
@@ -121,3 +121,24 @@ $ dash-cli -rpcwallet="restored-wallet" getwalletinfo
 ```
 
 The restored wallet can also be loaded in the GUI via `File` ->`Open wallet`.
+
+## Migrating Legacy Wallets to Descriptor Wallets
+
+Legacy wallets (traditional non-descriptor wallets) can be migrated to become Descriptor wallets
+through the use of the `migratewallet` RPC. Migrated wallets will have all of their addresses and private keys added to
+a newly created Descriptor wallet that has the same name as the original wallet. Because Descriptor
+wallets do not support having private keys and watch-only scripts, there may be up to two
+additional wallets created after migration. In addition to a descriptor wallet of the same name,
+there may also be a wallet named `<name>_watchonly` and `<name>_solvables`. `<name>_watchonly`
+contains all of the watchonly scripts. `<name>_solvables` contains any scripts which the wallet
+knows but is not watching the corresponding P2SH scripts.
+
+Given that there is an extremely large number of possible configurations for the scripts that
+Legacy wallets can know about, be watching for, and be able to sign for, `migratewallet` only
+makes a best effort attempt to capture all of these things into Descriptor wallets. There may be
+unforeseen configurations which result in some scripts being excluded. If a migration fails
+unexpectedly or otherwise misses any scripts, please create an issue on GitHub. A backup of the
+original wallet can be found in the wallet directory with the name `<name>-<timestamp>.legacy.bak`.
+
+The backup can be restored using the `restorewallet` command as discussed in the
+[Restoring the Wallet From a Backup](#16-restoring-the-wallet-from-a-backup) section

--- a/doc/release-notes-19602.md
+++ b/doc/release-notes-19602.md
@@ -1,0 +1,9 @@
+Wallet
+======
+
+Migrating Legacy Wallets to Descriptor Wallets
+---------------------------------------------
+
+An experimental RPC `migratewallet` has been added to migrate Legacy (non-descriptor) wallets to
+Descriptor wallets. More information about the migration process is available in the
+[documentation](https://github.com/dashpay/dash/blob/master/doc/managing-wallets.md#migrating-legacy-wallets-to-descriptor-wallets).

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -587,7 +587,7 @@ public:
         return AddChecksum(ret);
     }
 
-    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override final
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const override
     {
         bool ret = ToStringHelper(&arg, out, StringType::PRIVATE);
         out = AddChecksum(out);
@@ -677,6 +677,7 @@ public:
         }
     }
     bool IsSingleType() const final { return true; }
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const final { return false; }
 };
 
 /** A parsed raw(H) descriptor. */
@@ -702,6 +703,7 @@ public:
         }
     }
     bool IsSingleType() const final { return true; }
+    bool ToPrivateString(const SigningProvider& arg, std::string& out) const final { return false; }
 };
 
 /** A parsed pk(P) descriptor. */

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -1103,6 +1103,59 @@ RPCHelpMan simulaterawtransaction()
     };
 }
 
+static RPCHelpMan migratewallet()
+{
+    return RPCHelpMan{"migratewallet",
+        "EXPERIMENTAL warning: This call may not work as expected and may be changed in future releases\n"
+        "\nMigrate the wallet to a descriptor wallet.\n"
+        "A new wallet backup will need to be made.\n"
+        "\nThe migration process will create a backup of the wallet before migrating. This backup\n"
+        "file will be named <wallet name>-<timestamp>.legacy.bak and can be found in the directory\n"
+        "for this wallet. In the event of an incorrect migration, the backup can be restored using restorewallet." +
+        HELP_REQUIRING_PASSPHRASE,
+        {},
+        RPCResult{
+            RPCResult::Type::OBJ, "", "",
+            {
+                {RPCResult::Type::STR, "wallet_name", "The name of the primary migrated wallet"},
+                {RPCResult::Type::STR, "watchonly_name", /*optional=*/true, "The name of the migrated wallet containing the watchonly scripts"},
+                {RPCResult::Type::STR, "solvables_name", /*optional=*/true, "The name of the migrated wallet containing solvable but not watched scripts"},
+                {RPCResult::Type::STR, "backup_path", "The location of the backup of the original wallet"},
+            }
+        },
+        RPCExamples{
+            HelpExampleCli("migratewallet", "")
+            + HelpExampleRpc("migratewallet", "")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        {
+            std::shared_ptr<CWallet> wallet = GetWalletForJSONRPCRequest(request);
+            if (!wallet) return NullUniValue;
+
+            EnsureWalletIsUnlocked(*wallet);
+
+            WalletContext& context = EnsureWalletContext(request.context);
+
+            util::Result<MigrationResult> res = MigrateLegacyToDescriptor(std::move(wallet), context);
+            if (!res) {
+                throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(res).original);
+            }
+
+            UniValue r{UniValue::VOBJ};
+            r.pushKV("wallet_name", res->wallet_name);
+            if (res->watchonly_wallet) {
+                r.pushKV("watchonly_name", res->watchonly_wallet->GetName());
+            }
+            if (res->solvables_wallet) {
+                r.pushKV("solvables_name", res->solvables_wallet->GetName());
+            }
+            r.pushKV("backup_path", fs::PathToString(res->backup_path));
+
+            return r;
+        },
+    };
+}
+
 // addresses
 RPCHelpMan getaddressinfo();
 RPCHelpMan getnewaddress();
@@ -1223,6 +1276,7 @@ Span<const CRPCCommand> GetWalletRPCCommands()
         {"wallet", &listwallets},
         {"wallet", &loadwallet},
         {"wallet", &lockunspent},
+        {"wallet", &migratewallet},
         {"wallet", &newkeypool},
         {"wallet", &removeprunedfunds},
         {"wallet", &rescanblockchain},

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -1132,7 +1132,9 @@ static RPCHelpMan migratewallet()
             std::shared_ptr<CWallet> wallet = GetWalletForJSONRPCRequest(request);
             if (!wallet) return NullUniValue;
 
-            EnsureWalletIsUnlocked(*wallet);
+            if (wallet->IsCrypted()) {
+                throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: migratewallet on encrypted wallets is currently unsupported.");
+            }
 
             WalletContext& context = EnsureWalletContext(request.context);
 

--- a/src/wallet/rpc/wallet.cpp
+++ b/src/wallet/rpc/wallet.cpp
@@ -1111,9 +1111,12 @@ static RPCHelpMan migratewallet()
         "A new wallet backup will need to be made.\n"
         "\nThe migration process will create a backup of the wallet before migrating. This backup\n"
         "file will be named <wallet name>-<timestamp>.legacy.bak and can be found in the directory\n"
-        "for this wallet. In the event of an incorrect migration, the backup can be restored using restorewallet." +
-        HELP_REQUIRING_PASSPHRASE,
-        {},
+        "for this wallet. In the event of an incorrect migration, the backup can be restored using restorewallet."
+        "\nEncrypted wallets must have the passphrase provided as an argument to this call.",
+        {
+            {"wallet_name", RPCArg::Type::STR, RPCArg::DefaultHint{"the wallet name from the RPC endpoint"}, "The name of the wallet to migrate. If provided both here and in the RPC endpoint, the two must be identical."},
+            {"passphrase", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "The wallet passphrase"},
+        },
         RPCResult{
             RPCResult::Type::OBJ, "", "",
             {
@@ -1129,16 +1132,26 @@ static RPCHelpMan migratewallet()
         },
         [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
         {
-            std::shared_ptr<CWallet> wallet = GetWalletForJSONRPCRequest(request);
-            if (!wallet) return NullUniValue;
+            std::string wallet_name;
+            if (GetWalletNameFromJSONRPCRequest(request, wallet_name)) {
+                if (!(request.params[0].isNull() || request.params[0].get_str() == wallet_name)) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "RPC endpoint wallet and wallet_name parameter specify different wallets");
+                }
+            } else {
+                if (request.params[0].isNull()) {
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Either RPC endpoint wallet or wallet_name parameter must be provided");
+                }
+                wallet_name = request.params[0].get_str();
+            }
 
-            if (wallet->IsCrypted()) {
-                throw JSONRPCError(RPC_WALLET_WRONG_ENC_STATE, "Error: migratewallet on encrypted wallets is currently unsupported.");
+            SecureString wallet_pass;
+            wallet_pass.reserve(100);
+            if (!request.params[1].isNull()) {
+                wallet_pass = std::string_view{request.params[1].get_str()};
             }
 
             WalletContext& context = EnsureWalletContext(request.context);
-
-            util::Result<MigrationResult> res = MigrateLegacyToDescriptor(std::move(wallet), context);
+            util::Result<MigrationResult> res = MigrateLegacyToDescriptor(wallet_name, wallet_pass, context);
             if (!res) {
                 throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(res).original);
             }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2414,7 +2414,9 @@ bool DescriptorScriptPubKeyMan::AdvanceNextIndexTo(int32_t target)
     // to cover the gap from the current next_index up to target.
     if (!TopUp(target - m_wallet_descriptor.next_index)) return false;
     m_wallet_descriptor.next_index = target;
-    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
+    if (!WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor)) {
+        return false;
+    }
     return true;
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1235,9 +1235,10 @@ bool LegacyScriptPubKeyMan::GetKeyOrigin(const CKeyID& keyID, KeyOriginInfo& inf
     {
         LOCK(cs_KeyStore);
         auto it = mapKeyMetadata.find(keyID);
-        if (it != mapKeyMetadata.end()) {
-            meta = it->second;
+        if (it == mapKeyMetadata.end()) {
+            return false;
         }
+        meta = it->second;
     }
     if (meta.has_key_origin) {
         std::copy(meta.key_origin.fingerprint, meta.key_origin.fingerprint + 4, info.fingerprint);
@@ -1820,6 +1821,319 @@ bool LegacyScriptPubKeyMan::GetHDChain(CHDChain& hdChainRet) const
     return !m_hd_chain.IsNull();
 }
 
+std::unordered_set<CScript, SaltedSipHasher> LegacyScriptPubKeyMan::GetScriptPubKeys() const
+{
+    LOCK(cs_KeyStore);
+    std::unordered_set<CScript, SaltedSipHasher> spks;
+
+    // All keys have at least P2PK and P2PKH
+    for (const auto& key_pair : mapKeys) {
+        const CPubKey& pub = key_pair.second.GetPubKey();
+        spks.insert(GetScriptForRawPubKey(pub));
+        spks.insert(GetScriptForDestination(PKHash(pub)));
+    }
+    for (const auto& key_pair : mapCryptedKeys) {
+        const CPubKey& pub = key_pair.second.first;
+        spks.insert(GetScriptForRawPubKey(pub));
+        spks.insert(GetScriptForDestination(PKHash(pub)));
+    }
+    // Dash: HD keys are stored in mapHdPubKeys, not in mapKeys/mapCryptedKeys
+    // Only P2PKH is used for HD keys in Dash (BIP44)
+    for (const auto& key_pair : mapHdPubKeys) {
+        const CPubKey& pub = key_pair.second.extPubKey.pubkey;
+        spks.insert(GetScriptForDestination(PKHash(pub)));
+    }
+
+    // For every script in mapScript, only the ISMINE_SPENDABLE ones are being tracked.
+    // The watchonly ones will be in setWatchOnly which we deal with later
+    // For all keys, if they have segwit scripts, those scripts will end up in mapScripts
+    for (const auto& script_pair : mapScripts) {
+        const CScript& script = script_pair.second;
+        if (IsMine(script) == ISMINE_SPENDABLE) {
+            // Add ScriptHash for scripts that are not already P2SH
+            if (!script.IsPayToScriptHash()) {
+                spks.insert(GetScriptForDestination(ScriptHash(script)));
+            }
+        } else {
+            // Multisigs are special. They don't show up as ISMINE_SPENDABLE unless they are in a P2SH
+            // So check the P2SH of a multisig to see if we should insert it
+            std::vector<std::vector<unsigned char>> sols;
+            TxoutType type = Solver(script, sols);
+            if (type == TxoutType::MULTISIG) {
+                CScript ms_spk = GetScriptForDestination(ScriptHash(script));
+                if (IsMine(ms_spk) != ISMINE_NO) {
+                    spks.insert(ms_spk);
+                }
+            }
+        }
+    }
+
+    // All watchonly scripts are raw
+    spks.insert(setWatchOnly.begin(), setWatchOnly.end());
+
+    return spks;
+}
+
+std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
+{
+    LOCK(cs_KeyStore);
+    if (m_storage.IsLocked(false)) {
+        return std::nullopt;
+    }
+
+    MigrationData out;
+
+    std::unordered_set<CScript, SaltedSipHasher> spks{GetScriptPubKeys()};
+
+    // Get all key ids
+    std::set<CKeyID> keyids;
+    for (const auto& key_pair : mapKeys) {
+        keyids.insert(key_pair.first);
+    }
+    for (const auto& key_pair : mapCryptedKeys) {
+        keyids.insert(key_pair.first);
+    }
+
+    // Get key metadata and figure out which keys don't have a seed
+    // Note that we do not ignore the seeds themselves because they are considered IsMine!
+    // In Dash, HD keys are tracked via mapHdPubKeys, not via metadata fields
+    for (auto keyid_it = keyids.begin(); keyid_it != keyids.end();) {
+        const CKeyID& keyid = *keyid_it;
+        if (mapHdPubKeys.count(keyid) > 0) {
+            // This key belongs to the HD chain, will be handled below
+            keyid_it = keyids.erase(keyid_it);
+            continue;
+        }
+        keyid_it++;
+    }
+
+    // keyids is now all non-HD keys. Each key will have its own combo descriptor
+    for (const CKeyID& keyid : keyids) {
+        CKey key;
+        if (!GetKey(keyid, key)) {
+            assert(false);
+        }
+
+        // Get birthdate from key meta
+        uint64_t creation_time = 0;
+        const auto& it = mapKeyMetadata.find(keyid);
+        if (it != mapKeyMetadata.end()) {
+            creation_time = it->second.nCreateTime;
+        }
+
+        // Get the key origin
+        // Maybe this doesn't matter because floating keys here shouldn't have origins
+        KeyOriginInfo info;
+        bool has_info = GetKeyOrigin(keyid, info);
+        std::string origin_str = has_info ? "[" + HexStr(info.fingerprint) + FormatHDKeypath(info.path) + "]" : "";
+
+        // Construct the combo descriptor
+        std::string desc_str = "combo(" + origin_str + HexStr(key.GetPubKey()) + ")";
+        FlatSigningProvider keys;
+        std::string error;
+        std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, error, false);
+        WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
+
+        // Make the DescriptorScriptPubKeyMan and get the scriptPubKeys
+        auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc));
+        desc_spk_man->AddDescriptorKey(key, key.GetPubKey());
+        desc_spk_man->TopUp();
+        auto desc_spks = desc_spk_man->GetScriptPubKeys();
+
+        // Remove the scriptPubKeys from our current set
+        for (const CScript& spk : desc_spks) {
+            size_t erased = spks.erase(spk);
+            assert(erased == 1);
+            assert(IsMine(spk) == ISMINE_SPENDABLE);
+        }
+
+        out.desc_spkms.push_back(std::move(desc_spk_man));
+    }
+
+    // Handle HD keys: build one inactive combo() descriptor per BIP44 chain
+    // (external + internal). This mirrors Bitcoin Core's MigrateToDescriptor —
+    // combo descriptors emit P2PK + P2PKH + P2SH-P2PKH for every derived index,
+    // so the migrated wallet's script-centric IsMine recognizes every script
+    // form the legacy keyid-centric IsMine matched via HaveKey(). The active
+    // address-providing pkh() descriptors are still created later by
+    // SetupDescriptorScriptPubKeyMans() in ApplyMigrationData; the combos sit
+    // alongside as non-active history coverage.
+    if (!m_hd_chain.IsNull()) {
+        // Decrypt the HD chain if the wallet is encrypted
+        CHDChain hdChainDecrypted;
+        if (m_hd_chain.IsCrypted()) {
+            if (!m_storage.WithEncryptionKey([&](const CKeyingMaterial& encryption_key) {
+                    return DecryptHDChain(encryption_key, hdChainDecrypted);
+                })) {
+                throw std::runtime_error(std::string(__func__) + ": DecryptHDChain failed");
+            }
+            if (hdChainDecrypted.GetID() != hdChainDecrypted.GetSeedHash()) {
+                throw std::runtime_error(std::string(__func__) + ": Wrong HD chain!");
+            }
+        } else {
+            hdChainDecrypted = m_hd_chain;
+        }
+
+        CHDAccount acc;
+        if (!hdChainDecrypted.GetAccount(0, acc)) {
+            throw std::runtime_error(std::string(__func__) + ": GetAccount(0) failed");
+        }
+
+        // Derive the master key from the seed and extract the mnemonic for both
+        // the migration combo descriptors below and the active descriptors that
+        // ApplyMigrationData will create via SetupDescriptorScriptPubKeyMans.
+        CExtKey master_key;
+        master_key.SetSeed(MakeByteSpan(hdChainDecrypted.GetSeed()));
+        out.master_key = master_key;
+        SecureString ssMnemonic, ssMnemonicPassphrase;
+        if (hdChainDecrypted.GetMnemonic(ssMnemonic, ssMnemonicPassphrase)) {
+            out.mnemonic = ssMnemonic;
+            out.mnemonic_passphrase = ssMnemonicPassphrase;
+        }
+
+        // Build per-chain inactive combo() descriptors with range_end set to the
+        // legacy chain counter so TopUp() populates every historical index.
+        const std::string xpub_str = EncodeExtPubKey(master_key.Neuter());
+        for (int i = 0; i < 2; ++i) {
+            const uint32_t chain_counter = (i == 1) ? acc.nInternalChainCounter : acc.nExternalChainCounter;
+            const std::string desc_str = strprintf("combo(%s/%d'/%d'/0'/%d/*)",
+                xpub_str, BIP32_PURPOSE_STANDARD, Params().ExtCoinType(), i);
+            FlatSigningProvider keys;
+            std::string error;
+            std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, error, false);
+            if (!desc) {
+                throw std::runtime_error(std::string(__func__) + ": failed to parse migration combo descriptor: " + error);
+            }
+            WalletDescriptor w_desc(std::move(desc), 0, 0, chain_counter, 0);
+
+            auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc));
+            desc_spk_man->AddDescriptorKey(master_key.key, master_key.key.GetPubKey(), out.mnemonic, out.mnemonic_passphrase);
+            desc_spk_man->TopUp();
+            auto desc_spks = desc_spk_man->GetScriptPubKeys();
+
+            // Erase every script form combo just produced from the tracking set.
+            // Legacy GetScriptPubKeys only enumerates P2PKH for HD keys, so the
+            // P2PK and P2SH-P2PKH forms are not in `spks` — only erase what's there.
+            for (const CScript& spk : desc_spks) {
+                spks.erase(spk);
+            }
+
+            out.desc_spkms.push_back(std::move(desc_spk_man));
+        }
+    }
+
+    // Handle the rest of the scriptPubKeys which must be imports and may not have all info
+    for (auto it = spks.begin(); it != spks.end();) {
+        const CScript& spk = *it;
+
+        // Get birthdate from script meta
+        uint64_t creation_time = 0;
+        const auto& mit = m_script_metadata.find(CScriptID(spk));
+        if (mit != m_script_metadata.end()) {
+            creation_time = mit->second.nCreateTime;
+        }
+
+        // InferDescriptor as that will get us all the solving info if it is there
+        std::unique_ptr<Descriptor> desc = InferDescriptor(spk, *GetSolvingProvider(spk));
+        // Get the private keys for this descriptor
+        std::vector<CScript> scripts;
+        FlatSigningProvider keys;
+        if (!desc->Expand(0, DUMMY_SIGNING_PROVIDER, scripts, keys)) {
+            assert(false);
+        }
+        std::set<CKeyID> privkeyids;
+        for (const auto& key_orig_pair : keys.origins) {
+            privkeyids.insert(key_orig_pair.first);
+        }
+
+        std::vector<CScript> desc_spks;
+
+        // Make the descriptor string with private keys
+        std::string desc_str;
+        bool watchonly = !desc->ToPrivateString(*this, desc_str);
+        if (watchonly && !m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+            out.watch_descs.push_back({desc->ToString(), creation_time});
+
+            // Get the scriptPubKeys without writing this to the wallet
+            FlatSigningProvider provider;
+            desc->Expand(0, provider, desc_spks, provider);
+        } else {
+            // Make the DescriptorScriptPubKeyMan and get the scriptPubKeys
+            WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
+            auto desc_spk_man = std::unique_ptr<DescriptorScriptPubKeyMan>(new DescriptorScriptPubKeyMan(m_storage, w_desc));
+            for (const auto& keyid : privkeyids) {
+                CKey key;
+                if (!GetKey(keyid, key)) {
+                    continue;
+                }
+                desc_spk_man->AddDescriptorKey(key, key.GetPubKey());
+            }
+            desc_spk_man->TopUp();
+            auto desc_spks_set = desc_spk_man->GetScriptPubKeys();
+            desc_spks.insert(desc_spks.end(), desc_spks_set.begin(), desc_spks_set.end());
+
+            out.desc_spkms.push_back(std::move(desc_spk_man));
+        }
+
+        // Remove the scriptPubKeys from our current set
+        for (const CScript& desc_spk : desc_spks) {
+            auto del_it = spks.find(desc_spk);
+            assert(del_it != spks.end());
+            assert(IsMine(desc_spk) != ISMINE_NO);
+            it = spks.erase(del_it);
+        }
+    }
+
+    // Multisigs are special. They don't show up as ISMINE_SPENDABLE unless they are in a P2SH
+    // So we have to check if any of our scripts are a multisig and if so, add the P2SH
+    for (const auto& script_pair : mapScripts) {
+        const CScript script = script_pair.second;
+
+        // Get birthdate from script meta
+        uint64_t creation_time = 0;
+        const auto& it = m_script_metadata.find(CScriptID(script));
+        if (it != m_script_metadata.end()) {
+            creation_time = it->second.nCreateTime;
+        }
+
+        std::vector<std::vector<unsigned char>> sols;
+        TxoutType type = Solver(script, sols);
+        if (type == TxoutType::MULTISIG) {
+            CScript sh_spk = GetScriptForDestination(ScriptHash(script));
+
+            // We only want the multisigs that we have not already seen, i.e. they are not watchonly and not spendable
+            // For P2SH, a multisig is not ISMINE_NO when:
+            // * All keys are in the wallet
+            // * The multisig itself is watch only
+            // * The P2SH is watch only
+            // For P2SH-P2WSH, if the script is in the wallet, then it will have the same conditions as P2SH.
+            // For P2WSH, a multisig is not ISMINE_NO when, other than the P2SH conditions:
+            // * The P2WSH script is in the wallet and it is being watched
+            std::vector<std::vector<unsigned char>> keys(sols.begin() + 1, sols.begin() + sols.size() - 1);
+            if (HaveWatchOnly(sh_spk) || HaveWatchOnly(script) || HaveKeys(keys, *this)) {
+                // The above emulates IsMine for these 3 scriptPubKeys, so double check that by running IsMine
+                assert(IsMine(sh_spk) != ISMINE_NO);
+                continue;
+            }
+            assert(IsMine(sh_spk) == ISMINE_NO);
+
+            std::unique_ptr<Descriptor> sh_desc = InferDescriptor(sh_spk, *GetSolvingProvider(sh_spk));
+            out.solvable_descs.push_back({sh_desc->ToString(), creation_time});
+        }
+    }
+
+    // Make sure that we have accounted for all scriptPubKeys
+    assert(spks.size() == 0);
+    return out;
+}
+
+bool LegacyScriptPubKeyMan::DeleteRecords()
+{
+    LOCK(cs_KeyStore);
+    WalletBatch batch(m_storage.GetDatabase());
+    return batch.EraseRecords(DBKeys::LEGACY_TYPES);
+}
+
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination()
 {
     // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later
@@ -2072,11 +2386,11 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(Wa
     return result;
 }
 
-void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey &pubkey)
+void DescriptorScriptPubKeyMan::AddDescriptorKey(const CKey& key, const CPubKey &pubkey, const SecureString& mnemonic, const SecureString& mnemonic_passphrase)
 {
     LOCK(cs_desc_man);
     WalletBatch batch(m_storage.GetDatabase());
-    if (!AddDescriptorKeyWithDB(batch, key, pubkey, "", "")) {
+    if (!AddDescriptorKeyWithDB(batch, key, pubkey, mnemonic, mnemonic_passphrase)) {
         throw std::runtime_error(std::string(__func__) + ": writing descriptor private key failed");
     }
 }
@@ -2513,19 +2827,19 @@ WalletDescriptor DescriptorScriptPubKeyMan::GetWalletDescriptor() const
     return m_wallet_descriptor;
 }
 
-std::vector<CScript> DescriptorScriptPubKeyMan::GetScriptPubKeys() const
+std::unordered_set<CScript, SaltedSipHasher> DescriptorScriptPubKeyMan::GetScriptPubKeys() const
 {
     return GetScriptPubKeys(0);
 }
 
-std::vector<CScript> DescriptorScriptPubKeyMan::GetScriptPubKeys(int32_t minimum_index) const
+std::unordered_set<CScript, SaltedSipHasher>  DescriptorScriptPubKeyMan::GetScriptPubKeys(int32_t minimum_index) const
 {
     LOCK(cs_desc_man);
-    std::vector<CScript> script_pub_keys;
+    std::unordered_set<CScript, SaltedSipHasher> script_pub_keys;
     script_pub_keys.reserve(m_map_script_pub_keys.size());
 
     for (auto const& [script_pub_key, index] : m_map_script_pub_keys) {
-        if (index >= minimum_index) script_pub_keys.push_back(script_pub_key);
+        if (index >= minimum_index) script_pub_keys.insert(script_pub_key);
     }
     return script_pub_keys;
 }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1881,6 +1881,18 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
         return std::nullopt;
     }
 
+    // Wrap every DB write produced by the per-chain TopUp() calls below in a
+    // single SQLite transaction. Without this, each key/script insert auto-
+    // commits and fsyncs to disk, turning a large-chain migration (e.g. a Dash
+    // wallet with a long CoinJoin-driven external counter) into tens of
+    // thousands of tiny commits. SQLiteBatch tracks transaction ownership per
+    // batch, so inner WalletBatches created inside TopUp share this outer
+    // transaction rather than fighting it.
+    WalletBatch migration_batch(m_storage.GetDatabase());
+    if (!migration_batch.TxnBegin()) {
+        throw std::runtime_error(std::string(__func__) + ": failed to begin migration transaction");
+    }
+
     MigrationData out;
 
     std::unordered_set<CScript, SaltedSipHasher> spks{GetScriptPubKeys()};
@@ -2139,6 +2151,11 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
 
     // Make sure that we have accounted for all scriptPubKeys
     assert(spks.size() == 0);
+
+    if (!migration_batch.TxnCommit()) {
+        throw std::runtime_error(std::string(__func__) + ": failed to commit migration transaction");
+    }
+
     return out;
 }
 
@@ -2146,7 +2163,23 @@ bool LegacyScriptPubKeyMan::DeleteRecords()
 {
     LOCK(cs_KeyStore);
     WalletBatch batch(m_storage.GetDatabase());
-    return batch.EraseRecords(DBKeys::LEGACY_TYPES);
+    // Wrap the legacy-record deletion in a single SQLite transaction. Without
+    // this, EraseRecords cursor-walks the entire DB and every matching row's
+    // Erase auto-commits+fsyncs on its own — legacy wallets with thousands of
+    // KEY/HDPUBKEY/POOL/KEYMETA rows then take minutes instead of milliseconds.
+    if (!batch.TxnBegin()) {
+        WalletLogPrintf("DeleteRecords: TxnBegin failed\n");
+        return false;
+    }
+    if (!batch.EraseRecords(DBKeys::LEGACY_TYPES)) {
+        batch.TxnAbort();
+        return false;
+    }
+    if (!batch.TxnCommit()) {
+        WalletLogPrintf("DeleteRecords: TxnCommit failed\n");
+        return false;
+    }
+    return true;
 }
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination()

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1978,6 +1978,8 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
         if (!hdChainDecrypted.GetAccount(0, acc)) {
             throw std::runtime_error(std::string(__func__) + ": GetAccount(0) failed");
         }
+        out.external_chain_counter = acc.nExternalChainCounter;
+        out.internal_chain_counter = acc.nInternalChainCounter;
 
         // Derive the master key from the seed and extract the mnemonic for both
         // the migration combo descriptors below and the active descriptors that
@@ -2355,6 +2357,18 @@ bool DescriptorScriptPubKeyMan::TopUp(unsigned int size)
     assert(m_wallet_descriptor.range_end - 1 == m_max_cached_index);
 
     NotifyCanGetAddressesChanged();
+    return true;
+}
+
+bool DescriptorScriptPubKeyMan::AdvanceNextIndexTo(int32_t target)
+{
+    LOCK(cs_desc_man);
+    if (target <= m_wallet_descriptor.next_index) return true;
+    // TopUp() bases its new_range_end on next_index + size, so request enough
+    // to cover the gap from the current next_index up to target.
+    if (!TopUp(target - m_wallet_descriptor.next_index)) return false;
+    m_wallet_descriptor.next_index = target;
+    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
     return true;
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1940,11 +1940,13 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
         desc_spk_man->TopUp();
         auto desc_spks = desc_spk_man->GetScriptPubKeys();
 
-        // Remove the scriptPubKeys from our current set
+        // Erase every script form combo just produced from the tracking set.
+        // Legacy GetScriptPubKeys only enumerates P2PK and P2PKH for loose
+        // keys (Dash has no segwit, so LearnRelatedScripts never inserts the
+        // P2SH-P2PKH form into mapScripts), so the third script combo emits
+        // is not in `spks` — only erase what's there.
         for (const CScript& spk : desc_spks) {
-            size_t erased = spks.erase(spk);
-            assert(erased == 1);
-            assert(IsMine(spk) == ISMINE_SPENDABLE);
+            spks.erase(spk);
         }
 
         out.desc_spkms.push_back(std::move(desc_spk_man));

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1974,6 +1974,17 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
             hdChainDecrypted = m_hd_chain;
         }
 
+        // Stock Dash legacy wallets only ever use a single BIP44 account (index 0):
+        // GenerateNewKey is hardcoded to account 0 at every call site and the chain
+        // is initialized with exactly one AddAccount(). A wallet created by a
+        // modified build with multiple accounts cannot be migrated by this code path
+        // since the descriptor wallet also only uses one account — bail out instead
+        // of silently dropping the higher accounts' keys.
+        if (hdChainDecrypted.CountAccounts() != 1) {
+            throw std::runtime_error(strprintf("%s: legacy HD chain has %d accounts; "
+                "migration only supports wallets with a single BIP44 account",
+                __func__, hdChainDecrypted.CountAccounts()));
+        }
         CHDAccount acc;
         if (!hdChainDecrypted.GetAccount(0, acc)) {
             throw std::runtime_error(std::string(__func__) + ": GetAccount(0) failed");

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -611,7 +611,7 @@ public:
     //! script at `target`. Used by wallet migration to make sure the active
     //! pkh() descriptors don't re-derive addresses the legacy wallet had
     //! already given out. No-op if next_index is already at or beyond target.
-    bool AdvanceNextIndexTo(int32_t target);
+    [[nodiscard]] bool AdvanceNextIndexTo(int32_t target);
 
     std::vector<WalletDestination> MarkUnusedAddresses(WalletBatch &batch, const CScript& script, const std::optional<int64_t>& block_time) override;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -239,6 +239,9 @@ public:
 
     virtual uint256 GetID() const { return uint256(); }
 
+    /** Returns a set of all the scriptPubKeys that this ScriptPubKeyMan watches */
+    virtual std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const { return {}; };
+
     /** Prepends the wallet name in logging output to ease debugging in multi-wallet use cases */
     template<typename... Params>
     void WalletLogPrintf(std::string fmt, Params... parameters) const {
@@ -251,6 +254,8 @@ public:
     /** Keypool has new keys */
     boost::signals2::signal<void ()> NotifyCanGetAddressesChanged;
 };
+
+class DescriptorScriptPubKeyMan;
 
 class LegacyScriptPubKeyMan : public ScriptPubKeyMan, public FillableSigningProvider
 {
@@ -507,6 +512,13 @@ public:
     const std::map<CKeyID, int64_t>& GetAllReserveKeys() const { return m_pool_key_to_index; }
 
     std::set<CKeyID> GetKeys() const override;
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override;
+
+    /** Get the DescriptorScriptPubKeyMans (with private keys) that have the same scriptPubKeys as this LegacyScriptPubKeyMan.
+     * Does not modify this ScriptPubKeyMan. */
+    std::optional<MigrationData> MigrateToDescriptor();
+    /** Delete all the records ofthis LegacyScriptPubKeyMan from disk*/
+    bool DeleteRecords();
 };
 
 /** Wraps a LegacyScriptPubKeyMan so that it can be returned in a new unique_ptr. Does not provide privkeys */
@@ -636,12 +648,12 @@ public:
     bool HasWalletDescriptor(const WalletDescriptor& desc) const;
     void UpdateWalletDescriptor(WalletDescriptor& descriptor);
     bool CanUpdateToWalletDescriptor(const WalletDescriptor& descriptor, std::string& error);
-    void AddDescriptorKey(const CKey& key, const CPubKey &pubkey);
+    void AddDescriptorKey(const CKey& key, const CPubKey &pubkey, const SecureString& mnemonic = "", const SecureString& mnemonic_passphrase = "");
     void WriteDescriptor();
 
     WalletDescriptor GetWalletDescriptor() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    std::vector<CScript> GetScriptPubKeys() const;
-    std::vector<CScript> GetScriptPubKeys(int32_t minimum_index) const;
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys() const override;
+    std::unordered_set<CScript, SaltedSipHasher> GetScriptPubKeys(int32_t minimum_index) const;
     int32_t GetEndRange() const;
 
     bool GetDescriptorString(std::string& out, const bool priv) const;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -606,6 +606,13 @@ public:
     // (with or without private keys), the "keypool" is a single xpub.
     bool TopUp(unsigned int size = 0) override;
 
+    //! Fast-forward this descriptor's next_index to `target` (topping up the
+    //! script cache as needed) so the next GetNewDestination() returns the
+    //! script at `target`. Used by wallet migration to make sure the active
+    //! pkh() descriptors don't re-derive addresses the legacy wallet had
+    //! already given out. No-op if next_index is already at or beyond target.
+    bool AdvanceNextIndexTo(int32_t target);
+
     std::vector<WalletDestination> MarkUnusedAddresses(WalletBatch &batch, const CScript& script, const std::optional<int64_t>& block_time) override;
 
     bool IsHDEnabled() const override;

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -389,8 +389,11 @@ SQLiteBatch::SQLiteBatch(SQLiteDatabase& database)
 
 void SQLiteBatch::Close()
 {
-    // If m_db is in a transaction (i.e. not in autocommit mode), then abort the transaction in progress
-    if (m_database.m_db && sqlite3_get_autocommit(m_database.m_db) == 0) {
+    // If this batch started a transaction that was never committed/aborted,
+    // abort it now. We intentionally only abort transactions this batch owns:
+    // nested WalletBatches sharing the SQLite connection must not roll back an
+    // outer transaction started by a different batch.
+    if (m_txn_started && m_database.m_db && sqlite3_get_autocommit(m_database.m_db) == 0) {
         if (TxnAbort()) {
             LogPrintf("SQLiteBatch: Batch closed unexpectedly without the transaction being explicitly committed or aborted\n");
         } else {
@@ -546,26 +549,38 @@ bool SQLiteBatch::TxnBegin()
     int res = sqlite3_exec(m_database.m_db, "BEGIN TRANSACTION", nullptr, nullptr, nullptr);
     if (res != SQLITE_OK) {
         LogPrintf("SQLiteBatch: Failed to begin the transaction\n");
+    } else {
+        m_txn_started = true;
     }
     return res == SQLITE_OK;
 }
 
 bool SQLiteBatch::TxnCommit()
 {
+    // Refuse to operate on a transaction this batch does not own, so a nested
+    // batch whose TxnBegin() failed cannot accidentally commit an outer
+    // transaction started by a different batch on the shared connection.
+    if (!m_txn_started) return false;
     if (!m_database.m_db || sqlite3_get_autocommit(m_database.m_db) != 0) return false;
     int res = sqlite3_exec(m_database.m_db, "COMMIT TRANSACTION", nullptr, nullptr, nullptr);
     if (res != SQLITE_OK) {
         LogPrintf("SQLiteBatch: Failed to commit the transaction\n");
+    } else {
+        m_txn_started = false;
     }
     return res == SQLITE_OK;
 }
 
 bool SQLiteBatch::TxnAbort()
 {
+    // Refuse to operate on a transaction this batch does not own; see TxnCommit.
+    if (!m_txn_started) return false;
     if (!m_database.m_db || sqlite3_get_autocommit(m_database.m_db) != 0) return false;
     int res = sqlite3_exec(m_database.m_db, "ROLLBACK TRANSACTION", nullptr, nullptr, nullptr);
     if (res != SQLITE_OK) {
         LogPrintf("SQLiteBatch: Failed to abort the transaction\n");
+    } else {
+        m_txn_started = false;
     }
     return res == SQLITE_OK;
 }

--- a/src/wallet/sqlite.h
+++ b/src/wallet/sqlite.h
@@ -24,6 +24,12 @@ private:
 
     bool m_cursor_init = false;
 
+    // True iff TxnBegin() succeeded on this batch and has not yet been
+    // matched by TxnCommit()/TxnAbort(). Only the batch that started the
+    // transaction auto-aborts in Close(); other batches sharing the SQLite
+    // connection while an outer transaction is in flight must not interfere.
+    bool m_txn_started{false};
+
     sqlite3_stmt* m_read_stmt{nullptr};
     sqlite3_stmt* m_insert_stmt{nullptr};
     sqlite3_stmt* m_overwrite_stmt{nullptr};

--- a/src/wallet/test/ismine_tests.cpp
+++ b/src/wallet/test/ismine_tests.cpp
@@ -44,11 +44,13 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         // Keystore does not have key
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has key
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddKey(keys[0]));
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 1);
     }
 
     // P2PK uncompressed
@@ -61,11 +63,13 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         // Keystore does not have key
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has key
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddKey(uncompressedKey));
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 1);
     }
 
     // P2PKH compressed
@@ -78,11 +82,13 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         // Keystore does not have key
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has key
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddKey(keys[0]));
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 1);
     }
 
     // P2PKH uncompressed
@@ -95,11 +101,13 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         // Keystore does not have key
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has key
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddKey(uncompressedKey));
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 1);
     }
 
     // P2SH
@@ -114,16 +122,19 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         // Keystore does not have redeemScript or key
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has redeemScript but no key
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddCScript(redeemScript));
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has redeemScript and key
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddKey(keys[0]));
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 1);
     }
 
     //  (P2PKH inside) P2SH inside P2SH (invalid)
@@ -142,6 +153,7 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddKey(keys[0]));
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
     }
 
     // scriptPubKey multisig
@@ -155,24 +167,28 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         // Keystore does not have any keys
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has 1/2 keys
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddKey(uncompressedKey));
 
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has 2/2 keys
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddKey(keys[1]));
 
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has 2/2 keys and the script
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddCScript(scriptPubKey));
 
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
     }
 
     // P2SH multisig
@@ -189,11 +205,13 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
         // Keystore has no redeemScript
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
 
         // Keystore has redeemScript
         BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->AddCScript(redeemScript));
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 1);
     }
 
     // OP_RETURN
@@ -208,6 +226,7 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
 
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
     }
 
     // Nonstandard
@@ -222,6 +241,7 @@ BOOST_AUTO_TEST_CASE(ismine_standard)
 
         result = keystore.GetLegacyScriptPubKeyMan()->IsMine(scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(keystore.GetLegacyScriptPubKeyMan()->GetScriptPubKeys().count(scriptPubKey) == 0);
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4476,6 +4476,23 @@ bool CWallet::ApplyMigrationData(MigrationData& data, bilingual_str& error)
             }
         }
     }
+
+    // Persist added address book entries (labels, purpose) for watchonly and solvable wallets
+    auto persist_address_book = [](const CWallet& wallet) {
+        LOCK(wallet.cs_wallet);
+        WalletBatch batch{wallet.GetDatabase()};
+        for (const auto& [destination, addr_book_data] : wallet.m_address_book) {
+            auto address{EncodeDestination(destination)};
+            auto purpose{addr_book_data.purpose};
+            auto label{addr_book_data.GetLabel()};
+            // don't bother writing default values (unknown purpose, empty label)
+            if (purpose != "unknown") batch.WritePurpose(address, purpose);
+            if (!label.empty()) batch.WriteName(address, label);
+        }
+    };
+    if (data.watchonly_wallet) persist_address_book(*data.watchonly_wallet);
+    if (data.solvable_wallet) persist_address_book(*data.solvable_wallet);
+
     // Remove the things to delete
     if (dests_to_delete.size() > 0) {
         for (const auto& dest : dests_to_delete) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4003,23 +4003,9 @@ void CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc)
     }
 }
 
-void CWallet::SetupDescriptorScriptPubKeyMans(const SecureString& mnemonic_arg, const SecureString mnemonic_passphrase)
+void CWallet::SetupDescriptorScriptPubKeyMans(const CExtKey& master_key, const SecureString& mnemonic, const SecureString mnemonic_passphrase)
 {
     AssertLockHeld(cs_wallet);
-
-    if (!IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
-    // Make a seed
-    // TODO: remove duplicated code with CHDChain::SetMnemonic
-    const SecureString mnemonic = mnemonic_arg.empty() ? CMnemonic::Generate(m_args.GetIntArg("-mnemonicbits", CHDChain::DEFAULT_MNEMONIC_BITS)) : mnemonic_arg;
-    if (!CMnemonic::Check(mnemonic)) {
-        throw std::runtime_error(std::string(__func__) + ": invalid mnemonic: `" + std::string(mnemonic) + "`");
-    }
-    SecureVector seed_key;
-    CMnemonic::ToSeed(mnemonic, mnemonic_passphrase, seed_key);
-
-    // Get the extended key
-    CExtKey master_key;
-    master_key.SetSeed(MakeByteSpan(seed_key));
 
     for (auto type : {PathDerivationType::BIP44_External, PathDerivationType::BIP44_Internal, PathDerivationType::DIP0009_CoinJoin}) {
         { // OUTPUT_TYPE is only one: LEGACY
@@ -4040,6 +4026,27 @@ void CWallet::SetupDescriptorScriptPubKeyMans(const SecureString& mnemonic_arg, 
             }
         }
     }
+}
+
+void CWallet::SetupDescriptorScriptPubKeyMans(const SecureString& mnemonic_arg, const SecureString mnemonic_passphrase)
+{
+    AssertLockHeld(cs_wallet);
+
+    if (!IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
+    // Make a seed
+    // TODO: remove duplicated code with CHDChain::SetMnemonic
+    const SecureString mnemonic = mnemonic_arg.empty() ? CMnemonic::Generate(m_args.GetIntArg("-mnemonicbits", CHDChain::DEFAULT_MNEMONIC_BITS)) : mnemonic_arg;
+    if (!CMnemonic::Check(mnemonic)) {
+        throw std::runtime_error(std::string(__func__) + ": invalid mnemonic: `" + std::string(mnemonic) + "`");
+    }
+    SecureVector seed_key;
+    CMnemonic::ToSeed(mnemonic, mnemonic_passphrase, seed_key);
+
+    // Get the extended key
+    CExtKey master_key;
+    master_key.SetSeed(MakeByteSpan(seed_key));
+
+        SetupDescriptorScriptPubKeyMans(master_key, mnemonic, mnemonic_passphrase);
     } else {
         ExternalSigner signer = ExternalSignerScriptPubKeyMan::GetExternalSigner();
 
@@ -4211,9 +4218,13 @@ ScriptPubKeyMan* CWallet::AddWalletDescriptor(WalletDescriptor& desc, const Flat
             return nullptr;
         }
 
-        CTxDestination dest;
-        if (!internal && ExtractDestination(script_pub_keys.at(0), dest)) {
-            SetAddressBook(dest, label, "receive");
+        if (!internal) {
+            for (const auto& script : script_pub_keys) {
+                CTxDestination dest;
+                if (ExtractDestination(script, dest)) {
+                    SetAddressBook(dest, label, "receive");
+                }
+            }
         }
     }
 
@@ -4221,5 +4232,473 @@ ScriptPubKeyMan* CWallet::AddWalletDescriptor(WalletDescriptor& desc, const Flat
     spk_man->WriteDescriptor();
 
     return spk_man;
+}
+
+bool CWallet::MigrateToSQLite(bilingual_str& error)
+{
+    AssertLockHeld(cs_wallet);
+
+    WalletLogPrintf("Migrating wallet storage database from BerkeleyDB to SQLite.\n");
+
+    if (m_database->Format() == "sqlite") {
+        error = _("Error: This wallet already uses SQLite");
+        return false;
+    }
+
+    // Get all of the records for DB type migration
+    std::unique_ptr<DatabaseBatch> batch = m_database->MakeBatch();
+    std::vector<std::pair<SerializeData, SerializeData>> records;
+    if (!batch->StartCursor()) {
+        error = _("Error: Unable to begin reading all records in the database");
+        return false;
+    }
+    bool complete = false;
+    while (true) {
+        CDataStream ss_key(SER_DISK, CLIENT_VERSION);
+        CDataStream ss_value(SER_DISK, CLIENT_VERSION);
+        bool ret = batch->ReadAtCursor(ss_key, ss_value, complete);
+        if (!ret) {
+            break;
+        }
+        SerializeData key(ss_key.begin(), ss_key.end());
+        SerializeData value(ss_value.begin(), ss_value.end());
+        records.emplace_back(key, value);
+    }
+    batch->CloseCursor();
+    batch.reset();
+    if (!complete) {
+        error = _("Error: Unable to read all records in the database");
+        return false;
+    }
+
+    // Close this database and delete the file
+    fs::path db_path = fs::PathFromString(m_database->Filename());
+    fs::path db_dir = db_path.parent_path();
+    m_database->Close();
+    fs::remove(db_path);
+
+    // Make new DB
+    DatabaseOptions opts;
+    opts.require_create = true;
+    opts.require_format = DatabaseFormat::SQLITE;
+    DatabaseStatus db_status;
+    std::unique_ptr<WalletDatabase> new_db = MakeDatabase(db_dir, opts, db_status, error);
+    assert(new_db); // This is to prevent doing anything further with this wallet. The original file was deleted, but a backup exists.
+    m_database.reset();
+    m_database = std::move(new_db);
+
+    // Write existing records into the new DB
+    batch = m_database->MakeBatch();
+    bool began = batch->TxnBegin();
+    assert(began); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
+    for (const auto& [key, value] : records) {
+        CDataStream ss_key(key, SER_DISK, CLIENT_VERSION);
+        CDataStream ss_value(value, SER_DISK, CLIENT_VERSION);
+        if (!batch->Write(ss_key, ss_value)) {
+            batch->TxnAbort();
+            m_database->Close();
+            fs::remove(m_database->Filename());
+            assert(false); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
+        }
+    }
+    bool committed = batch->TxnCommit();
+    assert(committed); // This is a critical error, the new db could not be written to. The original db exists as a backup, but we should not continue execution.
+    return true;
+}
+
+std::optional<MigrationData> CWallet::GetDescriptorsForLegacy(bilingual_str& error) const
+{
+    AssertLockHeld(cs_wallet);
+
+    LegacyScriptPubKeyMan* legacy_spkm = GetLegacyScriptPubKeyMan();
+    if (!legacy_spkm) {
+        error = _("Error: This wallet is already a descriptor wallet");
+        return std::nullopt;
+    }
+
+    std::optional<MigrationData> res = legacy_spkm->MigrateToDescriptor();
+    if (res == std::nullopt) {
+        error = _("Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first");
+        return std::nullopt;
+    }
+    return res;
+}
+
+bool CWallet::ApplyMigrationData(MigrationData& data, bilingual_str& error)
+{
+    AssertLockHeld(cs_wallet);
+
+    LegacyScriptPubKeyMan* legacy_spkm = GetLegacyScriptPubKeyMan();
+    if (!legacy_spkm) {
+        error = _("Error: This wallet is already a descriptor wallet");
+        return false;
+    }
+
+    for (auto& desc_spkm : data.desc_spkms) {
+        if (m_spk_managers.count(desc_spkm->GetID()) > 0) {
+            error = _("Error: Duplicate descriptors created during migration. Your wallet may be corrupted.");
+            return false;
+        }
+        m_spk_managers[desc_spkm->GetID()] = std::move(desc_spkm);
+    }
+
+    // Remove the LegacyScriptPubKeyMan from disk
+    if (!legacy_spkm->DeleteRecords()) {
+        return false;
+    }
+
+    // Remove the LegacyScriptPubKeyMan from memory
+    m_spk_managers.erase(legacy_spkm->GetID());
+    m_external_spk_managers = nullptr;
+    m_internal_spk_managers = nullptr;
+
+    // Setup new descriptors
+    SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    if (!IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+        // Use the existing master key if we have it
+        if (data.master_key.key.IsValid()) {
+            SetupDescriptorScriptPubKeyMans(data.master_key, data.mnemonic, data.mnemonic_passphrase);
+        } else {
+            // Setup with a new seed if we don't.
+            SetupDescriptorScriptPubKeyMans("", "");
+        }
+    }
+
+    // Check if the transactions in the wallet are still ours. Either they belong here, or they belong in the watchonly wallet.
+    // We need to go through these in the tx insertion order so that lookups to spends works.
+    std::vector<uint256> txids_to_delete;
+    for (const auto& [_pos, wtx] : wtxOrdered) {
+        if (!IsMine(*wtx->tx) && !IsFromMe(*wtx->tx)) {
+            // Check it is the watchonly wallet's
+            // solvable_wallet doesn't need to be checked because transactions for those scripts weren't being watched for
+            if (data.watchonly_wallet) {
+                LOCK(data.watchonly_wallet->cs_wallet);
+                if (data.watchonly_wallet->IsMine(*wtx->tx) || data.watchonly_wallet->IsFromMe(*wtx->tx)) {
+                    // Add to watchonly wallet
+                    if (!data.watchonly_wallet->AddToWallet(wtx->tx, wtx->m_state)) {
+                        error = _("Error: Could not add watchonly tx to watchonly wallet");
+                        return false;
+                    }
+                    // Mark as to remove from this wallet
+                    txids_to_delete.push_back(wtx->GetHash());
+                    continue;
+                }
+            }
+            // Both not ours and not in the watchonly wallet
+            error = strprintf(_("Error: Transaction %s in wallet cannot be identified to belong to migrated wallets"), wtx->GetHash().GetHex());
+            return false;
+        }
+    }
+    // Do the removes
+    if (txids_to_delete.size() > 0) {
+        std::vector<uint256> deleted_txids;
+        if (ZapSelectTx(txids_to_delete, deleted_txids) != DBErrors::LOAD_OK) {
+            error = _("Error: Could not delete watchonly transactions");
+            return false;
+        }
+        if (deleted_txids != txids_to_delete) {
+            error = _("Error: Not all watchonly txs could be deleted");
+            return false;
+        }
+        // Tell the GUI of each tx
+        for (const uint256& txid : deleted_txids) {
+            NotifyTransactionChanged(txid, CT_UPDATED);
+        }
+    }
+
+    // Check the address book data in the same way we did for transactions
+    std::vector<CTxDestination> dests_to_delete;
+    for (const auto& addr_pair : m_address_book) {
+        // Labels applied to receiving addresses should go based on IsMine
+        if (addr_pair.second.purpose == "receive") {
+            if (!IsMine(addr_pair.first)) {
+                // Check the address book data is the watchonly wallet's
+                if (data.watchonly_wallet) {
+                    LOCK(data.watchonly_wallet->cs_wallet);
+                    if (data.watchonly_wallet->IsMine(addr_pair.first)) {
+                        // Add to the watchonly. Preserve the labels, purpose, and change-ness
+                        std::string label = addr_pair.second.GetLabel();
+                        std::string purpose = addr_pair.second.purpose;
+                        if (!purpose.empty()) {
+                            data.watchonly_wallet->m_address_book[addr_pair.first].purpose = purpose;
+                        }
+                        if (!addr_pair.second.IsChange()) {
+                            data.watchonly_wallet->m_address_book[addr_pair.first].SetLabel(label);
+                        }
+                        dests_to_delete.push_back(addr_pair.first);
+                        continue;
+                    }
+                }
+                if (data.solvable_wallet) {
+                    LOCK(data.solvable_wallet->cs_wallet);
+                    if (data.solvable_wallet->IsMine(addr_pair.first)) {
+                        // Add to the solvable. Preserve the labels, purpose, and change-ness
+                        std::string label = addr_pair.second.GetLabel();
+                        std::string purpose = addr_pair.second.purpose;
+                        if (!purpose.empty()) {
+                            data.solvable_wallet->m_address_book[addr_pair.first].purpose = purpose;
+                        }
+                        if (!addr_pair.second.IsChange()) {
+                            data.solvable_wallet->m_address_book[addr_pair.first].SetLabel(label);
+                        }
+                        dests_to_delete.push_back(addr_pair.first);
+                        continue;
+                    }
+                }
+                // Not ours, not in watchonly wallet, and not in solvable
+                error = _("Error: Address book data in wallet cannot be identified to belong to migrated wallets");
+                return false;
+            }
+        } else {
+            // Labels for everything else (send) should be cloned to all
+            if (data.watchonly_wallet) {
+                LOCK(data.watchonly_wallet->cs_wallet);
+                // Add to the watchonly. Preserve the labels, purpose, and change-ness
+                std::string label = addr_pair.second.GetLabel();
+                std::string purpose = addr_pair.second.purpose;
+                if (!purpose.empty()) {
+                    data.watchonly_wallet->m_address_book[addr_pair.first].purpose = purpose;
+                }
+                if (!addr_pair.second.IsChange()) {
+                    data.watchonly_wallet->m_address_book[addr_pair.first].SetLabel(label);
+                }
+                continue;
+            }
+            if (data.solvable_wallet) {
+                LOCK(data.solvable_wallet->cs_wallet);
+                // Add to the solvable. Preserve the labels, purpose, and change-ness
+                std::string label = addr_pair.second.GetLabel();
+                std::string purpose = addr_pair.second.purpose;
+                if (!purpose.empty()) {
+                    data.solvable_wallet->m_address_book[addr_pair.first].purpose = purpose;
+                }
+                if (!addr_pair.second.IsChange()) {
+                    data.solvable_wallet->m_address_book[addr_pair.first].SetLabel(label);
+                }
+                continue;
+            }
+        }
+    }
+    // Remove the things to delete
+    if (dests_to_delete.size() > 0) {
+        for (const auto& dest : dests_to_delete) {
+            if (!DelAddressBook(dest)) {
+                error = _("Error: Unable to remove watchonly address book data");
+                return false;
+            }
+        }
+    }
+
+    // Connect the SPKM signals
+    ConnectScriptPubKeyManNotifiers();
+    NotifyCanGetAddressesChanged();
+
+    WalletLogPrintf("Wallet migration complete.\n");
+
+    return true;
+}
+
+bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, MigrationResult& res) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    AssertLockHeld(wallet.cs_wallet);
+
+    // Get all of the descriptors from the legacy wallet
+    std::optional<MigrationData> data = wallet.GetDescriptorsForLegacy(error);
+    if (data == std::nullopt) return false;
+
+    // Create the watchonly and solvable wallets if necessary
+    if (data->watch_descs.size() > 0 || data->solvable_descs.size() > 0) {
+        DatabaseOptions options;
+        options.require_existing = false;
+        options.require_create = true;
+
+        // Make the wallets
+        options.create_flags = WALLET_FLAG_DISABLE_PRIVATE_KEYS | WALLET_FLAG_BLANK_WALLET | WALLET_FLAG_DESCRIPTORS;
+        if (wallet.IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE)) {
+            options.create_flags |= WALLET_FLAG_AVOID_REUSE;
+        }
+        if (wallet.IsWalletFlagSet(WALLET_FLAG_KEY_ORIGIN_METADATA)) {
+            options.create_flags |= WALLET_FLAG_KEY_ORIGIN_METADATA;
+        }
+        if (data->watch_descs.size() > 0) {
+            wallet.WalletLogPrintf("Making a new watchonly wallet containing the watched scripts\n");
+
+            DatabaseStatus status;
+            std::vector<bilingual_str> warnings;
+            std::string wallet_name = wallet.GetName() + "_watchonly";
+            data->watchonly_wallet = CreateWallet(context, wallet_name, std::nullopt, options, status, error, warnings);
+            if (status != DatabaseStatus::SUCCESS) {
+                error = _("Error: Failed to create new watchonly wallet");
+                return false;
+            }
+            res.watchonly_wallet = data->watchonly_wallet;
+            LOCK(data->watchonly_wallet->cs_wallet);
+
+            // Parse the descriptors and add them to the new wallet
+            for (const auto& [desc_str, creation_time] : data->watch_descs) {
+                // Parse the descriptor
+                FlatSigningProvider keys;
+                std::string parse_err;
+                std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, parse_err, /* require_checksum */ true);
+                assert(desc); // It shouldn't be possible to have the LegacyScriptPubKeyMan make an invalid descriptor
+                assert(!desc->IsRange()); // It shouldn't be possible to have LegacyScriptPubKeyMan make a ranged watchonly descriptor
+
+                // Add to the wallet
+                WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
+                data->watchonly_wallet->AddWalletDescriptor(w_desc, keys, "", false);
+            }
+
+            // Add the wallet to settings
+            UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/true, warnings);
+        }
+        if (data->solvable_descs.size() > 0) {
+            wallet.WalletLogPrintf("Making a new watchonly wallet containing the unwatched solvable scripts\n");
+
+            DatabaseStatus status;
+            std::vector<bilingual_str> warnings;
+            std::string wallet_name = wallet.GetName() + "_solvables";
+            data->solvable_wallet = CreateWallet(context, wallet_name, std::nullopt, options, status, error, warnings);
+            if (status != DatabaseStatus::SUCCESS) {
+                error = _("Error: Failed to create new watchonly wallet");
+                return false;
+            }
+            res.solvables_wallet = data->solvable_wallet;
+            LOCK(data->solvable_wallet->cs_wallet);
+
+            // Parse the descriptors and add them to the new wallet
+            for (const auto& [desc_str, creation_time] : data->solvable_descs) {
+                // Parse the descriptor
+                FlatSigningProvider keys;
+                std::string parse_err;
+                std::unique_ptr<Descriptor> desc = Parse(desc_str, keys, parse_err, /* require_checksum */ true);
+                assert(desc); // It shouldn't be possible to have the LegacyScriptPubKeyMan make an invalid descriptor
+                assert(!desc->IsRange()); // It shouldn't be possible to have LegacyScriptPubKeyMan make a ranged watchonly descriptor
+
+                // Add to the wallet
+                WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
+                data->solvable_wallet->AddWalletDescriptor(w_desc, keys, "", false);
+            }
+
+            // Add the wallet to settings
+            UpdateWalletSetting(*context.chain, wallet_name, /*load_on_startup=*/true, warnings);
+        }
+    }
+
+    // Add the descriptors to wallet, remove LegacyScriptPubKeyMan, and cleanup txs and address book data
+    if (!wallet.ApplyMigrationData(*data, error)) {
+        return false;
+    }
+    return true;
+}
+
+util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>&& wallet, WalletContext& context)
+{
+    MigrationResult res;
+    bilingual_str error;
+    std::vector<bilingual_str> warnings;
+
+    // Make a backup of the DB
+    std::string wallet_name = wallet->GetName();
+    fs::path this_wallet_dir = fs::absolute(fs::PathFromString(wallet->GetDatabase().Filename())).parent_path();
+    fs::path backup_filename = fs::PathFromString(strprintf("%s-%d.legacy.bak", wallet_name, GetTime()));
+    fs::path backup_path = this_wallet_dir / backup_filename;
+    if (!wallet->BackupWallet(fs::PathToString(backup_path))) {
+        return util::Error{_("Error: Unable to make a backup of your wallet")};
+    }
+    res.backup_path = backup_path;
+
+    // Unload the wallet so that nothing else tries to use it while we're changing it
+    if (!RemoveWallet(context, wallet, /*load_on_start=*/std::nullopt, warnings)) {
+        return util::Error{_("Unable to unload the wallet before migrating")};
+    }
+    UnloadWallet(std::move(wallet));
+
+    // Load the wallet but only in the context of this function.
+    // No signals should be connected nor should anything else be aware of this wallet
+    WalletContext empty_context;
+    empty_context.args = context.args;
+    DatabaseOptions options;
+    options.require_existing = true;
+    DatabaseStatus status;
+    std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(wallet_name, options, status, error);
+    if (!database) {
+        return util::Error{Untranslated("Wallet file verification failed.") + Untranslated(" ") + error};
+    }
+
+    std::shared_ptr<CWallet> local_wallet = CWallet::Create(empty_context, wallet_name, std::move(database), options.create_flags, error, warnings);
+    if (!local_wallet) {
+        return util::Error{Untranslated("Wallet loading failed.") + Untranslated(" ") + error};
+    }
+
+    bool success = false;
+    {
+        LOCK(local_wallet->cs_wallet);
+
+        // First change to using SQLite
+        if (!local_wallet->MigrateToSQLite(error)) return util::Error{error};
+
+        // Do the migration, and cleanup if it fails
+        success = DoMigration(*local_wallet, context, error, res);
+    }
+
+    if (success) {
+        // Migration successful, unload the wallet locally, then reload it.
+        assert(local_wallet.use_count() == 1);
+        local_wallet.reset();
+        LoadWallet(context, wallet_name, /*load_on_start=*/std::nullopt, options, status, error, warnings);
+        res.wallet_name = wallet_name;
+    } else {
+        // Migration failed, cleanup
+        // Copy the backup to the actual wallet dir
+        fs::path temp_backup_location = fsbridge::AbsPathJoin(GetWalletDir(), backup_filename);
+        fs::copy_file(backup_path, temp_backup_location, fs::copy_options::none);
+
+        // Remember this wallet's walletdir to remove after unloading
+        std::vector<fs::path> wallet_dirs;
+        wallet_dirs.push_back(fs::PathFromString(local_wallet->GetDatabase().Filename()).parent_path());
+
+        // Unload the wallet locally
+        assert(local_wallet.use_count() == 1);
+        local_wallet.reset();
+
+        // Make list of wallets to cleanup
+        std::vector<std::shared_ptr<CWallet>> created_wallets;
+        created_wallets.push_back(std::move(res.watchonly_wallet));
+        created_wallets.push_back(std::move(res.solvables_wallet));
+
+        // Get the directories to remove after unloading
+        for (std::shared_ptr<CWallet>& w : created_wallets) {
+            wallet_dirs.push_back(fs::PathFromString(w->GetDatabase().Filename()).parent_path());
+        }
+
+        // Unload the wallets
+        for (std::shared_ptr<CWallet>& w : created_wallets) {
+            if (!RemoveWallet(context, w, /*load_on_start=*/false)) {
+                error += _("\nUnable to cleanup failed migration");
+                return util::Error{error};
+            }
+            UnloadWallet(std::move(w));
+        }
+
+        // Delete the wallet directories
+        for (fs::path& dir : wallet_dirs) {
+            fs::remove_all(dir);
+        }
+
+        // Restore the backup
+        DatabaseStatus status;
+        std::vector<bilingual_str> warnings;
+        if (!RestoreWallet(context, temp_backup_location, wallet_name, /*load_on_start=*/std::nullopt, status, error, warnings)) {
+            error += _("\nUnable to restore backup of wallet.");
+            return util::Error{error};
+        }
+
+        // Move the backup to the wallet dir
+        fs::copy_file(temp_backup_location, backup_path, fs::copy_options::none);
+        fs::remove(temp_backup_location);
+
+        return util::Error{error};
+    }
+    return res;
 }
 } // namespace wallet

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4682,8 +4682,8 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
 
         // Make list of wallets to cleanup
         std::vector<std::shared_ptr<CWallet>> created_wallets;
-        created_wallets.push_back(std::move(res.watchonly_wallet));
-        created_wallets.push_back(std::move(res.solvables_wallet));
+        if (res.watchonly_wallet) created_wallets.push_back(std::move(res.watchonly_wallet));
+        if (res.solvables_wallet) created_wallets.push_back(std::move(res.solvables_wallet));
 
         // Get the directories to remove after unloading
         for (std::shared_ptr<CWallet>& w : created_wallets) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4355,6 +4355,18 @@ bool CWallet::ApplyMigrationData(MigrationData& data, bilingual_str& error)
         // Use the existing master key if we have it
         if (data.master_key.key.IsValid()) {
             SetupDescriptorScriptPubKeyMans(data.master_key, data.mnemonic, data.mnemonic_passphrase);
+
+            // Advance the active pkh() descriptors past the legacy chain
+            // counters so post-migration getnewaddress doesn't hand back
+            // addresses the legacy wallet already derived. The historical
+            // scripts themselves are still recognized by the inactive combo
+            // descriptors built in MigrateToDescriptor.
+            for (bool internal : {false, true}) {
+                auto* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(GetScriptPubKeyMan(/*internal=*/internal));
+                if (desc_spk_man == nullptr) continue;
+                const uint32_t counter = internal ? data.internal_chain_counter : data.external_chain_counter;
+                if (counter > 0) desc_spk_man->AdvanceNextIndexTo(counter);
+            }
         } else {
             // Setup with a new seed if we don't.
             SetupDescriptorScriptPubKeyMans("", "");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4311,10 +4311,7 @@ std::optional<MigrationData> CWallet::GetDescriptorsForLegacy(bilingual_str& err
     AssertLockHeld(cs_wallet);
 
     LegacyScriptPubKeyMan* legacy_spkm = GetLegacyScriptPubKeyMan();
-    if (!legacy_spkm) {
-        error = _("Error: This wallet is already a descriptor wallet");
-        return std::nullopt;
-    }
+    assert(legacy_spkm);
 
     std::optional<MigrationData> res = legacy_spkm->MigrateToDescriptor();
     if (res == std::nullopt) {
@@ -4593,6 +4590,11 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
 
 util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>&& wallet, WalletContext& context)
 {
+    // Before anything else, check if there is something to migrate.
+    if (!wallet->GetLegacyScriptPubKeyMan()) {
+        return util::Error{_("Error: This wallet is already a descriptor wallet")};
+    }
+
     MigrationResult res;
     bilingual_str error;
     std::vector<bilingual_str> warnings;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4315,7 +4315,7 @@ std::optional<MigrationData> CWallet::GetDescriptorsForLegacy(bilingual_str& err
 
     std::optional<MigrationData> res = legacy_spkm->MigrateToDescriptor();
     if (res == std::nullopt) {
-        error = _("Error: Unable to produce descriptors for this legacy wallet. Make sure the wallet is unlocked first");
+        error = _("Error: Unable to produce descriptors for this legacy wallet. Make sure to provide the wallet's passphrase if it is encrypted.");
         return std::nullopt;
     }
     return res;
@@ -4605,32 +4605,19 @@ bool DoMigration(CWallet& wallet, WalletContext& context, bilingual_str& error, 
     return true;
 }
 
-util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>&& wallet, WalletContext& context)
+util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& wallet_name, const SecureString& passphrase, WalletContext& context)
 {
-    // Before anything else, check if there is something to migrate.
-    if (!wallet->GetLegacyScriptPubKeyMan()) {
-        return util::Error{_("Error: This wallet is already a descriptor wallet")};
-    }
-
     MigrationResult res;
     bilingual_str error;
     std::vector<bilingual_str> warnings;
 
-    // Make a backup of the DB
-    std::string wallet_name = wallet->GetName();
-    fs::path this_wallet_dir = fs::absolute(fs::PathFromString(wallet->GetDatabase().Filename())).parent_path();
-    fs::path backup_filename = fs::PathFromString(strprintf("%s-%d.legacy.bak", wallet_name, GetTime()));
-    fs::path backup_path = this_wallet_dir / backup_filename;
-    if (!wallet->BackupWallet(fs::PathToString(backup_path))) {
-        return util::Error{_("Error: Unable to make a backup of your wallet")};
+    // If the wallet is still loaded, unload it so that nothing else tries to use it while we're changing it
+    if (auto wallet = GetWallet(context, wallet_name)) {
+        if (!RemoveWallet(context, wallet, /*load_on_start=*/std::nullopt, warnings)) {
+            return util::Error{_("Unable to unload the wallet before migrating")};
+        }
+        UnloadWallet(std::move(wallet));
     }
-    res.backup_path = backup_path;
-
-    // Unload the wallet so that nothing else tries to use it while we're changing it
-    if (!RemoveWallet(context, wallet, /*load_on_start=*/std::nullopt, warnings)) {
-        return util::Error{_("Unable to unload the wallet before migrating")};
-    }
-    UnloadWallet(std::move(wallet));
 
     // Load the wallet but only in the context of this function.
     // No signals should be connected nor should anything else be aware of this wallet
@@ -4644,14 +4631,42 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
         return util::Error{Untranslated("Wallet file verification failed.") + Untranslated(" ") + error};
     }
 
+    // Make the local wallet
     std::shared_ptr<CWallet> local_wallet = CWallet::Create(empty_context, wallet_name, std::move(database), options.create_flags, error, warnings);
     if (!local_wallet) {
         return util::Error{Untranslated("Wallet loading failed.") + Untranslated(" ") + error};
     }
 
+    // Before anything else, check if there is something to migrate.
+    if (!local_wallet->GetLegacyScriptPubKeyMan()) {
+        return util::Error{_("Error: This wallet is already a descriptor wallet")};
+    }
+
+    // Make a backup of the DB
+    fs::path this_wallet_dir = fs::absolute(fs::PathFromString(local_wallet->GetDatabase().Filename())).parent_path();
+    fs::path backup_filename = fs::PathFromString(strprintf("%s-%d.legacy.bak", wallet_name, GetTime()));
+    fs::path backup_path = this_wallet_dir / backup_filename;
+    if (!local_wallet->BackupWallet(fs::PathToString(backup_path))) {
+        return util::Error{_("Error: Unable to make a backup of your wallet")};
+    }
+    res.backup_path = backup_path;
+
     bool success = false;
     {
         LOCK(local_wallet->cs_wallet);
+
+        // Unlock the wallet if needed
+        if (local_wallet->IsLocked() && !local_wallet->Unlock(passphrase)) {
+            if (passphrase.find('\0') == std::string::npos) {
+                return util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase was not provided or was incorrect.")};
+            } else {
+                return util::Error{Untranslated("Error: Wallet decryption failed, the wallet passphrase entered was incorrect. "
+                                                "The passphrase contains a null character (ie - a zero byte). "
+                                                "If this passphrase was set with a version of this software prior to 25.0, "
+                                                "please try again with only the characters up to — but not including — "
+                                                "the first null character.")};
+            }
+        }
 
         // First change to using SQLite
         if (!local_wallet->MigrateToSQLite(error)) return util::Error{error};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4365,7 +4365,10 @@ bool CWallet::ApplyMigrationData(MigrationData& data, bilingual_str& error)
                 auto* desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(GetScriptPubKeyMan(/*internal=*/internal));
                 if (desc_spk_man == nullptr) continue;
                 const uint32_t counter = internal ? data.internal_chain_counter : data.external_chain_counter;
-                if (counter > 0) desc_spk_man->AdvanceNextIndexTo(counter);
+                if (counter > 0 && !desc_spk_man->AdvanceNextIndexTo(counter)) {
+                    error = _("Error: Failed to advance active descriptor past legacy chain counter during migration.");
+                    return false;
+                }
             }
         } else {
             // Setup with a new seed if we don't.
@@ -4656,7 +4659,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& walle
 
     // Make a backup of the DB
     fs::path this_wallet_dir = fs::absolute(fs::PathFromString(local_wallet->GetDatabase().Filename())).parent_path();
-    fs::path backup_filename = fs::PathFromString(strprintf("%s-%d.legacy.bak", wallet_name, GetTime()));
+    fs::path backup_filename = fs::PathFromString(strprintf("%s-%d.legacy.bak", wallet_name.empty() ? "wallet" : wallet_name, GetTime()));
     fs::path backup_path = this_wallet_dir / backup_filename;
     if (!local_wallet->BackupWallet(fs::PathToString(backup_path))) {
         return util::Error{_("Error: Unable to make a backup of your wallet")};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4657,9 +4657,19 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& walle
         return util::Error{_("Error: This wallet is already a descriptor wallet")};
     }
 
-    // Make a backup of the DB
+    // Make a backup of the DB in the wallet's directory with a unique filename
+    // based on the wallet name and current timestamp. The backup filename uses
+    // the basename of the wallet path (or "wallet" if the name is blank) so that
+    // path-style wallet names cannot escape the wallet directory.
+    // TODO: backport bitcoin/bitcoin#32273 to also move the backup into the
+    //       top-level walletdir and unify with upstream.
     fs::path this_wallet_dir = fs::absolute(fs::PathFromString(local_wallet->GetDatabase().Filename())).parent_path();
-    fs::path backup_filename = fs::PathFromString(strprintf("%s-%d.legacy.bak", wallet_name.empty() ? "wallet" : wallet_name, GetTime()));
+    const std::string backup_prefix = wallet_name.empty() ? "wallet" : [&] {
+        // fs::weakly_canonical resolves relative specifiers and removes trailing slashes.
+        const auto legacy_wallet_path = fs::weakly_canonical(GetWalletDir() / fs::PathFromString(wallet_name));
+        return fs::PathToString(legacy_wallet_path.filename());
+    }();
+    fs::path backup_filename = fs::PathFromString(strprintf("%s-%d.legacy.bak", backup_prefix, GetTime()));
     fs::path backup_path = this_wallet_dir / backup_filename;
     if (!local_wallet->BackupWallet(fs::PathToString(backup_path))) {
         return util::Error{_("Error: Unable to make a backup of your wallet")};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4664,11 +4664,15 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& walle
     // TODO: backport bitcoin/bitcoin#32273 to also move the backup into the
     //       top-level walletdir and unify with upstream.
     fs::path this_wallet_dir = fs::absolute(fs::PathFromString(local_wallet->GetDatabase().Filename())).parent_path();
-    const std::string backup_prefix = wallet_name.empty() ? "wallet" : [&] {
+    std::string backup_prefix;
+    if (!wallet_name.empty()) {
         // fs::weakly_canonical resolves relative specifiers and removes trailing slashes.
         const auto legacy_wallet_path = fs::weakly_canonical(GetWalletDir() / fs::PathFromString(wallet_name));
-        return fs::PathToString(legacy_wallet_path.filename());
-    }();
+        backup_prefix = fs::PathToString(legacy_wallet_path.filename());
+    }
+    // Fall back when the name was blank or canonicalizes to an empty filename
+    // (e.g. "/", "."), so we never emit a file like "-1748432384.legacy.bak".
+    if (backup_prefix.empty()) backup_prefix = "wallet";
     fs::path backup_filename = fs::PathFromString(strprintf("%s-%d.legacy.bak", backup_prefix, GetTime()));
     fs::path backup_path = this_wallet_dir / backup_filename;
     if (!local_wallet->BackupWallet(fs::PathToString(backup_path))) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -381,7 +381,7 @@ private:
     std::string m_name;
 
     /** Internal database handle. */
-    std::unique_ptr<WalletDatabase> const m_database;
+    std::unique_ptr<WalletDatabase> m_database;
 
     /**
      * The following is used to keep track of how far behind the wallet is
@@ -1069,6 +1069,7 @@ public:
     void DeactivateScriptPubKeyMan(uint256 id, bool internal);
 
     //! Create new DescriptorScriptPubKeyMans and add them to the wallet
+    void SetupDescriptorScriptPubKeyMans(const CExtKey& master_key, const SecureString& mnemonic, const SecureString mnemonic_passphrase) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void SetupDescriptorScriptPubKeyMans(const SecureString& mnemonic, const SecureString mnemonic_passphrase) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Return the DescriptorScriptPubKeyMan for a WalletDescriptor if it is already in the wallet
@@ -1081,6 +1082,20 @@ public:
 
     //! Add a descriptor to the wallet, return a ScriptPubKeyMan & associated output type
     ScriptPubKeyMan* AddWalletDescriptor(WalletDescriptor& desc, const FlatSigningProvider& signing_provider, const std::string& label, bool internal) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    /** Move all records from the BDB database to a new SQLite database for storage.
+     * The original BDB file will be deleted and replaced with a new SQLite file.
+     * A backup is not created.
+     * May crash if something unexpected happens in the filesystem.
+     */
+    bool MigrateToSQLite(bilingual_str& error) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    //! Get all of the descriptors from a legacy wallet
+    std::optional<MigrationData> GetDescriptorsForLegacy(bilingual_str& error) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    //! Adds the ScriptPubKeyMans given in MigrationData to this wallet, removes LegacyScriptPubKeyMan,
+    //! and where needed, moves tx and address book entries to watchonly_wallet or solvable_wallet
+    bool ApplyMigrationData(MigrationData& data, bilingual_str& error) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 };
 
 /**
@@ -1141,6 +1156,16 @@ bool RemoveWalletSetting(interfaces::Chain& chain, const std::string& wallet_nam
 bool DummySignInput(const SigningProvider& provider, CTxIn &tx_in, const CTxOut &txout, const CCoinControl* coin_control = nullptr);
 
 bool FillInputToWeight(CTxIn& txin, int64_t target_weight);
+
+struct MigrationResult {
+    std::string wallet_name;
+    std::shared_ptr<CWallet> watchonly_wallet;
+    std::shared_ptr<CWallet> solvables_wallet;
+    fs::path backup_path;
+};
+
+//! Do all steps to migrate a legacy wallet to a descriptor wallet
+util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>&& wallet, WalletContext& context);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLET_H

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1165,7 +1165,7 @@ struct MigrationResult {
 };
 
 //! Do all steps to migrate a legacy wallet to a descriptor wallet
-util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>&& wallet, WalletContext& context);
+util::Result<MigrationResult> MigrateLegacyToDescriptor(const std::string& wallet_name, const SecureString& passphrase, WalletContext& context);
 } // namespace wallet
 
 #endif // BITCOIN_WALLET_WALLET_H

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -67,6 +67,7 @@ const std::string WALLETDESCRIPTORCKEY{"walletdescriptorckey"};
 const std::string WALLETDESCRIPTORKEY{"walletdescriptorkey"};
 const std::string WATCHMETA{"watchmeta"};
 const std::string WATCHS{"watchs"};
+const std::unordered_set<std::string> LEGACY_TYPES{CRYPTED_KEY, CRYPTED_HDCHAIN, CSCRIPT, DEFAULTKEY, HDCHAIN, HDPUBKEY, KEYMETA, KEY, OLD_KEY, POOL, PRIVATESEND_SALT, WATCHMETA, WATCHS};
 } // namespace DBKeys
 
 //
@@ -1145,6 +1146,45 @@ bool WalletBatch::WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& k
 bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 {
     return WriteIC(DBKeys::FLAGS, flags);
+}
+
+bool WalletBatch::EraseRecords(const std::unordered_set<std::string>& types)
+{
+    // Get cursor
+    if (!m_batch->StartCursor())
+    {
+        return false;
+    }
+
+    // Iterate the DB and look for any records that have the type prefixes
+    while (true)
+    {
+        // Read next record
+        CDataStream key(SER_DISK, CLIENT_VERSION);
+        CDataStream value(SER_DISK, CLIENT_VERSION);
+        bool complete;
+        bool ret = m_batch->ReadAtCursor(key, value, complete);
+        if (complete) {
+            break;
+        }
+        else if (!ret)
+        {
+            m_batch->CloseCursor();
+            return false;
+        }
+
+        // Make a copy of key to avoid data being deleted by the following read of the type
+        Span<const unsigned char> key_data = MakeUCharSpan(key);
+
+        std::string type;
+        key >> type;
+
+        if (types.count(type) > 0) {
+            m_batch->Erase(key_data);
+        }
+    }
+    m_batch->CloseCursor();
+    return true;
 }
 
 bool WalletBatch::TxnBegin()

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -93,6 +93,9 @@ extern const std::string WALLETDESCRIPTORCKEY;
 extern const std::string WALLETDESCRIPTORKEY;
 extern const std::string WATCHMETA;
 extern const std::string WATCHS;
+
+// Keys in this set pertain only to the legacy wallet (LegacyScriptPubKeyMan) and are removed during migration from legacy to descriptors.
+extern const std::unordered_set<std::string> LEGACY_TYPES;
 } // namespace DBKeys
 
 class CKeyMetadata
@@ -242,6 +245,9 @@ public:
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain& chain);
     bool WriteHDPubKey(const CHDPubKey& hdPubKey, const CKeyMetadata& keyMeta);
+
+    //! Delete records of the given types
+    bool EraseRecords(const std::unordered_set<std::string>& types);
 
     bool WriteWalletFlags(const uint64_t flags);
     //! Begin a new transaction

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -111,6 +111,15 @@ struct MigrationData
     CExtKey master_key;
     SecureString mnemonic;
     SecureString mnemonic_passphrase;
+    // Highest BIP44 index the legacy wallet ever derived per chain (external/0,
+    // internal/1). The active pkh() descriptors created during migration must
+    // start handing out the next address from this index, otherwise post-
+    // migration getnewaddress would re-derive addresses the legacy wallet had
+    // already given out. Carried via MigrationData purely to advance the active
+    // descriptors' next_index — the inactive combo descriptors built in
+    // MigrateToDescriptor already cover the history themselves.
+    uint32_t external_chain_counter{0};
+    uint32_t internal_chain_counter{0};
     std::vector<std::pair<std::string, int64_t>> watch_descs;
     std::vector<std::pair<std::string, int64_t>> solvable_descs;
     std::vector<std::unique_ptr<DescriptorScriptPubKeyMan>> desc_spkms;

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -7,6 +7,7 @@
 
 #include <fs.h>
 #include <script/descriptor.h>
+#include <support/allocators/secure.h>
 
 #include <vector>
 
@@ -99,6 +100,22 @@ public:
 
     WalletDescriptor() {}
     WalletDescriptor(std::shared_ptr<Descriptor> descriptor, uint64_t creation_time, int32_t range_start, int32_t range_end, int32_t next_index) : descriptor(descriptor), id(DescriptorID(*descriptor)), creation_time(creation_time), range_start(range_start), range_end(range_end), next_index(next_index) { }
+};
+
+class CWallet;
+class DescriptorScriptPubKeyMan;
+
+/** struct containing information needed for migrating legacy wallets to descriptor wallets */
+struct MigrationData
+{
+    CExtKey master_key;
+    SecureString mnemonic;
+    SecureString mnemonic_passphrase;
+    std::vector<std::pair<std::string, int64_t>> watch_descs;
+    std::vector<std::pair<std::string, int64_t>> solvable_descs;
+    std::vector<std::unique_ptr<DescriptorScriptPubKeyMan>> desc_spkms;
+    std::shared_ptr<CWallet> watchonly_wallet{nullptr};
+    std::shared_ptr<CWallet> solvable_wallet{nullptr};
 };
 } // namespace wallet
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -408,6 +408,7 @@ BASE_SCRIPTS = [
     'rpc_help.py',
     'feature_dirsymlinks.py',
     'feature_help.py',
+    'wallet_migration.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -64,7 +64,7 @@ class ToolWalletTest(BitcoinTestFramework):
         result = 'unchanged' if new == old else 'increased!'
         self.log.debug('Wallet file timestamp {}'.format(result))
 
-    def get_expected_info_output(self, name="", transactions=0, keypool=2, address=0):
+    def get_expected_info_output(self, name="", transactions=0, keypool=2, address=0, imported_privs=0):
         wallet_name = self.default_wallet_name if name == "" else name
         output_types = 1  # p2pkh
         if self.options.descriptors:
@@ -79,7 +79,7 @@ class ToolWalletTest(BitcoinTestFramework):
                 Keypool Size: %d
                 Transactions: %d
                 Address Book: %d
-            ''' % (wallet_name, keypool * output_types, transactions, address))
+            ''' % (wallet_name, keypool * output_types, transactions, imported_privs * 2 + address))
         else:
             return textwrap.dedent('''\
                 Wallet info
@@ -92,7 +92,7 @@ class ToolWalletTest(BitcoinTestFramework):
                 Keypool Size: %d
                 Transactions: %d
                 Address Book: %d
-            ''' % (wallet_name, keypool, transactions, address * output_types))
+            ''' % (wallet_name, keypool, transactions, (address + imported_privs) * output_types))
 
     def read_dump(self, filename):
         dump = OrderedDict()
@@ -214,7 +214,7 @@ class ToolWalletTest(BitcoinTestFramework):
         # shasum_before = self.wallet_shasum()
         timestamp_before = self.wallet_timestamp()
         self.log.debug('Wallet file timestamp before calling info: {}'.format(timestamp_before))
-        out = self.get_expected_info_output(address=1)
+        out = self.get_expected_info_output(imported_privs=1)
         self.assert_tool_output(out, '-wallet=' + self.default_wallet_name, 'info')
 
         timestamp_after = self.wallet_timestamp()
@@ -246,7 +246,7 @@ class ToolWalletTest(BitcoinTestFramework):
         shasum_before = self.wallet_shasum()
         timestamp_before = self.wallet_timestamp()
         self.log.debug('Wallet file timestamp before calling info: {}'.format(timestamp_before))
-        out = self.get_expected_info_output(transactions=1, address=1)
+        out = self.get_expected_info_output(transactions=1, imported_privs=1)
         self.assert_tool_output(out, '-wallet=' + self.default_wallet_name, 'info')
         shasum_after = self.wallet_shasum()
         timestamp_after = self.wallet_timestamp()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -417,6 +417,15 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         assert_equal(bals, wallet.getbalances())
 
+    def test_encrypted(self):
+        self.log.info("Test migration of an encrypted wallet")
+        wallet = self.create_legacy_wallet("encrypted")
+
+        wallet.encryptwallet("pass")
+
+        assert_raises_rpc_error(-15, "Error: migratewallet on encrypted wallets is currently unsupported.", wallet.migratewallet)
+        # TODO: Fix migratewallet so that we can actually migrate encrypted wallets
+
     def run_test(self):
         self.generate(self.nodes[0], 101)
 
@@ -426,6 +435,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.test_other_watchonly()
         self.test_no_privkeys()
         self.test_pk_coinbases()
+        self.test_encrypted()
 
 if __name__ == '__main__':
     WalletMigrationTest().main()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test Migrating a wallet from legacy to descriptor."""
+
+import os
+import random
+from test_framework.descriptors import descsum_create
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+    find_vout_for_address,
+)
+
+
+class WalletMigrationTest(BitcoinTestFramework):
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[]]
+        self.supports_cli = False
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+        self.skip_if_no_sqlite()
+        self.skip_if_no_bdb()
+
+    def assert_is_sqlite(self, wallet_name):
+        wallet_file_path = os.path.join(self.nodes[0].datadir, "regtest/wallets", wallet_name, self.wallet_data_filename)
+        with open(wallet_file_path, 'rb') as f:
+            file_magic = f.read(16)
+            assert_equal(file_magic, b'SQLite format 3\x00')
+        assert_equal(self.nodes[0].get_wallet_rpc(wallet_name).getwalletinfo()["format"], "sqlite")
+
+    def create_legacy_wallet(self, wallet_name):
+        self.nodes[0].createwallet(wallet_name=wallet_name)
+        wallet = self.nodes[0].get_wallet_rpc(wallet_name)
+        assert_equal(wallet.getwalletinfo()["descriptors"], False)
+        assert_equal(wallet.getwalletinfo()["format"], "bdb")
+        return wallet
+
+    def assert_addr_info_equal(self, addr_info, addr_info_old):
+        assert_equal(addr_info["address"], addr_info_old["address"])
+        assert_equal(addr_info["scriptPubKey"], addr_info_old["scriptPubKey"])
+        assert_equal(addr_info["ismine"], addr_info_old["ismine"])
+        assert_equal(addr_info["hdkeypath"], addr_info_old["hdkeypath"])
+        assert_equal(addr_info["solvable"], addr_info_old["solvable"])
+        assert_equal(addr_info["ischange"], addr_info_old["ischange"])
+        assert_equal(addr_info["hdmasterfingerprint"], addr_info_old["hdmasterfingerprint"])
+
+    def assert_list_txs_equal(self, received_list_txs, expected_list_txs):
+        for d in received_list_txs:
+            if "parent_descs" in d:
+                del d["parent_descs"]
+        for d in expected_list_txs:
+            if "parent_descs" in d:
+                del d["parent_descs"]
+        assert_equal(received_list_txs, expected_list_txs)
+
+    def test_basic(self):
+        default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        self.log.info("Test migration of a basic keys only wallet without balance")
+        basic0 = self.create_legacy_wallet("basic0")
+
+        addr = basic0.getnewaddress()
+        change = basic0.getrawchangeaddress()
+
+        old_addr_info = basic0.getaddressinfo(addr)
+        old_change_addr_info = basic0.getaddressinfo(change)
+        assert_equal(old_addr_info["ismine"], True)
+        assert_equal(old_addr_info["hdkeypath"], "m/44'/1'/0'/0/0")
+        assert_equal(old_change_addr_info["ismine"], True)
+        assert_equal(old_change_addr_info["hdkeypath"], "m/44'/1'/0'/1/0")
+
+        # Note: migration could take a while.
+        basic0.migratewallet()
+
+        # Verify created descriptors
+        assert_equal(basic0.getwalletinfo()["descriptors"], True)
+        self.assert_is_sqlite("basic0")
+
+        # The wallet should create the following descriptors:
+        # * BIP44 descriptors in the form of "44'/1'/0'/0/*" and "44'/1'/0'/1/*" (2 descriptors)
+        # * Inactive DIP0009 CoinJoin: pkh(xpub/9'/1'/4'/0'/0/*) (1 descriptor)
+        # * Inactive Migration descriptors for the legacy HD keys (2 combo descriptors)
+        # Dash uses the same BIP44 paths for both legacy and descriptor wallets, but
+        # combo descriptor can not be active
+        # So, should have a total of 5 descriptors on it.
+        assert_equal(len(basic0.listdescriptors()["descriptors"]), 5)
+
+        # Compare addresses info
+        addr_info = basic0.getaddressinfo(addr)
+        change_addr_info = basic0.getaddressinfo(change)
+        self.assert_addr_info_equal(addr_info, old_addr_info)
+        self.assert_addr_info_equal(change_addr_info, old_change_addr_info)
+
+        self.log.info("Test migration of a basic keys only wallet with a balance")
+        basic1 = self.create_legacy_wallet("basic1")
+
+        for _ in range(0, 10):
+            default.sendtoaddress(basic1.getnewaddress(), 1)
+
+        self.generate(self.nodes[0], 1)
+
+        for _ in range(0, 5):
+            basic1.sendtoaddress(default.getnewaddress(), 0.5)
+
+        self.generate(self.nodes[0], 1)
+        bal = basic1.getbalance()
+        txs = basic1.listtransactions()
+
+        basic1.migratewallet()
+        assert_equal(basic1.getwalletinfo()["descriptors"], True)
+        self.assert_is_sqlite("basic1")
+        assert_equal(basic1.getbalance(), bal)
+        self.assert_list_txs_equal(basic1.listtransactions(), txs)
+
+        # restart node and verify that everything is still there
+        self.restart_node(0)
+        default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.nodes[0].loadwallet("basic1")
+        basic1 = self.nodes[0].get_wallet_rpc("basic1")
+        assert_equal(basic1.getwalletinfo()["descriptors"], True)
+        self.assert_is_sqlite("basic1")
+        assert_equal(basic1.getbalance(), bal)
+        self.assert_list_txs_equal(basic1.listtransactions(), txs)
+
+        self.log.info("Test migration of a wallet with balance received on seed-derived addresses")
+        # Unlike Bitcoin Core, Dash's sethdseed does NOT register the raw seed
+        # privkey in mapKeys, so the seed pubkey's own P2PKH is never IsMine.
+        # We must therefore receive on BIP44 children of the seed (the same
+        # addresses sethdseed's NewKeyPool derives into the legacy wallet) and
+        # use the matching extended xprv with `deriveaddresses` to look them up
+        # without touching basic2's keypool.
+        #
+        # The (WIF, xprv) pair below was generated together offline from the
+        # BIP32 test vector #1 seed (000102...1f). The xprv is the master
+        # extended key produced by HMAC-SHA512("Bitcoin seed", seed_bytes), i.e.
+        # what CExtKey::SetSeed (src/key.cpp) computes from the WIF's privkey
+        # bytes when sethdseed feeds them into CHDChain.
+        BASIC2_SEED_WIF = "cMai6KJ8sHnNejZctqjiYdg2KSLeiaKcuTbZQrJNEjmMY5JQw6eP"
+        BASIC2_SEED_XPRV = "tprv8ZgxMBicQKsPe48qChGvN9oKqP6PP2Ecaso2tZ254CTd85JyX3dPfaWw3vWN4wgQeaNrX8ZfK3Zq2Q5LHvEoyfZv3mmJpyUz1caSFLya1Ca"
+
+        self.nodes[0].createwallet(wallet_name="basic2", blank=True)
+        basic2 = self.nodes[0].get_wallet_rpc("basic2")
+        basic2.sethdseed(True, BASIC2_SEED_WIF)
+        assert_equal(basic2.getbalance(), 0)
+
+        desc = descsum_create(f"pkh({BASIC2_SEED_XPRV}/44'/1'/0'/0/*)")
+        derived_addrs = self.nodes[0].deriveaddresses(desc, [0, 2])
+
+        basic2_balance = 0
+        for addr in derived_addrs:
+            send_value = random.randint(1, 4)
+            default.sendtoaddress(addr, send_value)
+            basic2_balance += send_value
+            self.generate(self.nodes[0], 1)
+            assert_equal(basic2.getbalance(), basic2_balance)
+        basic2_txs = basic2.listtransactions()
+
+        # Now migrate and test that we still see have the same balance/transactions
+        basic2.migratewallet()
+        assert_equal(basic2.getwalletinfo()["descriptors"], True)
+        self.assert_is_sqlite("basic2")
+        assert_equal(basic2.getbalance(), basic2_balance)
+        self.assert_list_txs_equal(basic2.listtransactions(), basic2_txs)
+
+    def test_multisig(self):
+        default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        # Contrived case where all the multisig keys are in a single wallet
+        self.log.info("Test migration of a wallet with all keys for a multisig")
+        multisig0 = self.create_legacy_wallet("multisig0")
+        addr1 = multisig0.getnewaddress()
+        addr2 = multisig0.getnewaddress()
+        addr3 = multisig0.getnewaddress()
+
+        ms_info = multisig0.addmultisigaddress(2, [addr1, addr2, addr3])
+
+        multisig0.migratewallet()
+        assert_equal(multisig0.getwalletinfo()["descriptors"], True)
+        self.assert_is_sqlite("multisig0")
+        ms_addr_info = multisig0.getaddressinfo(ms_info["address"])
+        assert_equal(ms_addr_info["ismine"], True)
+        assert_equal(ms_addr_info["desc"], ms_info["descriptor"])
+        assert_equal("multisig0_watchonly" in self.nodes[0].listwallets(), False)
+        assert_equal("multisig0_solvables" in self.nodes[0].listwallets(), False)
+
+        pub1 = multisig0.getaddressinfo(addr1)["pubkey"]
+        pub2 = multisig0.getaddressinfo(addr2)["pubkey"]
+
+        # Some keys in multisig do not belong to this wallet
+        self.log.info("Test migration of a wallet that has some keys in a multisig")
+        self.nodes[0].createwallet(wallet_name="multisig1")
+        multisig1 = self.nodes[0].get_wallet_rpc("multisig1")
+        ms_info = multisig1.addmultisigaddress(2, [multisig1.getnewaddress(), pub1, pub2])
+        ms_info2 = multisig1.addmultisigaddress(2, [multisig1.getnewaddress(), pub1, pub2])
+        assert_equal(multisig1.getwalletinfo()["descriptors"], False)
+
+        addr1 = ms_info["address"]
+        addr2 = ms_info2["address"]
+        txid = default.sendtoaddress(addr1, 10)
+        multisig1.importaddress(addr1)
+        assert_equal(multisig1.getaddressinfo(addr1)["ismine"], False)
+        assert_equal(multisig1.getaddressinfo(addr1)["iswatchonly"], True)
+        assert_equal(multisig1.getaddressinfo(addr1)["solvable"], True)
+        self.generate(self.nodes[0], 1)
+        multisig1.gettransaction(txid)
+        assert_equal(multisig1.getbalances()["watchonly"]["trusted"], 10)
+        assert_equal(multisig1.getaddressinfo(addr2)["ismine"], False)
+        assert_equal(multisig1.getaddressinfo(addr2)["iswatchonly"], False)
+        assert_equal(multisig1.getaddressinfo(addr2)["solvable"], True)
+
+        # Migrating multisig1 should see the multisig is no longer part of multisig1
+        # A new wallet multisig1_watchonly is created which has the multisig address
+        # Transaction to multisig is in multisig1_watchonly and not multisig1
+        multisig1.migratewallet()
+        assert_equal(multisig1.getwalletinfo()["descriptors"], True)
+        self.assert_is_sqlite("multisig1")
+        assert_equal(multisig1.getaddressinfo(addr1)["ismine"], False)
+        assert_equal(multisig1.getaddressinfo(addr1)["iswatchonly"], False)
+        assert_equal(multisig1.getaddressinfo(addr1)["solvable"], False)
+        assert_raises_rpc_error(-5, "Invalid or non-wallet transaction id", multisig1.gettransaction, txid)
+        assert_equal(multisig1.getbalance(), 0)
+        assert_equal(multisig1.listtransactions(), [])
+
+        assert_equal("multisig1_watchonly" in self.nodes[0].listwallets(), True)
+        ms1_watchonly = self.nodes[0].get_wallet_rpc("multisig1_watchonly")
+        ms1_wallet_info = ms1_watchonly.getwalletinfo()
+        assert_equal(ms1_wallet_info['descriptors'], True)
+        assert_equal(ms1_wallet_info['private_keys_enabled'], False)
+        self.assert_is_sqlite("multisig1_watchonly")
+        assert_equal(ms1_watchonly.getaddressinfo(addr1)["ismine"], True)
+        assert_equal(ms1_watchonly.getaddressinfo(addr1)["solvable"], True)
+        # Because addr2 was not being watched, it isn't in multisig1_watchonly but rather multisig1_solvables
+        assert_equal(ms1_watchonly.getaddressinfo(addr2)["ismine"], False)
+        assert_equal(ms1_watchonly.getaddressinfo(addr2)["solvable"], False)
+        ms1_watchonly.gettransaction(txid)
+        assert_equal(ms1_watchonly.getbalance(), 10)
+
+        # Migrating multisig1 should see the second multisig is no longer part of multisig1
+        # A new wallet multisig1_solvables is created which has the second address
+        # This should have no transactions
+        assert_equal("multisig1_solvables" in self.nodes[0].listwallets(), True)
+        ms1_solvable = self.nodes[0].get_wallet_rpc("multisig1_solvables")
+        ms1_wallet_info = ms1_solvable.getwalletinfo()
+        assert_equal(ms1_wallet_info['descriptors'], True)
+        assert_equal(ms1_wallet_info['private_keys_enabled'], False)
+        self.assert_is_sqlite("multisig1_solvables")
+        assert_equal(ms1_solvable.getaddressinfo(addr1)["ismine"], False)
+        assert_equal(ms1_solvable.getaddressinfo(addr1)["solvable"], False)
+        assert_equal(ms1_solvable.getaddressinfo(addr2)["ismine"], True)
+        assert_equal(ms1_solvable.getaddressinfo(addr2)["solvable"], True)
+        assert_equal(ms1_solvable.getbalance(), 0)
+        assert_equal(ms1_solvable.listtransactions(), [])
+
+
+    def test_other_watchonly(self):
+        default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        # Wallet with an imported address. Should be the same thing as the multisig test
+        self.log.info("Test migration of a wallet with watchonly imports")
+        self.nodes[0].createwallet(wallet_name="imports0")
+        imports0 = self.nodes[0].get_wallet_rpc("imports0")
+        assert_equal(imports0.getwalletinfo()["descriptors"], False)
+
+        # Exteranl address label
+        imports0.setlabel(default.getnewaddress(), "external")
+
+        # Normal non-watchonly tx
+        received_addr = imports0.getnewaddress()
+        imports0.setlabel(received_addr, "Receiving")
+        received_txid = default.sendtoaddress(received_addr, 10)
+
+        # Watchonly tx
+        import_addr = default.getnewaddress()
+        imports0.importaddress(import_addr)
+        imports0.setlabel(import_addr, "imported")
+        received_watchonly_txid = default.sendtoaddress(import_addr, 10)
+
+        # Received watchonly tx that is then spent
+        import_sent_addr = default.getnewaddress()
+        imports0.importaddress(import_sent_addr)
+        received_sent_watchonly_txid = default.sendtoaddress(import_sent_addr, 10)
+        received_sent_watchonly_vout = find_vout_for_address(self.nodes[0], received_sent_watchonly_txid, import_sent_addr)
+        send = default.sendall(recipients=[default.getnewaddress()], options={"inputs": [{"txid": received_sent_watchonly_txid, "vout": received_sent_watchonly_vout}]})
+        sent_watchonly_txid = send["txid"]
+
+        self.generate(self.nodes[0], 1)
+
+        balances = imports0.getbalances()
+        spendable_bal = balances["mine"]["trusted"]
+        watchonly_bal = balances["watchonly"]["trusted"]
+        assert_equal(len(imports0.listtransactions(include_watchonly=True)), 4)
+
+        # Migrate
+        imports0.migratewallet()
+        assert_equal(imports0.getwalletinfo()["descriptors"], True)
+        self.assert_is_sqlite("imports0")
+        assert_raises_rpc_error(-5, "Invalid or non-wallet transaction id", imports0.gettransaction, received_watchonly_txid)
+        assert_raises_rpc_error(-5, "Invalid or non-wallet transaction id", imports0.gettransaction, received_sent_watchonly_txid)
+        assert_raises_rpc_error(-5, "Invalid or non-wallet transaction id", imports0.gettransaction, sent_watchonly_txid)
+        assert_equal(len(imports0.listtransactions(include_watchonly=True)), 1)
+        imports0.gettransaction(received_txid)
+        assert_equal(imports0.getbalance(), spendable_bal)
+
+        assert_equal("imports0_watchonly" in self.nodes[0].listwallets(), True)
+        watchonly = self.nodes[0].get_wallet_rpc("imports0_watchonly")
+        watchonly_info = watchonly.getwalletinfo()
+        assert_equal(watchonly_info["descriptors"], True)
+        self.assert_is_sqlite("imports0_watchonly")
+        assert_equal(watchonly_info["private_keys_enabled"], False)
+        watchonly.gettransaction(received_watchonly_txid)
+        watchonly.gettransaction(received_sent_watchonly_txid)
+        watchonly.gettransaction(sent_watchonly_txid)
+        assert_equal(watchonly.getbalance(), watchonly_bal)
+        assert_raises_rpc_error(-5, "Invalid or non-wallet transaction id", watchonly.gettransaction, received_txid)
+        assert_equal(len(watchonly.listtransactions(include_watchonly=True)), 3)
+
+    def test_no_privkeys(self):
+        default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        # Migrating an actual watchonly wallet should not create a new watchonly wallet
+        self.log.info("Test migration of a pure watchonly wallet")
+        self.nodes[0].createwallet(wallet_name="watchonly0", disable_private_keys=True)
+        watchonly0 = self.nodes[0].get_wallet_rpc("watchonly0")
+        info = watchonly0.getwalletinfo()
+        assert_equal(info["descriptors"], False)
+        assert_equal(info["private_keys_enabled"], False)
+
+        addr = default.getnewaddress()
+        desc = default.getaddressinfo(addr)["desc"]
+        res = watchonly0.importmulti([
+            {
+                "desc": desc,
+                "watchonly": True,
+                "timestamp": "now",
+            }])
+        assert_equal(res[0]['success'], True)
+        default.sendtoaddress(addr, 10)
+        self.generate(self.nodes[0], 1)
+
+        watchonly0.migratewallet()
+        assert_equal("watchonly0_watchonly" in self.nodes[0].listwallets(), False)
+        info = watchonly0.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["private_keys_enabled"], False)
+        self.assert_is_sqlite("watchonly0")
+
+        # Migrating a wallet with pubkeys added to the keypool
+        self.log.info("Test migration of a pure watchonly wallet with pubkeys in keypool")
+        self.nodes[0].createwallet(wallet_name="watchonly1", disable_private_keys=True)
+        watchonly1 = self.nodes[0].get_wallet_rpc("watchonly1")
+        info = watchonly1.getwalletinfo()
+        assert_equal(info["descriptors"], False)
+        assert_equal(info["private_keys_enabled"], False)
+
+        addr1 = default.getnewaddress()
+        addr2 = default.getnewaddress()
+        desc1 = default.getaddressinfo(addr1)["desc"]
+        desc2 = default.getaddressinfo(addr2)["desc"]
+        res = watchonly1.importmulti([
+            {
+                "desc": desc1,
+                "keypool": True,
+                "timestamp": "now",
+            },
+            {
+                "desc": desc2,
+                "keypool": True,
+                "timestamp": "now",
+            }
+        ])
+        assert_equal(res[0]["success"], True)
+        assert_equal(res[1]["success"], True)
+        # Before migrating, we can fetch addr1 from the keypool
+        assert_equal(watchonly1.getnewaddress(), addr1)
+
+        watchonly1.migratewallet()
+        info = watchonly1.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["private_keys_enabled"], False)
+        self.assert_is_sqlite("watchonly1")
+        # After migrating, the "keypool" is empty
+        assert_raises_rpc_error(-4, "Error: This wallet has no available keys", watchonly1.getnewaddress)
+
+    def test_pk_coinbases(self):
+        self.log.info("Test migration of a wallet using old pk() coinbases")
+        wallet = self.create_legacy_wallet("pkcb")
+
+        addr = wallet.getnewaddress()
+        addr_info = wallet.getaddressinfo(addr)
+        desc = descsum_create("pk(" + addr_info["pubkey"] + ")")
+
+        self.nodes[0].generatetodescriptor(1, desc, invalid_call=False)
+
+        bals = wallet.getbalances()
+
+        wallet.migratewallet()
+
+        assert_equal(bals, wallet.getbalances())
+
+    def run_test(self):
+        self.generate(self.nodes[0], 101)
+
+        # TODO: Test the actual records in the wallet for these tests too. The behavior may be correct, but the data written may not be what we actually want
+        self.test_basic()
+        self.test_multisig()
+        self.test_other_watchonly()
+        self.test_no_privkeys()
+        self.test_pk_coinbases()
+
+if __name__ == '__main__':
+    WalletMigrationTest().main()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -274,7 +274,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         imports0 = self.nodes[0].get_wallet_rpc("imports0")
         assert_equal(imports0.getwalletinfo()["descriptors"], False)
 
-        # Exteranl address label
+        # External address label
         imports0.setlabel(default.getnewaddress(), "external")
 
         # Normal non-watchonly tx
@@ -326,6 +326,13 @@ class WalletMigrationTest(BitcoinTestFramework):
         assert_equal(watchonly.getbalance(), watchonly_bal)
         assert_raises_rpc_error(-5, "Invalid or non-wallet transaction id", watchonly.gettransaction, received_txid)
         assert_equal(len(watchonly.listtransactions(include_watchonly=True)), 3)
+
+        # Check that labels were migrated and persisted to watchonly wallet
+        self.nodes[0].unloadwallet("imports0_watchonly")
+        self.nodes[0].loadwallet("imports0_watchonly")
+        labels = watchonly.listlabels()
+        assert "external" in labels
+        assert "imported" in labels
 
     def test_no_privkeys(self):
         default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -517,6 +517,31 @@ class WalletMigrationTest(BitcoinTestFramework):
 
         assert_equal(bals, wallet.getbalances())
 
+    def test_wallet_name_with_slashes(self):
+        self.log.info("Test migration of a wallet whose name contains slashes places the backup inside the wallet's directory")
+        # createwallet allows nested wallet names; the backup-filename
+        # derivation in MigrateLegacyToDescriptor must reduce the name to a
+        # single basename so the backup file cannot end up in a nested or
+        # nonexistent subdirectory.
+        nested_name = "nested/subdir_wallet"
+        wallet = self.create_legacy_wallet(nested_name)
+        wallet.getnewaddress()
+
+        migrate_result = wallet.migratewallet()
+        backup_path = migrate_result["backup_path"]
+
+        # Backup must live directly inside the wallet's own directory.
+        expected_wallet_dir = os.path.join(self.nodes[0].datadir, "regtest", "wallets", "nested", "subdir_wallet")
+        assert_equal(os.path.dirname(os.path.abspath(backup_path)), os.path.abspath(expected_wallet_dir))
+
+        # Basename must use the sanitized prefix derived from the wallet
+        # name's last component, not the full "nested/..." path.
+        backup_basename = os.path.basename(backup_path)
+        assert backup_basename.startswith("subdir_wallet-"), backup_basename
+        assert backup_basename.endswith(".legacy.bak"), backup_basename
+
+        self.assert_is_sqlite(nested_name)
+
     def run_test(self):
         self.generate(self.nodes[0], 101)
 
@@ -529,6 +554,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.test_encrypted()
         self.test_unloaded()
         self.test_unloaded_by_path()
+        self.test_wallet_name_with_slashes()
 
 if __name__ == '__main__':
     WalletMigrationTest().main()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -420,11 +420,75 @@ class WalletMigrationTest(BitcoinTestFramework):
     def test_encrypted(self):
         self.log.info("Test migration of an encrypted wallet")
         wallet = self.create_legacy_wallet("encrypted")
+        default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
 
         wallet.encryptwallet("pass")
+        addr = wallet.getnewaddress()
+        txid = default.sendtoaddress(addr, 1)
+        self.generate(self.nodes[0], 1)
+        bals = wallet.getbalances()
 
-        assert_raises_rpc_error(-15, "Error: migratewallet on encrypted wallets is currently unsupported.", wallet.migratewallet)
-        # TODO: Fix migratewallet so that we can actually migrate encrypted wallets
+        assert_raises_rpc_error(-4, "Error: Wallet decryption failed, the wallet passphrase was not provided or was incorrect", wallet.migratewallet)
+        assert_raises_rpc_error(-4, "Error: Wallet decryption failed, the wallet passphrase was not provided or was incorrect", wallet.migratewallet, None, "badpass")
+        assert_raises_rpc_error(-4, "The passphrase contains a null character", wallet.migratewallet, None, "pass\0with\0null")
+
+        wallet.migratewallet(passphrase="pass")
+
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["format"], "sqlite")
+        assert_equal(info["unlocked_until"], 0)
+        wallet.gettransaction(txid)
+
+        assert_equal(bals, wallet.getbalances())
+
+    def test_unloaded(self):
+        self.log.info("Test migration of a wallet that isn't loaded")
+        wallet = self.create_legacy_wallet("notloaded")
+        default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        addr = wallet.getnewaddress()
+        txid = default.sendtoaddress(addr, 1)
+        self.generate(self.nodes[0], 1)
+        bals = wallet.getbalances()
+
+        wallet.unloadwallet()
+
+        assert_raises_rpc_error(-8, "RPC endpoint wallet and wallet_name parameter specify different wallets", wallet.migratewallet, "someotherwallet")
+        assert_raises_rpc_error(-8, "Either RPC endpoint wallet or wallet_name parameter must be provided", self.nodes[0].migratewallet)
+        self.nodes[0].migratewallet("notloaded")
+
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["format"], "sqlite")
+        wallet.gettransaction(txid)
+
+        assert_equal(bals, wallet.getbalances())
+
+    def test_unloaded_by_path(self):
+        self.log.info("Test migration of a wallet that isn't loaded, specified by path")
+        wallet = self.create_legacy_wallet("notloaded2")
+        default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+
+        addr = wallet.getnewaddress()
+        txid = default.sendtoaddress(addr, 1)
+        self.generate(self.nodes[0], 1)
+        bals = wallet.getbalances()
+
+        wallet.unloadwallet()
+
+        wallet_file_path = os.path.join(self.nodes[0].datadir, "regtest", "wallets", "notloaded2")
+        self.nodes[0].migratewallet(wallet_file_path)
+
+        # Because we gave the name by full path, the loaded wallet's name is that path too.
+        wallet = self.nodes[0].get_wallet_rpc(wallet_file_path)
+
+        info = wallet.getwalletinfo()
+        assert_equal(info["descriptors"], True)
+        assert_equal(info["format"], "sqlite")
+        wallet.gettransaction(txid)
+
+        assert_equal(bals, wallet.getbalances())
 
     def run_test(self):
         self.generate(self.nodes[0], 101)
@@ -436,6 +500,8 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.test_no_privkeys()
         self.test_pk_coinbases()
         self.test_encrypted()
+        self.test_unloaded()
+        self.test_unloaded_by_path()
 
 if __name__ == '__main__':
     WalletMigrationTest().main()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -100,6 +100,16 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.assert_addr_info_equal(addr_info, old_addr_info)
         self.assert_addr_info_equal(change_addr_info, old_change_addr_info)
 
+        self.log.info("Test for re-using old addresses after migration")
+        new_addr = basic0.getnewaddress()
+        new_change = basic0.getrawchangeaddress()
+        assert not new_addr == addr
+        assert not new_change == change
+        assert_equal(addr_info["hdkeypath"], "m/44'/1'/0'/0/0")
+        assert_equal(change_addr_info["hdkeypath"], "m/44'/1'/0'/1/0")
+        assert_equal(basic0.getaddressinfo(new_addr)["hdkeypath"], "m/44'/1'/0'/0/2")
+        assert_equal(basic0.getaddressinfo(new_change)["hdkeypath"], "m/44'/1'/0'/1/2")
+
         self.log.info("Test migration of a basic keys only wallet with a balance")
         basic1 = self.create_legacy_wallet("basic1")
 

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -78,6 +78,10 @@ class WalletMigrationTest(BitcoinTestFramework):
         assert_equal(old_change_addr_info["ismine"], True)
         assert_equal(old_change_addr_info["hdkeypath"], "m/44'/1'/0'/1/0")
 
+        legacy_hdinfo = basic0.dumphdinfo()
+        legacy_mnemonic = legacy_hdinfo["mnemonic"]
+        legacy_mnemonic_passphrase = legacy_hdinfo["mnemonicpassphrase"]
+
         # Note: migration could take a while.
         basic0.migratewallet()
 
@@ -99,6 +103,10 @@ class WalletMigrationTest(BitcoinTestFramework):
         change_addr_info = basic0.getaddressinfo(change)
         self.assert_addr_info_equal(addr_info, old_addr_info)
         self.assert_addr_info_equal(change_addr_info, old_change_addr_info)
+
+        for d in basic0.listdescriptors(True)["descriptors"]:
+            assert_equal(d["mnemonic"], legacy_mnemonic)
+            assert_equal(d["mnemonicpassphrase"], legacy_mnemonic_passphrase)
 
         self.log.info("Test for re-using old addresses after migration")
         new_addr = basic0.getnewaddress()

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -171,6 +171,10 @@ class WalletMigrationTest(BitcoinTestFramework):
         assert_equal(basic2.getbalance(), basic2_balance)
         self.assert_list_txs_equal(basic2.listtransactions(), basic2_txs)
 
+        # Now test migration on a descriptor wallet
+        self.log.info("Test \"nothing to migrate\" when the user tries to migrate a wallet with no legacy data")
+        assert_raises_rpc_error(-4, "Error: This wallet is already a descriptor wallet", basic2.migratewallet)
+
     def test_multisig(self):
         default = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
 

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -114,12 +114,21 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.generate(self.nodes[0], 1)
         bal = basic1.getbalance()
         txs = basic1.listtransactions()
+        addr_gps = basic1.listaddressgroupings()
 
-        basic1.migratewallet()
+        basic1_migrate = basic1.migratewallet()
         assert_equal(basic1.getwalletinfo()["descriptors"], True)
         self.assert_is_sqlite("basic1")
         assert_equal(basic1.getbalance(), bal)
         self.assert_list_txs_equal(basic1.listtransactions(), txs)
+
+        self.log.info("Test backup file can be successfully restored")
+        self.nodes[0].restorewallet("basic1_restored", basic1_migrate['backup_path'])
+        basic1_restored = self.nodes[0].get_wallet_rpc("basic1_restored")
+        basic1_restored_wi = basic1_restored.getwalletinfo()
+        assert_equal(basic1_restored_wi['balance'], bal)
+        assert_equal(basic1_restored.listaddressgroupings(), addr_gps)
+        self.assert_list_txs_equal(basic1_restored.listtransactions(), txs)
 
         # restart node and verify that everything is still there
         self.restart_node(0)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Legacy wallets is subject to be removed in Bitcoin Core, here's bitcoin's timeline for reference: https://github.com/bitcoin/bitcoin/issues/20160

Descriptor wallets is going to be created by default from Dash Core v24: https://github.com/dashpay/dash/pull/7204


## What was done?
Backports: 
 - bitcoin/bitcoin#19602
 - bitcoin/bitcoin#26910
 - bitcoin/bitcoin#26761
 - bitcoin/bitcoin#26594
 - bitcoin/bitcoin#26595
 - bitcoin/bitcoin#28257

And more to be done in further PR

There are several key differences with Bitcoin Core:
 - bitcoin uses multiple path derivation and paths for legacy bip44 and descriptor bip44 is not matched; while Dash Core always uses the same derivation path for all HD wallets
 - combo descriptors can not be used as "active" descriptors so, they added as "inactive" descriptors
 - there's added 1 more coinjoin derivation path for compability with mobile. It covers a case if used used the same once on mobile wallet and run coinjoin
 - implementation of HD wallet in our legacy wallets and bitcoin's are not exactly same because this code hasn't been backported. Beside lookup of `mapKeys` and `mapCryptedKeys` there should be done extra lookup over `mapHdPubKeys` in migration code

## How Has This Been Tested?
See updates for new functional test wallet_migration.py

Also all my own legacy wallets (mainnet, testnet) has been successfully migrated to descriptor during testing of this PR, including coinjoin-status of mixed coins.

One of my wallet on testnet highlighted existing bug of mainstream. This bug with watch-only addresses has been fixed by https://github.com/bitcoin/bitcoin/pull/28868 and this fix will be included in the next batch of backports.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
