### PR TITLE
ci: use cheaper ARM bootstrap runner for check-skip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,8 @@ concurrency:
 jobs:
   check-skip:
     name: Check skip conditions
-    runs-on: ${{ vars.RUNNER_AMD64 || 'ubuntu-24.04' }}
+    # Keep the bootstrap job cheap; RUNNER_CHECK_SKIP can point to a small Blacksmith ARM runner.
+    runs-on: ${{ vars.RUNNER_CHECK_SKIP || 'ubuntu-24.04-arm' }}
     outputs:
       skip: ${{ steps.skip-check.outputs.skip }}
       runner-amd64: ${{ steps.select-runner.outputs.runner_amd64 }}


### PR DESCRIPTION
# Summary

Move only the `check-skip` bootstrap job onto a cheaper ARM runner path.

## Problem

`check-skip` currently uses the generic amd64 runner setting, so even the
lightweight bootstrap step can consume the more expensive primary runner pool.

## Solution

- add a dedicated `RUNNER_CHECK_SKIP` override for the `check-skip` job
- default that job to GitHub-hosted ARM (`ubuntu-24.04-arm`)
- leave downstream dynamic runner selection unchanged for the heavier CI jobs

This keeps the tiny bootstrap step cheap by default while still allowing an
org-level Blacksmith ARM label, such as a small 1 vCPU runner, to be
configured later without affecting the main build/test jobs.

## Related

- split out from <https://github.com/dashpay/dash/pull/7232>

## Validation

- parsed `.github/workflows/build.yml` successfully with PyYAML after the
  change
- reviewed the workflow context around `check-skip`,
  `select_dynamic_runner.py`, and `cache-depends-sources.yml`
- ran the mandatory code-review gate on
  `upstream/develop..ci/check-skip-arm-bootstrap` → *ship*
