### PR TITLE
refactor: use SteadyClock instead of SystemClock for duration measurements in Dash-specific code

### DIFF
--- a/src/active/dkgsessionhandler.cpp
+++ b/src/active/dkgsessionhandler.cpp
@@ -202,13 +202,13 @@ void ActiveDKGSessionHandler::SleepBeforePhase(QuorumPhase curPhase, const uint2
     double adjustedPhaseSleepTimePerMember = phaseSleepTimePerMember * randomSleepFactor;
 
     int64_t sleepTime = (int64_t)(adjustedPhaseSleepTimePerMember * curSession->GetMyMemberIndex().value_or(0));
-    int64_t endTime = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) + sleepTime;
+    const auto endTime = SteadyClock::now() + std::chrono::milliseconds{sleepTime};
     int heightTmp{currentHeight.load()};
     int heightStart{heightTmp};
 
     LogPrint(BCLog::LLMQ_DKG, "ActiveDKGSessionHandler::%s -- %s qi[%d] - starting sleep for %d ms, curPhase=%d\n", __func__, params.name, quorumIndex, sleepTime, std23::to_underlying(curPhase));
 
-    while (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) < endTime) {
+    while (SteadyClock::now() < endTime) {
         if (stopRequested) {
             LogPrint(BCLog::LLMQ_DKG, "ActiveDKGSessionHandler::%s -- %s qi[%d] - aborting due to stop/shutdown requested\n", __func__, params.name, quorumIndex);
             throw AbortPhaseException();

--- a/src/instantsend/instantsend.cpp
+++ b/src/instantsend/instantsend.cpp
@@ -35,7 +35,7 @@ void CInstantSendManager::EnqueueInstantSendLock(NodeId from, const uint256& has
             LOCK(cs_timingsTxSeen);
             if (auto it = timingsTxSeen.find(islock->txid); it != timingsTxSeen.end()) {
                 // This is the normal case where we received the TX before the islock
-                auto diff = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - it->second;
+                auto diff = Ticks<std::chrono::milliseconds>(SteadyClock::now() - it->second);
                 timingsTxSeen.erase(it);
                 return diff;
             }
@@ -180,7 +180,7 @@ void CInstantSendManager::AddNonLockedTx(const CTransactionRef& tx, const CBlock
     if (ShouldReportISLockTiming()) {
         LOCK(cs_timingsTxSeen);
         // Only insert the time the first time we see the tx, as we sometimes try to resign
-        timingsTxSeen.try_emplace(tx->GetHash(), TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
+        timingsTxSeen.try_emplace(tx->GetHash(), SteadyClock::now());
     }
 
     LogPrint(BCLog::INSTANTSEND, "CInstantSendManager::%s -- txid=%s, pindexMined=%s\n", __func__,

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -78,7 +78,7 @@ private:
     Uint256HashSet pendingRetryTxs GUARDED_BY(cs_pendingRetry);
 
     mutable Mutex cs_timingsTxSeen;
-    Uint256HashMap<int64_t> timingsTxSeen GUARDED_BY(cs_timingsTxSeen);
+    Uint256HashMap<SteadyClock::time_point> timingsTxSeen GUARDED_BY(cs_timingsTxSeen);
 
     mutable Mutex cs_height_cache;
     static constexpr size_t MAX_BLOCK_HEIGHT_CACHE{16384};

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -311,7 +311,7 @@ bool CDKGSessionManager::GetVerifiedContributions(Consensus::LLMQType llmqType, 
                 CBLSSecretKey skContribution;
                 db->Read(std::make_tuple(DB_SKCONTRIB, llmqType, pQuorumBaseBlockIndex->GetBlockHash(), proTxHash), skContribution);
 
-                it = contributionsCache.emplace(cacheKey, ContributionsCacheEntry{TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()), vvecPtr, skContribution}).first;
+                it = contributionsCache.emplace(cacheKey, ContributionsCacheEntry{SteadyClock::now(), vvecPtr, skContribution}).first;
             }
 
             memberIndexesRet.emplace_back(i);
@@ -358,7 +358,7 @@ bool CDKGSessionManager::GetEncryptedContributions(Consensus::LLMQType llmqType,
 void CDKGSessionManager::CleanupCache() const
 {
     LOCK(contributionsCacheCs);
-    auto curTime = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+    const auto curTime = SteadyClock::now();
     for (auto it = contributionsCache.begin(); it != contributionsCache.end(); ) {
         if (curTime - it->second.entryTime > MAX_CONTRIBUTION_CACHE_TIME) {
             it = contributionsCache.erase(it);

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -57,7 +57,7 @@ public:
     using SessionHandlerMap = std::map<SessionHandlerKey, std::unique_ptr<CDKGSessionHandler>>;
 
 private:
-    static constexpr int64_t MAX_CONTRIBUTION_CACHE_TIME = 60 * 1000;
+    static constexpr auto MAX_CONTRIBUTION_CACHE_TIME = 60s;
 
 private:
     CDeterministicMNManager& m_dmnman;
@@ -84,7 +84,7 @@ private:
         }
     };
     struct ContributionsCacheEntry {
-        int64_t entryTime;
+        SteadyClock::time_point entryTime;
         BLSVerificationVectorPtr vvec;
         CBLSSecretKey skContribution;
     };

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2119,7 +2119,7 @@ void CConnman::DisconnectNodes()
                 // the socket), we can be pretty sure that they are not interested in any pending messages anymore and
                 // thus can immediately close the socket.
                 if (!pnode->fOtherSideDisconnected) {
-                    if (pnode->nDisconnectLingerTime == 0) {
+                    if (pnode->nDisconnectLingerTime.load() == SteadyClock::time_point{}) {
                         // let's not immediately close the socket but instead wait for at least 100ms so that there is a
                         // chance to flush all/some pending data. Otherwise the other side might not receive REJECT messages
                         // that were pushed right before setting fDisconnect=true
@@ -2127,9 +2127,9 @@ void CConnman::DisconnectNodes()
                         //   1. vSendMsg must be empty and all messages sent via send(). This is ensured by SocketHandler()
                         //      being called before DisconnectNodes and also by the linger time
                         //   2. Internal socket send buffers must be flushed. This is ensured solely by the linger time
-                        pnode->nDisconnectLingerTime = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) + 100;
+                        pnode->nDisconnectLingerTime = SteadyClock::now() + 100ms;
                     }
-                    if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) < pnode->nDisconnectLingerTime) {
+                    if (SteadyClock::now() < pnode->nDisconnectLingerTime.load()) {
                         // everything flushed to the kernel?
                         const auto& [to_send, more, _msg_type] = pnode->m_transport->GetBytesToSend(pnode->nSendMsgSize != 0);
                         const bool queue_is_empty{to_send.empty() && !more};
@@ -2636,18 +2636,18 @@ void CConnman::ThreadSocketHandler(CMasternodeSync& mn_sync)
 {
     AssertLockNotHeld(m_total_bytes_sent_mutex);
 
-    int64_t nLastCleanupNodes = 0;
+    auto nLastCleanupNodes = SteadyClock::time_point{};
 
     while (!interruptNet)
     {
         // Handle sockets before we do the next round of disconnects. This allows us to flush send buffers one last time
         // before actually closing sockets. Receiving is however skipped in case a peer is pending to be disconnected
         SocketHandler(mn_sync);
-        if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - nLastCleanupNodes > 1000) {
+        if (SteadyClock::now() - nLastCleanupNodes > 1s) {
             ForEachNode(AllNodes, [&](CNode* pnode) {
                 if (InactivityCheck(*pnode)) pnode->fDisconnect = true;
             });
-            nLastCleanupNodes = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+            nLastCleanupNodes = SteadyClock::now();
         }
         DisconnectNodes();
         NotifyNumConnectionsChanged(mn_sync);
@@ -3663,7 +3663,7 @@ void CConnman::ThreadMessageHandler()
 {
     LOCK(NetEventsInterface::g_msgproc_mutex);
 
-    int64_t nLastSendMessagesTimeMasternodes = 0;
+    auto nLastSendMessagesTimeMasternodes = SteadyClock::time_point{};
 
     FastRandomContext rng;
     while (!flagInterruptMsgProc)
@@ -3671,9 +3671,9 @@ void CConnman::ThreadMessageHandler()
         bool fMoreWork = false;
 
         bool fSkipSendMessagesForMasternodes = true;
-        if (TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - nLastSendMessagesTimeMasternodes >= 100) {
+        if (SteadyClock::now() - nLastSendMessagesTimeMasternodes >= 100ms) {
             fSkipSendMessagesForMasternodes = false;
-            nLastSendMessagesTimeMasternodes = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
+            nLastSendMessagesTimeMasternodes = SteadyClock::now();
         }
 
         // Randomize the order in which we process messages from/to our peers.

--- a/src/net.h
+++ b/src/net.h
@@ -784,7 +784,7 @@ public:
     // Setting fDisconnect to true will cause the node to be disconnected the
     // next time DisconnectNodes() runs
     std::atomic_bool fDisconnect{false};
-    std::atomic<int64_t> nDisconnectLingerTime{0};
+    std::atomic<SteadyClock::time_point> nDisconnectLingerTime{SteadyClock::time_point{}};
     std::atomic_bool fSocketShutdown{false};
     std::atomic_bool fOtherSideDisconnected { false };
     // If 'true' this node will be disconnected on CMasternodeMan::ProcessMasternodeConnections()


### PR DESCRIPTION
## Issue being fixed or feature implemented
Extends the approach from bitcoin#27405 to Dash-specific code. All six call sites were purely measuring elapsed time for timeouts, throttling, or cache expiry — SteadyClock is monotonic and immune to NTP adjustments, making it the correct choice.

## What was done?


## How Has This Been Tested?


## Breaking Changes
n/a

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

