### PR TITLE
refactor: simplify asset lock validation code

### DIFF
--- a/src/evo/assetlocktx.cpp
+++ b/src/evo/assetlocktx.cpp
@@ -24,21 +24,6 @@ using node::BlockManager;
 
 
 /**
- *  Common code for Asset Lock and Asset Unlock
- */
-bool CheckAssetLockUnlockTx(const BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state)
-{
-    switch (tx.nType) {
-    case TRANSACTION_ASSET_LOCK:
-        return CheckAssetLockTx(tx, state);
-    case TRANSACTION_ASSET_UNLOCK:
-        return CheckAssetUnlockTx(blockman, qman, tx, pindexPrev, indexes, state);
-    default:
-        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-not-asset-locks-at-all");
-    }
-}
-
-/**
  * Asset Lock Transaction
  */
 bool CheckAssetLockTx(const CTransaction& tx, TxValidationState& state)

--- a/src/evo/assetlocktx.h
+++ b/src/evo/assetlocktx.h
@@ -156,7 +156,6 @@ public:
 
 bool CheckAssetLockTx(const CTransaction& tx, TxValidationState& state);
 bool CheckAssetUnlockTx(const node::BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state);
-bool CheckAssetLockUnlockTx(const node::BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, gsl::not_null<const CBlockIndex*> pindexPrev, const std::optional<CRangesSet>& indexes, TxValidationState& state);
 bool GetAssetUnlockFee(const CTransaction& tx, CAmount& txfee, TxValidationState& state);
 
 #endif // BITCOIN_EVO_ASSETLOCKTX_H

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -300,18 +300,14 @@ bool CCreditPoolDiff::Unlock(const CTransaction& tx, TxValidationState& state)
 bool CCreditPoolDiff::ProcessLockUnlockTransaction(const BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, TxValidationState& state)
 {
     if (!tx.IsSpecialTxVersion()) return true;
-    if (tx.nType != TRANSACTION_ASSET_LOCK && tx.nType != TRANSACTION_ASSET_UNLOCK) return true;
-
-    if (!CheckAssetLockUnlockTx(blockman, qman, tx, pindexPrev, pool.indexes, state)) {
-        // pass the state returned by the function above
-        return false;
-    }
 
     try {
         switch (tx.nType) {
         case TRANSACTION_ASSET_LOCK:
+            if (!CheckAssetLockTx(tx, state)) return false; // pass the state set by CheckAssetLockTx
             return Lock(tx, state);
         case TRANSACTION_ASSET_UNLOCK:
+            if (!CheckAssetUnlockTx(blockman, qman, tx, pindexPrev, pool.indexes, state)) return false; // pass the state set by CheckAssetUnlockTx
             return Unlock(tx, state);
         default:
             return true;

--- a/src/evo/creditpool.cpp
+++ b/src/evo/creditpool.cpp
@@ -22,7 +22,6 @@
 #include <memory>
 #include <stack>
 
-using node::BlockManager;
 using node::ReadBlockFromDisk;
 
 // Forward declaration to prevent a new circular dependencies through masternode/payments.h
@@ -248,8 +247,7 @@ CCreditPoolManager::~CCreditPoolManager() = default;
 
 CCreditPoolDiff::CCreditPoolDiff(CCreditPool starter, const CBlockIndex* pindexPrev,
                                  const Consensus::Params& consensusParams, const CAmount blockSubsidy) :
-    pool(std::move(starter)),
-    pindexPrev(pindexPrev)
+    pool(std::move(starter))
 {
     assert(pindexPrev);
 
@@ -297,17 +295,15 @@ bool CCreditPoolDiff::Unlock(const CTransaction& tx, TxValidationState& state)
     return true;
 }
 
-bool CCreditPoolDiff::ProcessLockUnlockTransaction(const BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, TxValidationState& state)
+bool CCreditPoolDiff::ProcessLockUnlockTransaction(const CTransaction& tx, TxValidationState& state)
 {
     if (!tx.IsSpecialTxVersion()) return true;
 
     try {
         switch (tx.nType) {
         case TRANSACTION_ASSET_LOCK:
-            if (!CheckAssetLockTx(tx, state)) return false; // pass the state set by CheckAssetLockTx
             return Lock(tx, state);
         case TRANSACTION_ASSET_UNLOCK:
-            if (!CheckAssetUnlockTx(blockman, qman, tx, pindexPrev, pool.indexes, state)) return false; // pass the state set by CheckAssetUnlockTx
             return Unlock(tx, state);
         default:
             return true;
@@ -318,7 +314,7 @@ bool CCreditPoolDiff::ProcessLockUnlockTransaction(const BlockManager& blockman,
     }
 }
 
-std::optional<CCreditPoolDiff> GetCreditPoolDiffForBlock(CCreditPoolManager& cpoolman, const BlockManager& blockman, const llmq::CQuorumManager& qman,
+std::optional<CCreditPoolDiff> GetCreditPoolDiffForBlock(CCreditPoolManager& cpoolman,
                                                          const CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams,
                                                          const CAmount blockSubsidy, BlockValidationState& state)
 {
@@ -329,7 +325,7 @@ std::optional<CCreditPoolDiff> GetCreditPoolDiffForBlock(CCreditPoolManager& cpo
         for (size_t i = 1; i < block.vtx.size(); ++i) {
             const auto& tx = *block.vtx[i];
             TxValidationState tx_state;
-            if (!creditPoolDiff.ProcessLockUnlockTransaction(blockman, qman, tx, tx_state)) {
+            if (!creditPoolDiff.ProcessLockUnlockTransaction(tx, tx_state)) {
                 assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS);
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(),
                                  strprintf("Process Lock/Unlock Transaction failed at Credit Pool (tx hash %s) %s", tx.GetHash().ToString(), tx_state.GetDebugMessage()));

--- a/src/evo/creditpool.h
+++ b/src/evo/creditpool.h
@@ -33,9 +33,6 @@ struct Params;
 namespace llmq {
 class CQuorumManager;
 } // namespace llmq
-namespace node {
-class BlockManager;
-} // namespace node
 
 struct CCreditPool {
     CAmount locked{0};
@@ -70,15 +67,14 @@ struct CCreditPool {
  * limits should stay same and depends only on the previous block.
  */
 class CCreditPoolDiff {
-private:
+public:
     const CCreditPool pool;
+private:
     std::unordered_set<uint64_t> newIndexes;
 
     CAmount sessionLocked{0};
     CAmount sessionUnlocked{0};
     CAmount platformReward{0};
-
-    const CBlockIndex *pindexPrev{nullptr};
 
 public:
     explicit CCreditPoolDiff(CCreditPool starter, const CBlockIndex *pindexPrev,
@@ -90,7 +86,7 @@ public:
      * to change amount of credit pool
      * @return true if transaction can be included in this block
      */
-    bool ProcessLockUnlockTransaction(const node::BlockManager& blockman, const llmq::CQuorumManager& qman, const CTransaction& tx, TxValidationState& state);
+    bool ProcessLockUnlockTransaction(const CTransaction& tx, TxValidationState& state);
 
     /**
      * this function returns total amount of credits for the next block
@@ -147,7 +143,7 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(!cache_mutex);
 };
 
-std::optional<CCreditPoolDiff> GetCreditPoolDiffForBlock(CCreditPoolManager& cpoolman, const node::BlockManager& blockman, const llmq::CQuorumManager& qman,
+std::optional<CCreditPoolDiff> GetCreditPoolDiffForBlock(CCreditPoolManager& cpoolman,
                                                          const CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams,
                                                          const CAmount blockSubsidy, BlockValidationState& state);
 

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -743,7 +743,7 @@ bool CSpecialTxProcessor::CheckCreditPoolDiffForBlock(const CBlock& block, const
 
     try {
         const CAmount blockSubsidy = GetBlockSubsidy(pindex, m_consensus_params);
-        const auto creditPoolDiff = GetCreditPoolDiffForBlock(m_cpoolman, m_chainman.m_blockman, m_qman, block,
+        const auto creditPoolDiff = GetCreditPoolDiffForBlock(m_cpoolman, block,
                                                               pindex->pprev, m_consensus_params, blockSubsidy, state);
         if (!creditPoolDiff.has_value()) return false;
 

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -305,7 +305,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
                     LogPrintf("CreateNewBlock() h[%d] CbTx failed to find best CL. Inserting null CL\n", nHeight);
                 }
                 BlockValidationState state;
-                const auto creditPoolDiff = GetCreditPoolDiffForBlock(*m_chain_helper.credit_pool_manager, m_blockman, m_qman, *pblock, pindexPrev, chainparams.GetConsensus(), blockSubsidy, state);
+                const auto creditPoolDiff = GetCreditPoolDiffForBlock(*m_chain_helper.credit_pool_manager, *pblock, pindexPrev, chainparams.GetConsensus(), blockSubsidy, state);
                 if (creditPoolDiff == std::nullopt) {
                     throw std::runtime_error(strprintf("%s: GetCreditPoolDiffForBlock failed: %s", __func__, state.ToString()));
                 }
@@ -544,7 +544,20 @@ void BlockAssembler::addPackageTxs(const CTxMemPool& mempool, int& nPackagesSele
             // `state` is local here because used only to log info about this specific tx
             TxValidationState state;
 
-            if (!creditPoolDiff->ProcessLockUnlockTransaction(m_blockman, m_qman, iter->GetTx(), state)) {
+            if (iter->GetTx().IsSpecialTxVersion() && iter->GetTx().nType == TRANSACTION_ASSET_UNLOCK) {
+                // ASSET_UNLOCK transactions may expire after being added to mempool
+                // They should not be included to the block
+                if (!CheckAssetUnlockTx(m_blockman, m_qman, iter->GetTx(), pindexPrev, creditPoolDiff->pool.indexes, state)) {
+                    if (fUsingModified) {
+                        mapModifiedTx.get<ancestor_score>().erase(modit);
+                        failedTx.insert(iter);
+                    }
+                    LogPrintf("%s: asset unlock tx %s is skipped due %s\n",
+                              __func__, iter->GetTx().GetHash().ToString(), state.ToString());
+                    continue;
+                }
+            }
+            if (!creditPoolDiff->ProcessLockUnlockTransaction(iter->GetTx(), state)) {
                 if (fUsingModified) {
                     mapModifiedTx.get<ancestor_score>().erase(modit);
                     failedTx.insert(iter);


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR is a refactoring to simplify asset lock validation and preparation for 2 version of assset locks which is going to be validated with different rules on pre-v24 fork and after v24 fork.

## What was done?
 - removed re-validation of asset lock transactions for existing blocks in the chain
 - inline CheckAssetLockUnlockTx function to creditpool

## How Has This Been Tested?
Run unit & functional tests

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone