### PR TITLE
revert: "fix: avoid improper dual way connection attempts" + tests

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -801,13 +801,28 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& 
              util_params.m_base_index->GetBlockHash().ToString());
 
     Uint256HashSet connections;
+    Uint256HashSet relayMembers;
     if (isMember) {
         connections = GetQuorumConnections(llmqParams, sporkman, util_params, myProTxHash, /*onlyOutbound=*/true);
+        // If all-members-connected is enabled for this quorum type, leverage the full-mesh
+        // connections for low-latency recovered sig propagation by treating all members as
+        // relay members (instead of the ring-based subset). This ensures peers will send
+        // QSENDRECSIGS to each other across the full mesh and set m_wants_recsigs widely.
+        if (IsAllMembersConnectedEnabled(llmqParams.type, sporkman)) {
+            for (const auto& dmn : members) {
+                if (dmn->proTxHash != myProTxHash) {
+                    relayMembers.emplace(dmn->proTxHash);
+                }
+            }
+        } else {
+            relayMembers = GetQuorumRelayMembers(llmqParams, util_params, myProTxHash, true);
+        }
     } else {
         auto cindexes = CalcDeterministicWatchConnections(llmqParams.type, util_params.m_base_index, members.size(), 1);
         for (auto idx : cindexes) {
             connections.emplace(members[idx]->proTxHash);
         }
+        relayMembers = connections;
     }
     if (!connections.empty()) {
         if (!connman.HasMasternodeQuorumNodes(llmqParams.type, util_params.m_base_index->GetBlockHash()) &&
@@ -826,7 +841,9 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& 
             LogPrint(BCLog::NET_NETCONN, debugMsg.c_str()); /* Continued */
         }
         connman.SetMasternodeQuorumNodes(llmqParams.type, util_params.m_base_index->GetBlockHash(), connections);
-        connman.SetMasternodeQuorumRelayMembers(llmqParams.type, util_params.m_base_index->GetBlockHash(), connections);
+    }
+    if (!relayMembers.empty()) {
+        connman.SetMasternodeQuorumRelayMembers(llmqParams.type, util_params.m_base_index->GetBlockHash(), relayMembers);
     }
     return true;
 }

--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -41,6 +41,7 @@ class LLMQSigningTest(DashTestFramework):
 
         if self.options.spork21:
             assert self.mninfo[0].get_node(self).getconnectioncount() == self.llmq_size
+            self.assert_qsendrecsigs_symmetric()
 
         id = "0000000000000000000000000000000000000000000000000000000000000001"
         msgHash = "0000000000000000000000000000000000000000000000000000000000000002"
@@ -199,6 +200,26 @@ class LLMQSigningTest(DashTestFramework):
             # Let 2 seconds pass so that the next node is used for recovery, which should succeed
             self.bump_mocktime(2)
             wait_for_sigs(True, False, True, 2)
+
+    def assert_qsendrecsigs_symmetric(self):
+        # If only one direction's QSENDRECSIGS arrives, the receiving side keeps
+        # m_wants_recsigs=false and silently drops half of all recsig pushes.
+        self.log.info("Assert QSENDRECSIGS was exchanged in both directions on every MN-MN edge")
+        mn_protxs = {mn.proTxHash for mn in self.mninfo}
+
+        def all_symmetric():
+            for mn in self.mninfo:
+                for p in mn.get_node(self).getpeerinfo():
+                    if p.get("verified_proregtx_hash", "") not in mn_protxs:
+                        continue
+                    if p.get("bytessent_per_msg", {}).get("qsendrecsigs", 0) == 0:
+                        return False
+                    if p.get("bytesrecv_per_msg", {}).get("qsendrecsigs", 0) == 0:
+                        return False
+            return True
+
+        self.wait_until(all_symmetric, timeout=10)
+
 
 if __name__ == '__main__':
     LLMQSigningTest().main()


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dashpay/dash/issues/7255
Intermittent failure at `feature_llmq_signing.py --spork21`

    File "feature_llmq_signing.py", line 111, in run_test
        wait_for_sigs(True, False, True, 15)
    File "feature_llmq_signing.py", line 60, in wait_for_sigs
        self.wait_until(lambda: check_sigs(hasrecsigs, isconflicting1, isconflicting2), timeout = timeout)
    AssertionError: Predicate '' not true after <timeout> seconds

## What was done?
This reverts a57a8119a081bfa75f044e75b9c5eb073f0b58d5 from PR #6967.

`relayMembers` and `connections` in EnsureQuorumConnections are not interchangeable.

* `connections`: who this node should connect TO. For each pair (A, B) only the deterministic-outbound side is listed, so the pair results in one TCP connection.

* `relayMembers`: who this node should ask to push recovered sigs. For every already-connected MN in the set we send QSENDRECSIGS=true, and the peer then flips m_wants_recsigs=true on its side. For the handshake to happen in both directions,
the set must list every other quorum member -- not just the outbound half.

After a57a811, only the outbound half is listed, so on the inbound half of each pair m_wants_recsigs stays false. RelayRecoveredSig only pushes QSIGREC to peers with m_wants_recsigs=true, so half of all proactive recovered-sig pushes are silently dropped.

This only triggers with spork21 on (IsAllMembersConnectedEnabled returns true). In this case both the path that uses the half-mesh outbound subset and the path that relies on proactive QSIGREC.


## How Has This Been Tested?
This fixes the functional test `feature_llmq_signing.py --spork21`, which times out in wait_for_sigs.
It reduced amount of failures on my localhost from ~50% to almost 0.

Added new functional test in feature_llmq_signing.py for --spork21 case; which fails as expected without this patch.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone