### PR TITLE
fix: read governance debug log tail in binary mode

### DIFF
--- a/test/functional/feature_governance_cl.py
+++ b/test/functional/feature_governance_cl.py
@@ -147,10 +147,10 @@ class DashGovernanceTest (DashTestFramework):
         expected_msg = f'CGovernanceManager::UpdatedBlockTip -- nCachedBlockHeight: {tip_height}'
 
         def governance_tip_updated(node):
-            with open(node.debug_log_path, encoding='utf-8') as dl:
+            with open(node.debug_log_path, "rb") as dl:
                 seek_pos = node.debug_log_size(mode="rb") - 100 * 1024  # read the last 100 KiB only
                 dl.seek(seek_pos if seek_pos > 0 else 0)
-                debug_log_part = dl.read()
+                debug_log_part = dl.read().decode("utf-8", errors="replace")
             return expected_msg in debug_log_part
 
         for node in self.nodes[0:5]:


### PR DESCRIPTION
# Summary

- fix `feature_governance_cl.py` log tail polling to seek `debug.log`
  in binary mode
- decode the tailed bytes after reading so the seek offset stays valid
  for the stream mode
- preserve the existing behavior of scanning only the last 100 KiB for
  the expected governance tip message

## Context

This is a follow-up for a valid review finding from merged PR #7258:
<https://github.com/dashpay/dash/pull/7258#discussion_r3060123920>

Upstream `develop` currently opens `debug.log` in text mode but computes
the seek position with a binary offset. The final fix here uses a fully
binary tail read and decodes afterward, which avoids both mixed-mode seek
problems and text-stream offset arithmetic.

## Validation

- `python3 -m py_compile test/functional/feature_governance_cl.py`
- pre-PR code review gate verdict: `ship`

I did not run `feature_governance_cl.py` end-to-end because this worktree
does not have built `dashd`/test binaries available, and building Dash
Core would be disproportionate for this narrowly scoped Python
functional-test fix.
