### PR TITLE
fix(qt): make governance search case-insensitive

### DIFF
--- a/src/qt/proposallist.cpp
+++ b/src/qt/proposallist.cpp
@@ -81,6 +81,7 @@ ProposalList::ProposalList(QWidget* parent) :
     proposalModelProxy->setSourceModel(proposalModel);
     proposalModelProxy->setSortRole(Qt::EditRole);
     proposalModelProxy->setFilterKeyColumn(ProposalModel::Column::TITLE); // filter by title column...
+    proposalModelProxy->setFilterCaseSensitivity(Qt::CaseInsensitive);
     connect(ui->filterLineEdit, &QLineEdit::textChanged, proposalModelProxy, &QSortFilterProxyModel::setFilterFixedString);
 
     // Changes to number of rows should update proposal count display.


### PR DESCRIPTION
# PR description

## Summary

- Make the Governance proposals title filter case-insensitive.
- Match the behavior already used by other Qt search/filter views.

Closes dashpay/dash#7287.

## Validation

- `git diff --check`
- Pre-PR review gate: ship
- Not run: full build / GUI smoke test; no build directory was available in
  this worktree.
