### PR TITLE
fix(qt): keep PoSe score visible when hiding banned masternodes

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -291,7 +291,6 @@ void MasternodeList::on_checkBoxOwned_stateChanged(int state)
 void MasternodeList::on_checkBoxHideBanned_stateChanged(int state)
 {
     const bool hide_banned{state == Qt::Checked};
-    ui->tableViewMasternodes->setColumnHidden(MasternodeModel::POSE, hide_banned);
     m_proxy_model->setHideBanned(hide_banned);
     m_proxy_model->forceInvalidateFilter();
     updateFilteredCount();


### PR DESCRIPTION
# PR description

## Summary

- Keep the Masternodes tab PoSe Score column visible when "Hide banned" is
  checked.
- Continue filtering banned masternodes via the existing proxy filter.

Closes dashpay/dash#7286.

## Validation

- `git diff --check`
- Pre-PR review gate: ship
- Not run: full build / GUI smoke test; no build directory was available in
  this worktree.
