### PR TITLE
refactor: multiple kernel-0 preparations

### DIFF
--- a/src/chainlock/chainlock.cpp
+++ b/src/chainlock/chainlock.cpp
@@ -4,11 +4,26 @@
 
 #include <chainlock/chainlock.h>
 
-#include <chainlock/clsig.h>
+#include <chain.h>
 #include <logging.h>
 #include <spork.h>
 
 namespace chainlock {
+
+ChainLockSig::ChainLockSig() = default;
+ChainLockSig::~ChainLockSig() = default;
+
+ChainLockSig::ChainLockSig(int32_t nHeight, const uint256& blockHash, const CBLSSignature& sig) :
+    nHeight{nHeight},
+    blockHash{blockHash},
+    sig{sig}
+{
+}
+
+std::string ChainLockSig::ToString() const
+{
+    return strprintf("ChainLockSig(nHeight=%d, blockHash=%s)", nHeight, blockHash.ToString());
+}
 
 Chainlocks::Chainlocks(const CSporkManager& sporkman) :
     m_sporks(sporkman)

--- a/src/chainlock/chainlock.h
+++ b/src/chainlock/chainlock.h
@@ -5,18 +5,44 @@
 #ifndef BITCOIN_CHAINLOCK_CHAINLOCK_H
 #define BITCOIN_CHAINLOCK_CHAINLOCK_H
 
-#include <chain.h>
-#include <chainlock/clsig.h>
+#include <bls/bls.h>
 #include <gsl/pointers.h>
+#include <serialize.h>
 #include <sync.h>
 #include <uint256.h>
 
+class CBlockIndex;
 class CSporkManager;
+class uint256;
 
 namespace chainlock {
 
 //! Depth of block including transactions before it's considered safe
 static constexpr int32_t TX_CONFIRM_THRESHOLD{5};
+
+struct ChainLockSig {
+private:
+    int32_t nHeight{-1};
+    uint256 blockHash;
+    CBLSSignature sig;
+
+public:
+    ChainLockSig();
+    ~ChainLockSig();
+
+    ChainLockSig(int32_t nHeight, const uint256& blockHash, const CBLSSignature& sig);
+
+    [[nodiscard]] int32_t getHeight() const { return nHeight; }
+    [[nodiscard]] const uint256& getBlockHash() const { return blockHash; }
+    [[nodiscard]] const CBLSSignature& getSig() const { return sig; }
+    [[nodiscard]] bool IsNull() const { return nHeight == -1 && blockHash == uint256(); }
+    [[nodiscard]] std::string ToString() const;
+
+    SERIALIZE_METHODS(ChainLockSig, obj)
+    {
+        READWRITE(obj.nHeight, obj.blockHash, obj.sig);
+    }
+};
 
 class Chainlocks
 {

--- a/src/chainlock/clsig.cpp
+++ b/src/chainlock/clsig.cpp
@@ -4,30 +4,27 @@
 
 #include <chainlock/clsig.h>
 
-#include <tinyformat.h>
+#include <chainparams.h>
+#include <chainlock/chainlock.h>
+#include <llmq/quorumsman.h>
 
 #include <string_view>
 
 namespace chainlock {
 static constexpr std::string_view CLSIG_REQUESTID_PREFIX{"clsig"};
 
-ChainLockSig::ChainLockSig() = default;
-ChainLockSig::~ChainLockSig() = default;
-
-ChainLockSig::ChainLockSig(int32_t nHeight, const uint256& blockHash, const CBLSSignature& sig) :
-    nHeight{nHeight},
-    blockHash{blockHash},
-    sig{sig}
-{
-}
-
-std::string ChainLockSig::ToString() const
-{
-    return strprintf("ChainLockSig(nHeight=%d, blockHash=%s)", nHeight, blockHash.ToString());
-}
-
 uint256 GenSigRequestId(const int32_t nHeight)
 {
     return ::SerializeHash(std::make_pair(CLSIG_REQUESTID_PREFIX, nHeight));
+}
+
+llmq::VerifyRecSigStatus VerifyChainLock(const Consensus::Params& params, const CChain& chain,
+                                         const llmq::CQuorumManager& qman, const chainlock::ChainLockSig& clsig)
+{
+    const auto llmqType = params.llmqTypeChainLocks;
+    const uint256 request_id = GenSigRequestId(clsig.getHeight());
+
+    return llmq::VerifyRecoveredSig(llmqType, chain, qman, clsig.getHeight(), request_id, clsig.getBlockHash(),
+                                    clsig.getSig());
 }
 } // namespace chainlock

--- a/src/chainlock/clsig.h
+++ b/src/chainlock/clsig.h
@@ -5,40 +5,28 @@
 #ifndef BITCOIN_CHAINLOCK_CLSIG_H
 #define BITCOIN_CHAINLOCK_CLSIG_H
 
-#include <serialize.h>
-#include <uint256.h>
-
-#include <bls/bls.h>
-
 #include <cstdint>
 
+class CChain;
+class uint256;
+
+namespace Consensus {
+struct Params;
+} // namespace Consensus
+
+namespace llmq {
+class CQuorumManager;
+enum class VerifyRecSigStatus : uint8_t;
+} // namespace llmq
+
 namespace chainlock {
-struct ChainLockSig {
-private:
-    int32_t nHeight{-1};
-    uint256 blockHash;
-    CBLSSignature sig;
-
-public:
-    ChainLockSig();
-    ~ChainLockSig();
-
-    ChainLockSig(int32_t nHeight, const uint256& blockHash, const CBLSSignature& sig);
-
-    [[nodiscard]] int32_t getHeight() const { return nHeight; }
-    [[nodiscard]] const uint256& getBlockHash() const { return blockHash; }
-    [[nodiscard]] const CBLSSignature& getSig() const { return sig; }
-    [[nodiscard]] bool IsNull() const { return nHeight == -1 && blockHash == uint256(); }
-    [[nodiscard]] std::string ToString() const;
-
-    SERIALIZE_METHODS(ChainLockSig, obj)
-    {
-        READWRITE(obj.nHeight, obj.blockHash, obj.sig);
-    }
-};
+struct ChainLockSig;
 
 //! Generate clsig request ID with block height
 uint256 GenSigRequestId(const int32_t nHeight);
+
+llmq::VerifyRecSigStatus VerifyChainLock(const Consensus::Params& params, const CChain& chain,
+                                         const llmq::CQuorumManager& qman, const ChainLockSig& clsig);
 } // namespace chainlock
 
 #endif // BITCOIN_CHAINLOCK_CLSIG_H

--- a/src/chainlock/handler.cpp
+++ b/src/chainlock/handler.cpp
@@ -4,20 +4,20 @@
 
 #include <chainlock/handler.h>
 
+#include <chain.h>
 #include <chainlock/chainlock.h>
+#include <chainlock/clsig.h>
+#include <chainparams.h>
+#include <consensus/validation.h>
 #include <instantsend/instantsend.h>
 #include <llmq/quorumsman.h>
 #include <masternode/sync.h>
 #include <msg_result.h>
-#include <stats/client.h>
-#include <util/std23.h>
-
-#include <chain.h>
-#include <chainparams.h>
-#include <consensus/validation.h>
 #include <node/interface_ui.h>
 #include <scheduler.h>
+#include <stats/client.h>
 #include <txmempool.h>
+#include <util/std23.h>
 #include <util/thread.h>
 #include <util/time.h>
 #include <validation.h>
@@ -325,13 +325,4 @@ void ChainlockHandler::Cleanup()
     }
 }
 
-llmq::VerifyRecSigStatus VerifyChainLock(const Consensus::Params& params, const CChain& chain,
-                                         const llmq::CQuorumManager& qman, const chainlock::ChainLockSig& clsig)
-{
-    const auto llmqType = params.llmqTypeChainLocks;
-    const uint256 request_id = chainlock::GenSigRequestId(clsig.getHeight());
-
-    return llmq::VerifyRecoveredSig(llmqType, chain, qman, clsig.getHeight(), request_id, clsig.getBlockHash(),
-                                    clsig.getSig());
-}
 } // namespace chainlock

--- a/src/chainlock/handler.h
+++ b/src/chainlock/handler.h
@@ -24,20 +24,14 @@
 
 class CBlock;
 class CBlockIndex;
-class CChain;
 class CMasternodeSync;
 class ChainstateManager;
 class CScheduler;
 class CTxMemPool;
 struct MessageProcessingResult;
 
-namespace Consensus {
-struct Params;
-} // namespace Consensus
-
 namespace llmq {
 class CQuorumManager;
-enum class VerifyRecSigStatus : uint8_t;
 } // namespace llmq
 
 namespace chainlock {
@@ -107,9 +101,6 @@ protected:
 private:
     void Cleanup() EXCLUSIVE_LOCKS_REQUIRED(!cs);
 };
-
-llmq::VerifyRecSigStatus VerifyChainLock(const Consensus::Params& params, const CChain& chain,
-                                         const llmq::CQuorumManager& qman, const chainlock::ChainLockSig& clsig);
 } // namespace chainlock
 
 #endif // BITCOIN_CHAINLOCK_HANDLER_H

--- a/src/chainlock/signing.h
+++ b/src/chainlock/signing.h
@@ -6,7 +6,6 @@
 #define BITCOIN_CHAINLOCK_SIGNING_H
 
 #include <chainlock/chainlock.h>
-#include <chainlock/clsig.h>
 #include <llmq/signing.h>
 #include <util/time.h>
 #include <validationinterface.h>

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -4,6 +4,10 @@
 
 #include <evo/deterministicmns.h>
 
+#include <chainparams.h>
+#include <coins.h>
+#include <consensus/validation.h>
+#include <deploymentstatus.h>
 #include <evo/dmn_types.h>
 #include <evo/dmnstate.h>
 #include <evo/evodb.h>
@@ -11,24 +15,18 @@
 #include <evo/simplifiedmns.h>
 #include <evo/specialtx.h>
 #include <masternode/meta.h>
-#include <stats/client.h>
-#include <util/helpers.h>
-
-#include <chainparams.h>
-#include <coins.h>
-#include <consensus/validation.h>
-#include <deploymentstatus.h>
-#include <index/txindex.h>
 #include <node/blockstorage.h>
 #include <script/standard.h>
+#include <stats/client.h>
 #include <uint256.h>
+#include <util/helpers.h>
+
+#include <univalue.h>
 
 #include <functional>
 #include <optional>
 #include <memory>
 #include <ranges>
-
-#include <univalue.h>
 
 static const std::string DB_LIST_SNAPSHOT = "dmn_S3";
 static const std::string DB_LIST_DIFF = "dmn_D4";        // Bumped for nVersion-first format
@@ -53,31 +51,6 @@ CSimplifiedMNListEntry CDeterministicMN::to_sml_entry() const
 std::string CDeterministicMN::ToString() const
 {
     return strprintf("CDeterministicMN(proTxHash=%s, collateralOutpoint=%s, nOperatorReward=%f, state=%s", proTxHash.ToString(), collateralOutpoint.ToStringShort(), (double)nOperatorReward / 100, pdmnState->ToString());
-}
-
-UniValue CDeterministicMN::ToJson() const
-{
-    UniValue obj(UniValue::VOBJ);
-    obj.pushKV("type", std::string(GetMnType(nType).description));
-    obj.pushKV("proTxHash", proTxHash.ToString());
-    obj.pushKV("collateralHash", collateralOutpoint.hash.ToString());
-    obj.pushKV("collateralIndex", collateralOutpoint.n);
-
-    if (g_txindex) {
-        CTransactionRef collateralTx;
-        uint256 nBlockHash;
-        g_txindex->FindTx(collateralOutpoint.hash, nBlockHash, collateralTx);
-        if (collateralTx) {
-            CTxDestination dest;
-            if (ExtractDestination(collateralTx->vout[collateralOutpoint.n].scriptPubKey, dest)) {
-                obj.pushKV("collateralAddress", EncodeDestination(dest));
-            }
-        }
-    }
-
-    obj.pushKV("operatorReward", (double)nOperatorReward / 100);
-    obj.pushKV("state", pdmnState->ToJson(nType));
-    return obj;
 }
 
 bool CDeterministicMNList::IsMNValid(const uint256& proTxHash) const

--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -4,11 +4,8 @@
 
 #include <evo/dmnstate.h>
 
-#include <script/standard.h>
-
 #include <evo/netinfo.h>
-#include <rpc/evo_util.h>
-
+#include <script/standard.h>
 #include <univalue.h>
 
 std::string CDeterministicMNState::ToString() const

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -752,14 +752,14 @@ bool CGovernanceManager::ProcessVoteAndRelay(const CGovernanceVote& vote, CGover
     AssertLockNotHeld(cs_store);
     AssertLockNotHeld(cs_relay);
     uint256 hashToRequest; // Ignored for local votes (no peer to request from)
-    bool fOK = ProcessVote(/*pfrom=*/nullptr, vote, exception, hashToRequest);
+    bool fOK = ProcessVote(vote, exception, hashToRequest);
     if (fOK) {
         RelayVote(vote);
     }
     return fOK;
 }
 
-bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, CGovernanceException& exception,
+bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceException& exception,
                                      uint256& hashToRequest)
 {
     AssertLockNotHeld(cs_store);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -831,7 +831,7 @@ void CGovernanceManager::CheckPostponedObjects()
         bool fMissingConfirmations;
         if (govobj.IsCollateralValid(m_chainman, strError, fMissingConfirmations)) {
             if (govobj.IsValidLocally(Assert(m_dmnman)->GetListAtChainTip(), m_chainman, strError, false)) {
-                AddGovernanceObjectInternal(govobj, "nullptr");
+                AddGovernanceObjectInternal(govobj, "<postponed>");
             } else {
                 LogPrint(BCLog::GOBJECT, "CGovernanceManager::CheckPostponedObjects -- %s invalid\n", nHash.ToString());
             }

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -181,7 +181,7 @@ void CGovernanceManager::AddPostponedObjectInternal(const CGovernanceObject& gov
     mapPostponedObjects.emplace(govobj.GetHash(), std::make_shared<CGovernanceObject>(govobj));
 }
 
-bool CGovernanceManager::ProcessObject(const CNode& peer, const uint256& nHash, CGovernanceObject& govobj)
+bool CGovernanceManager::ProcessObject(const std::string& peer_str, const uint256& nHash, CGovernanceObject& govobj)
 {
     std::string strHash = nHash.ToString();
 
@@ -227,7 +227,7 @@ bool CGovernanceManager::ProcessObject(const CNode& peer, const uint256& nHash, 
         }
     }
 
-    AddGovernanceObjectInternal(govobj, &peer);
+    AddGovernanceObjectInternal(govobj, peer_str);
     return true;
 }
 
@@ -260,7 +260,7 @@ void CGovernanceManager::CheckOrphanVotes(CGovernanceObject& govobj)
     }
 }
 
-void CGovernanceManager::AddGovernanceObjectInternal(CGovernanceObject& insert_obj, const CNode* pfrom)
+void CGovernanceManager::AddGovernanceObjectInternal(CGovernanceObject& insert_obj, const std::string& peer_str)
 {
     AssertLockHeld(::cs_main);
     AssertLockHeld(cs_store);
@@ -308,7 +308,7 @@ void CGovernanceManager::AddGovernanceObjectInternal(CGovernanceObject& insert_o
         return;
     }
 
-    LogPrint(BCLog::GOBJECT, "CGovernanceManager::AddGovernanceObject -- %s new, received from peer %s\n", strHash, pfrom ? pfrom->GetLogString() : "nullptr");
+    LogPrint(BCLog::GOBJECT, "CGovernanceManager::AddGovernanceObject -- %s new, received from peer %s\n", strHash, peer_str);
     RelayObject(*govobj);
 
     // Update the rate buffer
@@ -325,10 +325,10 @@ void CGovernanceManager::AddGovernanceObjectInternal(CGovernanceObject& insert_o
     uiInterface.NotifyGovernanceChanged();
 }
 
-void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, const CNode* pfrom)
+void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, const std::string& peer_str)
 {
     LOCK2(::cs_main, cs_store);
-    AddGovernanceObjectInternal(govobj, pfrom);
+    AddGovernanceObjectInternal(govobj, peer_str);
 }
 
 void CGovernanceManager::CheckAndRemove()
@@ -831,7 +831,7 @@ void CGovernanceManager::CheckPostponedObjects()
         bool fMissingConfirmations;
         if (govobj.IsCollateralValid(m_chainman, strError, fMissingConfirmations)) {
             if (govobj.IsValidLocally(Assert(m_dmnman)->GetListAtChainTip(), m_chainman, strError, false)) {
-                AddGovernanceObjectInternal(govobj);
+                AddGovernanceObjectInternal(govobj, "nullptr");
             } else {
                 LogPrint(BCLog::GOBJECT, "CGovernanceManager::CheckPostponedObjects -- %s invalid\n", nHash.ToString());
             }

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -321,7 +321,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
     std::vector<std::shared_ptr<const CGovernanceObject>> GetApprovedProposals(const CDeterministicMNList& tip_mn_list) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
-    void AddGovernanceObject(CGovernanceObject& govobj, const std::string& peer_str = "nullptr") override
+    void AddGovernanceObject(CGovernanceObject& govobj, const std::string& peer_str) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store, !cs_relay);
 
     // Superblocks

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -381,7 +381,7 @@ public:
     CDeterministicMNManager& GetMNManager();
     /** Process a governance vote. Returns true on success.
      *  If the vote is for an unknown object (orphan), hashToRequest is set to the object hash. */
-    bool ProcessVote(CNode* pfrom, const CGovernanceVote& vote, CGovernanceException& exception, uint256& hashToRequest)
+    bool ProcessVote(const CGovernanceVote& vote, CGovernanceException& exception, uint256& hashToRequest)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
 
 

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -321,7 +321,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
     std::vector<std::shared_ptr<const CGovernanceObject>> GetApprovedProposals(const CDeterministicMNList& tip_mn_list) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
-    void AddGovernanceObject(CGovernanceObject& govobj, const CNode* pfrom = nullptr) override
+    void AddGovernanceObject(CGovernanceObject& govobj, const std::string& peer_str = "nullptr") override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store, !cs_relay);
 
     // Superblocks
@@ -375,7 +375,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
     /// Called to indicate a requested object or vote has been received
     bool AcceptMessage(const uint256& nHash) EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
-    bool ProcessObject(const CNode& peer, const uint256& hash, CGovernanceObject& govobj)
+    bool ProcessObject(const std::string& peer_str, const uint256& hash, CGovernanceObject& govobj)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !cs_store, !cs_relay);
 
     CDeterministicMNManager& GetMNManager();
@@ -401,7 +401,7 @@ private:
         EXCLUSIVE_LOCKS_REQUIRED(cs_store);
 
     // Internal counterpart to "Signer interface"
-    void AddGovernanceObjectInternal(CGovernanceObject& govobj, const CNode* pfrom = nullptr)
+    void AddGovernanceObjectInternal(CGovernanceObject& govobj, const std::string& peer_str)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main, cs_store, !cs_relay);
 
     // ...

--- a/src/governance/net_governance.cpp
+++ b/src/governance/net_governance.cpp
@@ -134,7 +134,7 @@ void NetGovernance::ProcessMessage(CNode& peer, const std::string& msg_type, CDa
             return;
         }
 
-        if (!WITH_LOCK(::cs_main, return m_gov_manager.ProcessObject(peer, nHash, govobj))) {
+        if (!WITH_LOCK(::cs_main, return m_gov_manager.ProcessObject(peer.GetLogString(), nHash, govobj))) {
             // apply node's ban score
             m_peer_manager->PeerMisbehaving(peer.GetId(), 20);
         }

--- a/src/governance/net_governance.cpp
+++ b/src/governance/net_governance.cpp
@@ -169,7 +169,7 @@ void NetGovernance::ProcessMessage(CNode& peer, const std::string& msg_type, CDa
 
         CGovernanceException exception;
         uint256 hashToRequest;
-        if (m_gov_manager.ProcessVote(&peer, vote, exception, hashToRequest)) {
+        if (m_gov_manager.ProcessVote(vote, exception, hashToRequest)) {
             LogPrint(BCLog::GOBJECT, "MNGOVERNANCEOBJECTVOTE -- %s new\n", strHash);
             m_node_sync.BumpAssetLastTime("MNGOVERNANCEOBJECTVOTE");
 

--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -12,11 +12,11 @@
 #include <masternode/sync.h>
 
 #include <chainparams.h>
-#include <core_io.h>
 #include <index/txindex.h>
 #include <logging.h>
 #include <node/interface_ui.h>
 #include <timedata.h>
+#include <util/strencodings.h>
 #include <util/time.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -491,12 +491,12 @@ bool CGovernanceObject::IsCollateralValid(const ChainstateManager& chainman, std
     CAmount nMinFee = GetMinCollateralFee();
 
     LogPrint(BCLog::GOBJECT, "CGovernanceObject::IsCollateralValid -- txCollateral->vout.size() = %s, findScript = %s, nMinFee = %lld\n",
-                txCollateral->vout.size(), ScriptToAsmStr(findScript, false), nMinFee);
+                txCollateral->vout.size(), HexStr(findScript), nMinFee);
 
     bool foundOpReturn = false;
     for (const auto& output : txCollateral->vout) {
         LogPrint(BCLog::GOBJECT, "CGovernanceObject::IsCollateralValid -- txout = %s, output.nValue = %lld, output.scriptPubKey = %s\n",
-                    output.ToString(), output.nValue, ScriptToAsmStr(output.scriptPubKey, false));
+                    output.ToString(), output.nValue, HexStr(output.scriptPubKey));
         if (!output.scriptPubKey.IsPayToPublicKeyHash() && !output.scriptPubKey.IsUnspendable()) {
             strError = strprintf("Invalid Script %s", txCollateral->ToString());
             LogPrintf("CGovernanceObject::IsCollateralValid -- %s\n", strError);

--- a/src/governance/signing.cpp
+++ b/src/governance/signing.cpp
@@ -163,7 +163,7 @@ std::optional<const CGovernanceObject> GovernanceSigner::CreateGovernanceTrigger
     }
 
     // The trigger we just created looks good, submit it
-    m_govman.AddGovernanceObject(gov_sb);
+    m_govman.AddGovernanceObject(gov_sb, "nullptr");
     return std::make_optional<CGovernanceObject>(gov_sb);
 }
 

--- a/src/governance/signing.cpp
+++ b/src/governance/signing.cpp
@@ -163,7 +163,7 @@ std::optional<const CGovernanceObject> GovernanceSigner::CreateGovernanceTrigger
     }
 
     // The trigger we just created looks good, submit it
-    m_govman.AddGovernanceObject(gov_sb, "nullptr");
+    m_govman.AddGovernanceObject(gov_sb, "<local>");
     return std::make_optional<CGovernanceObject>(gov_sb);
 }
 

--- a/src/governance/signing.h
+++ b/src/governance/signing.h
@@ -23,7 +23,6 @@ class CGovernanceException;
 class CGovernanceVote;
 class ChainstateManager;
 class CMasternodeSync;
-class CNode;
 enum vote_outcome_enum_t : int;
 
 class GovernanceSignerParent
@@ -42,7 +41,7 @@ public:
     virtual std::vector<std::shared_ptr<CSuperblock>> GetActiveTriggers() const = 0;
     virtual std::vector<std::shared_ptr<const CGovernanceObject>> GetApprovedProposals(
         const CDeterministicMNList& tip_mn_list) = 0;
-    virtual void AddGovernanceObject(CGovernanceObject& govobj, const CNode* pfrom = nullptr) = 0;
+    virtual void AddGovernanceObject(CGovernanceObject& govobj, const std::string& peer_str) = 0;
 };
 
 class GovernanceSigner

--- a/src/llmq/dkgsessionmgr.cpp
+++ b/src/llmq/dkgsessionmgr.cpp
@@ -6,9 +6,11 @@
 
 #include <bls/bls_ies.h>
 #include <evo/deterministicmns.h>
+#include <llmq/dkgsessionhandler.h>
 #include <llmq/options.h>
 #include <llmq/params.h>
 #include <llmq/utils.h>
+#include <msg_result.h>
 #include <spork.h>
 #include <unordered_lru_cache.h>
 #include <util/helpers.h>

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -7,11 +7,10 @@
 
 #include <bls/bls.h>
 #include <bls/bls_worker.h>
-#include <llmq/dkgsessionhandler.h>
-#include <msg_result.h>
-#include <util/helpers.h>
-
+#include <chainparams.h>
 #include <net_types.h>
+#include <util/helpers.h>
+#include <sync.h>
 
 #include <map>
 #include <memory>
@@ -31,10 +30,10 @@ class ChainstateManager;
 class CMasternodeMetaMan;
 class CSporkManager;
 class PeerManager;
-class CDKGContribution;
-class CDKGComplaint;
-class CDKGJustification;
-class CDKGPrematureCommitment;
+class CInv;
+class CNode;
+class CConnman;
+struct MessageProcessingResult;
 namespace util {
 struct DbWrapperParams;
 } // namespace util
@@ -43,6 +42,11 @@ class UniValue;
 
 namespace llmq
 {
+class CDKGComplaint;
+class CDKGContribution;
+class CDKGJustification;
+class CDKGPrematureCommitment;
+class CDKGSessionHandler;
 class CQuorumSnapshotManager;
 
 class CDKGSessionManager
@@ -102,6 +106,7 @@ public:
     template <typename HandlerFn>
     void InitializeHandlers(HandlerFn&& handler_fn)
     {
+        // TODO: move it to cpp file and drop chainparams.h and helpers.h
         const Consensus::Params& consensus_params = Params().GetConsensus();
         for (const auto& params : consensus_params.llmqs) {
             auto session_count = (params.useRotation) ? params.signingActiveQuorumCount : 1;

--- a/src/llmq/observer.cpp
+++ b/src/llmq/observer.cpp
@@ -6,6 +6,7 @@
 
 #include <llmq/debug.h>
 #include <llmq/dkgsessionmgr.h>
+#include <llmq/dkgsessionhandler.h>
 
 #include <chain.h>
 #include <validation.h>

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -233,7 +233,9 @@ void DashChainstateSetup(ChainstateManager& chainman,
     llmq_ctx = std::make_unique<LLMQContext>(*dmnman, evodb, sporkman, chainman, mn_sync,
                                              util::DbWrapperParams{.path = data_dir, .memory = llmq_dbs_in_memory, .wipe = llmq_dbs_wipe},
                                              bls_threads, worker_count, max_recsigs_age);
-    mempool->ConnectManagers(dmnman.get(), llmq_ctx->isman.get());
+    if (mempool) {
+        mempool->ConnectManagers(dmnman.get(), llmq_ctx->isman.get());
+    }
     chain_helper.reset();
     chain_helper = std::make_unique<CChainstateHelper>(evodb, *dmnman, govman, *(llmq_ctx->isman), *(llmq_ctx->quorum_block_processor),
                                                        *(llmq_ctx->qsnapman), chainman, consensus_params, mn_sync, chainlocks,
@@ -248,7 +250,9 @@ void DashChainstateSetupClose(std::unique_ptr<CChainstateHelper>& chain_helper,
 {
     chain_helper.reset();
     llmq_ctx.reset();
-    mempool->DisconnectManagers();
+    if (mempool) {
+        mempool->DisconnectManagers();
+    }
     dmnman.reset();
 }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -403,7 +403,7 @@ public:
             context().govman->AddPostponedObject(govobj);
             context().govman->RelayObject(govobj);
         } else {
-            context().govman->AddGovernanceObject(govobj);
+            context().govman->AddGovernanceObject(govobj, "<local>");
         }
         out_object_hash = govobj.GetHash().ToString();
         return true;

--- a/src/qt/masternodemodel.cpp
+++ b/src/qt/masternodemodel.cpp
@@ -78,6 +78,7 @@ MasternodeEntry::MasternodeEntry(const interfaces::MnEntryCPtr& dmn, const QStri
         m_operator_reward = QObject::tr("NONE");
     }
 
+    // TODO: get rid of this JSON
     const auto json{dmn->toJson()};
     m_json = QString::fromStdString(json.write(2));
     if (const auto& val = json.find_value("collateralHash"); val.isStr()) {

--- a/src/rpc/evo_util.cpp
+++ b/src/rpc/evo_util.cpp
@@ -4,7 +4,9 @@
 
 #include <rpc/evo_util.h>
 
+#include <evo/deterministicmns.h>
 #include <evo/providertx.h>
+#include <index/txindex.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 
@@ -136,3 +138,29 @@ void ProcessNetInfoPlatform(ProTx& ptx, const UniValue& input_p2p, const UniValu
 }
 template void ProcessNetInfoPlatform(CProRegTx& ptx, const UniValue& input_p2p, const UniValue& input_http, const bool optional);
 template void ProcessNetInfoPlatform(CProUpServTx& ptx, const UniValue& input_p2p, const UniValue& input_http, const bool optional);
+
+
+UniValue CDeterministicMN::ToJson() const
+{
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("type", std::string(GetMnType(nType).description));
+    obj.pushKV("proTxHash", proTxHash.ToString());
+    obj.pushKV("collateralHash", collateralOutpoint.hash.ToString());
+    obj.pushKV("collateralIndex", collateralOutpoint.n);
+
+    if (g_txindex) {
+        CTransactionRef collateralTx;
+        uint256 nBlockHash;
+        g_txindex->FindTx(collateralOutpoint.hash, nBlockHash, collateralTx);
+        if (collateralTx) {
+            CTxDestination dest;
+            if (ExtractDestination(collateralTx->vout[collateralOutpoint.n].scriptPubKey, dest)) {
+                obj.pushKV("collateralAddress", EncodeDestination(dest));
+            }
+        }
+    }
+
+    obj.pushKV("operatorReward", (double)nOperatorReward / 100);
+    obj.pushKV("state", pdmnState->ToJson(nType));
+    return obj;
+}

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -413,7 +413,7 @@ static RPCHelpMan gobject_submit()
         node.govman->AddPostponedObject(govobj);
         node.govman->RelayObject(govobj);
     } else {
-        node.govman->AddGovernanceObject(govobj);
+        node.govman->AddGovernanceObject(govobj, "<local>");
     }
 
     return govobj.GetHash().ToString();

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -5,6 +5,7 @@
 #include <active/context.h>
 #include <active/masternode.h>
 #include <chainlock/chainlock.h>
+#include <chainlock/clsig.h>
 #include <chainlock/handler.h>
 #include <evo/deterministicmns.h>
 #include <llmq/blockprocessor.h>

--- a/src/test/llmq_chainlock_tests.cpp
+++ b/src/test/llmq_chainlock_tests.cpp
@@ -8,7 +8,7 @@
 #include <streams.h>
 #include <util/strencodings.h>
 
-#include <chainlock/clsig.h>
+#include <chainlock/chainlock.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/util/llmq_tests.h
+++ b/src/test/util/llmq_tests.h
@@ -16,7 +16,7 @@
 #include <streams.h>
 #include <uint256.h>
 
-#include <chainlock/clsig.h>
+#include <chainlock/chainlock.h>
 #include <llmq/commitment.h>
 #include <llmq/params.h>
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -23,7 +23,7 @@
 
 #include <zmq.h>
 
-#include <chainlock/clsig.h>
+#include <chainlock/chainlock.h>
 #include <governance/common.h>
 #include <governance/vote.h>
 #include <instantsend/lock.h>

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -44,6 +44,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "llmq/blockprocessor -> llmq/utils -> llmq/snapshot -> llmq/blockprocessor",
     "llmq/commitment -> llmq/utils -> llmq/snapshot -> llmq/commitment",
     "llmq/dkgsessionhandler -> net_processing -> llmq/dkgsessionmgr -> llmq/dkgsessionhandler",
+    "llmq/dkgsessionhandler -> net_processing -> llmq/observer -> llmq/dkgsessionhandler",
     "masternode/payments -> validation -> masternode/payments",
     "net -> netmessagemaker -> net",
     "netaddress -> netbase -> netaddress",


### PR DESCRIPTION
## Issue being fixed or feature implemented
That's some final preparation with various refactors for kernel-0 project, splitted out from #7234

## What was done?
 - drop pfrom from CGovernanceManager::ProcessVote
 - drop dependency of CGovernanceManager on net.cpp
 - drop dependency of governance/object on core_write (ScriptToAsmStr)
 - add guards for CTxMempool is nullptr [which could be for chainstate case]
 - removed multiple includes of msg_result.h over codebase
 - moved CDeterministicMN::ToJson to core_write to avoid g_txindex 
 - move VerifyChainLock and ChainLockSig between modules to untangle chain-state dependencies

NOTE: the circular dependency over `dkgsessionhandler <-> net_processing` is not new, it's pre-existing one but discovered by replacing removing `llmq/dkgsessionhandler.h` from `llmq/dkgsessionmgr.h` and direct adding this include to llmq/observer

        "llmq/dkgsessionhandler -> net_processing -> llmq/dkgsessionmgr -> llmq/dkgsessionhandler",
        "llmq/dkgsessionhandler -> net_processing -> llmq/observer -> llmq/dkgsessionhandler",

## How Has This Been Tested?
Run unit & functional tests; proof-of-concept of final PR is https://github.com/dashpay/dash/pull/7234

Compilation time is not affected by this PR: removing msg_result.h from the header have too small positive impact; replacing chainlock/clsig.h to chainlock/chainlock.h doesn't give any visible change either.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

