### PR TITLE
test: tolerate limited peer disconnect in p2p test

### DIFF
--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -80,11 +80,18 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
 
         # connect unsynced node 2 with pruned NODE_NETWORK_LIMITED peer
         # because node 2 is in IBD and node 0 is a NODE_NETWORK_LIMITED peer, sync must not be possible
-        self.connect_nodes(0, 2)
-        try:
-            self.sync_blocks([self.nodes[0], self.nodes[2]], timeout=5)
-        except Exception:
-            pass
+        with self.nodes[0].wait_for_debug_log(
+                [b"Ignore block request below NODE_NETWORK_LIMITED threshold"], timeout=15):
+            try:
+                self.connect_nodes(0, 2)
+            except AssertionError as e:
+                if "peer disconnected" not in str(e):
+                    raise
+                self.log.info("NODE_NETWORK_LIMITED peer disconnected unsynced peer before connect completed")
+            try:
+                self.sync_blocks([self.nodes[0], self.nodes[2]], timeout=5)
+            except AssertionError:
+                pass  # expected: NODE_NETWORK_LIMITED peer cannot serve IBD blocks
         # node2 must remain at height 0
         assert_equal(self.nodes[2].getblockheader(self.nodes[2].getbestblockhash())['height'], 0)
 


### PR DESCRIPTION
# test: tolerate limited peer disconnect in p2p test

## Summary

- Tolerate the expected `connect_nodes()` fast-disconnect race in
  `p2p_node_network_limited.py --v2transport`.
- Keep the behavior assertion by waiting for node 0 to log the
  `NODE_NETWORK_LIMITED` old-block disconnect.
- Preserve the final check that unsynced node 2 remains at height 0.

Fixes dashpay/dash#7288.

## Validation

- `./test/functional/p2p_node_network_limited.py --v2transport \
  --configfile=/Users/claw/Projects/dash/test/config.ini`
- `git diff --check`
- Pre-PR review gate: `code-review dashpay/dash upstream/develop \
  fix-7288-node-network-limited-disconnect` returned `ship`.
