### PR TITLE
test: keep RPC coverage dir under runner tmpdir

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -598,7 +598,7 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, attempts=1, enab
     flags = ['--cachedir={}'.format(cache_dir)] + args
 
     if enable_coverage:
-        coverage = RPCCoverage()
+        coverage = RPCCoverage(tmpdir)
         flags.append(coverage.flag)
         logging.debug("Initializing coverage directory at %s" % coverage.dir)
     else:
@@ -889,8 +889,8 @@ class RPCCoverage():
     See also: test/functional/test_framework/coverage.py
 
     """
-    def __init__(self):
-        self.dir = tempfile.mkdtemp(prefix="coverage")
+    def __init__(self, tmpdir):
+        self.dir = tempfile.mkdtemp(prefix="coverage", dir=tmpdir)
         self.flag = '--coveragedir=%s' % self.dir
 
     def report_rpc_coverage(self):


### PR DESCRIPTION
# Summary

## Motivation

`test_runner.py --coverage` currently creates the shared RPC coverage
directory directly under the system temp directory via
`tempfile.mkdtemp(prefix="coverage")`.

In CI this can leave the coverage lifecycle outside the runner-owned temp tree,
which matches dashpay/dash#7273 where `/tmp/coverage*` disappeared while
coverage-enabled functional tests were still running.

## Changes

- Pass the runner `tmpdir` into `RPCCoverage`.
- Create the shared RPC coverage directory under that runner-managed temp tree.

## Validation

- `python3 -m py_compile test/functional/test_runner.py`
- Smoke-tested `RPCCoverage(tmpdir)` creation/cleanup with a temporary parent
  directory.
- Pre-PR code review gate: `ship`.

Fixes dashpay/dash#7273.
