### PR TITLE
test: recreate RPC coverage directory before writes

### DIFF
--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -54,6 +54,7 @@ class AuthServiceProxyWrapper():
         rpc_method = self.auth_service_proxy_instance._service_name
 
         if self.coverage_logfile:
+            os.makedirs(os.path.dirname(self.coverage_logfile), exist_ok=True)
             with open(self.coverage_logfile, 'a+', encoding='utf8') as f:
                 f.write("%s\n" % rpc_method)
 
@@ -92,6 +93,7 @@ def write_all_rpc_commands(dirname: str, node: AuthServiceProxy) -> bool:
 
     """
     filename = os.path.join(dirname, REFERENCE_FILENAME)
+    os.makedirs(dirname, exist_ok=True)
 
     if os.path.isfile(filename):
         return False


### PR DESCRIPTION
# test: recreate RPC coverage directory before writes

## Summary

- Recreate the RPC coverage directory before writing per-node coverage logs.
- Recreate the directory before writing the shared `rpc_interface.txt` file.
- Fixes #7273.

## Validation

- `python3 -m py_compile test/functional/test_framework/coverage.py`
- Smoke test removed a temporary coverage directory before `_log_call()` and
  before `write_all_rpc_commands()`. Both paths recreated the directory and
  wrote the expected files.
- Pre-PR review:
  `code-review dashpay/dash upstream/develop fix-coverage-dir-recreate ...`
  returned `ship`.
