### PR TITLE
fix(qt): add non-native file dialog option

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -506,6 +506,7 @@ static void SetupUIArgs(ArgsManager& argsman)
     argsman.AddArg("-font-weight-normal", QObject::tr("Set the font weight for normal texts. Possible range %1 to %2 (default: %3)").arg(0).arg(8).arg(GUIUtil::weightToArg(GUIUtil::FontRegistry::TARGET_WEIGHT_NORMAL)).toStdString(), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-lang=<lang>", QObject::tr("Set language, for example \"de_DE\" (default: system locale)").toStdString(), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-min", QObject::tr("Start minimized").toStdString(), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
+    argsman.AddArg("-nativefiledialogs", strprintf(QObject::tr("Use system native file dialogs; set to 0 to force Qt file dialogs if native dialogs freeze or crash on some desktop environments (default: %u)").toStdString(), true), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-resetguisettings", QObject::tr("Reset all settings changed in the GUI").toStdString(), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-splash", strprintf(QObject::tr("Show splash screen on startup (default: %u)").toStdString(), DEFAULT_SPLASHSCREEN), ArgsManager::ALLOW_ANY, OptionsCategory::GUI);
     argsman.AddArg("-uiplatform", strprintf("Select platform to customize UI for (one of windows, macosx, other; default: %s)", BitcoinGUI::DEFAULT_UIPLATFORM), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::GUI);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -497,6 +497,13 @@ QString ExtractFirstSuffixFromFilter(const QString& filter)
     return suffix;
 }
 
+static QFileDialog::Options GetFileDialogOptions()
+{
+    return gArgs.GetBoolArg("-nativefiledialogs", /*fDefault=*/true)
+        ? QFileDialog::Options()
+        : QFileDialog::Options(QFileDialog::DontUseNativeDialog);
+}
+
 QString getSaveFileName(QWidget *parent, const QString &caption, const QString &dir,
     const QString &filter,
     QString *selectedSuffixOut)
@@ -512,7 +519,7 @@ QString getSaveFileName(QWidget *parent, const QString &caption, const QString &
         myDir = dir;
     }
     /* Directly convert path to native OS path separators */
-    QString result = QDir::toNativeSeparators(QFileDialog::getSaveFileName(parent, caption, myDir, filter, &selectedFilter));
+    QString result = QDir::toNativeSeparators(QFileDialog::getSaveFileName(parent, caption, myDir, filter, &selectedFilter, GetFileDialogOptions()));
 
     QString selectedSuffix = ExtractFirstSuffixFromFilter(selectedFilter);
 
@@ -552,7 +559,7 @@ QString getOpenFileName(QWidget *parent, const QString &caption, const QString &
         myDir = dir;
     }
     /* Directly convert path to native OS path separators */
-    QString result = QDir::toNativeSeparators(QFileDialog::getOpenFileName(parent, caption, myDir, filter, &selectedFilter));
+    QString result = QDir::toNativeSeparators(QFileDialog::getOpenFileName(parent, caption, myDir, filter, &selectedFilter, GetFileDialogOptions()));
 
     if(selectedSuffixOut)
     {
@@ -560,6 +567,11 @@ QString getOpenFileName(QWidget *parent, const QString &caption, const QString &
         ;
     }
     return result;
+}
+
+QString getExistingDirectory(QWidget* parent, const QString& caption, const QString& dir)
+{
+    return QDir::toNativeSeparators(QFileDialog::getExistingDirectory(parent, caption, dir, QFileDialog::ShowDirsOnly | GetFileDialogOptions()));
 }
 
 Qt::ConnectionType blockingGUIThreadConnection()

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -227,6 +227,9 @@ namespace GUIUtil
         const QString &filter,
         QString *selectedSuffixOut);
 
+    /** Get existing directory, convenience wrapper for QFileDialog::getExistingDirectory. */
+    QString getExistingDirectory(QWidget* parent, const QString& caption, const QString& dir);
+
     /** Get connection type to call object slot in GUI thread with invokeMethod. The call will be blocking.
 
        @returns If called from the GUI thread, return a Qt::DirectConnection.

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -20,7 +20,7 @@
 #include <util/system.h>
 #include <validation.h>
 
-#include <QFileDialog>
+#include <QDir>
 #include <QSettings>
 #include <QMessageBox>
 
@@ -326,7 +326,7 @@ void Intro::on_dataDirectory_textChanged(const QString &dataDirStr)
 
 void Intro::on_ellipsisButton_clicked()
 {
-    QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(nullptr, "Choose data directory", ui->dataDirectory->text()));
+    QString dir = GUIUtil::getExistingDirectory(this, tr("Choose data directory"), ui->dataDirectory->text());
     if(!dir.isEmpty())
         ui->dataDirectory->setText(dir);
 }


### PR DESCRIPTION
# PR Body

## Summary

- Add a `-nativefiledialogs` GUI option.
- Default remains the existing native-dialog behavior.
- With `-nativefiledialogs=0`, central save/open dialogs use Qt dialogs.
- Route the data-directory chooser through the same `GUIUtil` wrapper.

Fixes dashpay/dash#6935.

## Motivation

Some Linux desktop environments can hang or freeze in native Qt file dialogs
before Dash reaches the export or wallet-backup code paths.

This keeps the default UX unchanged while adding a narrow escape hatch for
affected users.

## Validation

- `git diff --check upstream/develop...HEAD`
- `code-review dashpay/dash upstream/develop fix/file-dialog-nonnative-option`
  returned `ship`
- Reviewed all changed files.
- Confirmed current static `QFileDialog` save/open/directory call sites under
  `src/qt` route through `GUIUtil` on this branch.

No GUI runtime test was run in this macOS worktree. The reported freeze requires
an affected Linux/KDE/native-dialog environment to reproduce.
