### PR TITLE
test: advance mocktime during quorum list waits

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2118,16 +2118,18 @@ class DashTestFramework(BitcoinTestFramework):
 
     def wait_for_quorum_list(self, quorum_hash, nodes, timeout=15, llmq_type_name="llmq_test"):
         def wait_func():
+            self.bump_mocktime(1, nodes=nodes)
             return quorum_hash in self.nodes[0].quorum('list')[llmq_type_name]
         self.log.info(f"quorums: {self.nodes[0].quorum('list')}")
-        self.wait_until(wait_func, timeout=timeout, sleep=0.05)
+        self.wait_until(wait_func, timeout=timeout, sleep=1)
 
     def wait_for_quorums_list(self, quorum_hash_0, quorum_hash_1, nodes, llmq_type_name="llmq_test",  timeout=15):
         def wait_func():
+            self.bump_mocktime(1, nodes=nodes)
             quorums = self.nodes[0].quorum("list")[llmq_type_name]
             return quorum_hash_0 in quorums and quorum_hash_1 in quorums
         self.log.info(f"h({self.nodes[0].getblockcount()}) quorums: {self.nodes[0].quorum('list')}")
-        self.wait_until(wait_func, timeout=timeout, sleep=0.05)
+        self.wait_until(wait_func, timeout=timeout, sleep=1)
 
     def move_blocks(self, nodes, num_blocks):
         self.bump_mocktime(1, nodes=nodes)


### PR DESCRIPTION
# Summary

## Motivation

`feature_asset_locks.py` intermittently times out after mining an
`llmq_test_platform` quorum. The final commitment is mined, but the new quorum
does not always appear in `quorum list` before the helper's short polling loop
expires.

In mocktime-driven functional tests, quorum-list publication can require
scheduler/mocktime progress after the final commitment block is mined.

Fixes dashpay/dash#7310.

## Changes

- Advance mocktime while polling `wait_for_quorum_list()`.
- Apply the same behavior to `wait_for_quorums_list()` so rotated-quorum flows
  keep the same synchronization semantics.
- Poll once per mocktime second instead of every 50ms while advancing mocktime.

## Validation

- `git diff --check`
- `python3 test/functional/feature_llmq_rotation.py --configfile=/Users/claw/Projects/dash/test/config.ini`
- `python3 test/functional/feature_asset_locks.py --configfile=/Users/claw/Projects/dash/test/config.ini`
- Pre-PR code review: no significant issues found.
