### PR TITLE
fix: intermittent incorrect logging of CheckQueue for invalid blocks

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2440,8 +2440,8 @@ bool CChainState::ConnectBlock(const CBlock& block, BlockValidationState& state,
     // in multiple threads). Preallocate the vector size so a new allocation
     // doesn't invalidate pointers into the vector, and keep txsdata in scope
     // for as long as `control`.
-    CCheckQueueControl<CScriptCheck> control(fScriptChecks && g_parallel_script_checks ? &scriptcheckqueue : nullptr);
     std::vector<PrecomputedTransactionData> txsdata(block.vtx.size());
+    CCheckQueueControl<CScriptCheck> control(fScriptChecks && g_parallel_script_checks ? &scriptcheckqueue : nullptr);
 
     std::vector<int> prevheights;
     CAmount nFees = 0;


### PR DESCRIPTION
## Issue being fixed or feature implemented

ConnectBlock may return no-named failure instead proper error code such as:

    2024-09-23T13:13:10Z ERROR: ConnectBlock: CheckQueue failed

## What was done?
This PR fixes this intermittent failure


## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
