### PR TITLE
fix(qt): handle pixel-sized fonts when scaling widgets

### DIFF
--- a/src/qt/guiutil_font.cpp
+++ b/src/qt/guiutil_font.cpp
@@ -579,14 +579,21 @@ void updateFonts()
         ++nUpdatable;
 
         QFont font = w->font();
-        assert(font.pointSize() > 0);
+        double font_size = font.pointSizeF();
+        if (font_size <= 0 && font.pixelSize() > 0) {
+            font_size = font.pixelSize() * 72.0 / w->logicalDpiY();
+            font.setPointSizeF(font_size);
+        }
+        if (font_size <= 0) {
+            continue;
+        }
         font.setFamily(qApp->font().family());
         font.setWeight(g_font_registry.GetWeightNormal());
         font.setStyleName(qApp->font().styleName());
         font.setStyle(qApp->font().style());
 
         // Insert/Get the default font size of the widget
-        auto itDefault = mapWidgetDefaultFontSizes.emplace(w, font.pointSize());
+        auto itDefault = mapWidgetDefaultFontSizes.emplace(w, font_size);
 
         auto it = mapFontUpdates.find(w);
         if (it != mapFontUpdates.end()) {


### PR DESCRIPTION
# Pixel-sized font scaling fix

## Summary

- handle Qt widgets whose stylesheet fonts are pixel-sized when
  `GUIUtil::updateFonts()` runs
- convert pixel sizes to point-size equivalents before applying the existing
  font-scaling path
- avoid the macOS assertion abort seen while opening the recovery phrase dialog

Fixes dashpay/dash#7281.

## Validation

- `git diff --check upstream/develop...HEAD`
- code-review gate: `ship` for `upstream/develop..tracker-1251`
- Static validation only. I do not have a macOS Tahoe GUI environment available
  to reproduce the original crash locally.
