### PR TITLE
fix: drop `virtual` specifier for `CZMQNotificationInterface` dtor

### DIFF
--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -19,7 +19,7 @@ class CZMQAbstractNotifier;
 class CZMQNotificationInterface final : public CValidationInterface
 {
 public:
-    virtual ~CZMQNotificationInterface();
+    ~CZMQNotificationInterface();
 
     std::list<const CZMQAbstractNotifier*> GetActiveNotifiers() const;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
```
In file included from zmq/zmqnotificationinterface.cpp:5:
./zmq/zmqnotificationinterface.h:22:13: error: virtual method '~CZMQNotificationInterface' is inside a 'final' class and can never be overridden [-Werror,-Wunnecessary-virtual-specifier]
   22 |     virtual ~CZMQNotificationInterface();
      |             ^
1 error generated.
```

## What was done?


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

