### PR TITLE
ci: tolerate conflict comment permission errors

### DIFF
--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -35,7 +35,8 @@ jobs:
         continue-on-error: true
       - name: Post conflict comment
         if: steps.validate_conflicts.outputs.has_conflicts == 'true'
-        uses: mshick/add-pr-comment@v2
+        continue-on-error: true
+        uses: mshick/add-pr-comment@v3
         with:
           message-id: conflict-prediction
           message: |
@@ -48,7 +49,8 @@ jobs:
             Please coordinate with the authors of these PRs to avoid merge conflicts.
       - name: Remove conflict comment if no conflicts
         if: steps.validate_conflicts.outputs.has_conflicts == 'false'
-        uses: mshick/add-pr-comment@v2
+        continue-on-error: true
+        uses: mshick/add-pr-comment@v3
         with:
           message-id: conflict-prediction
           message: |


### PR DESCRIPTION
# PR: tolerate conflict comment permission errors

## Summary

- upgrade the conflict-prediction sticky-comment action to
  `mshick/add-pr-comment@v3`
- make both sticky-comment publication/removal steps non-fatal
- keep the existing final `Fail if conflicts exist` gate authoritative

Closes #7268.

## Motivation

Fork/review-triggered `predict_conflicts` runs can fail with
`Resource not accessible by integration` while trying to update PR comments,
even when conflict detection itself has already completed. Comment delivery
should be best-effort; actual conflicts should continue to be enforced by the
final gate step.

## Validation

- Parsed `.github/workflows/predict-conflicts.yml` with `yaml.safe_load`.
- Ran `git diff --check upstream/master...HEAD`.
- Ran pre-PR code review:
  `code-review dashpay/dash upstream/master ci-predict-conflicts-comment-resilience`.
  Result: `Recommendation: ship`.
