### PR TITLE
test: backport LLMQ recsig relay symmetry

### DIFF
--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -799,13 +799,28 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& 
              util_params.m_base_index->GetBlockHash().ToString());
 
     Uint256HashSet connections;
+    Uint256HashSet relayMembers;
     if (isMember) {
         connections = GetQuorumConnections(llmqParams, sporkman, util_params, myProTxHash, /*onlyOutbound=*/true);
+        // If all-members-connected is enabled for this quorum type, leverage the full-mesh
+        // connections for low-latency recovered sig propagation by treating all members as
+        // relay members (instead of the ring-based subset). This ensures peers will send
+        // QSENDRECSIGS to each other across the full mesh and set m_wants_recsigs widely.
+        if (IsAllMembersConnectedEnabled(llmqParams.type, sporkman)) {
+            for (const auto& dmn : members) {
+                if (dmn->proTxHash != myProTxHash) {
+                    relayMembers.emplace(dmn->proTxHash);
+                }
+            }
+        } else {
+            relayMembers = GetQuorumRelayMembers(llmqParams, util_params, myProTxHash, true);
+        }
     } else {
         auto cindexes = CalcDeterministicWatchConnections(llmqParams.type, util_params.m_base_index, members.size(), 1);
         for (auto idx : cindexes) {
             connections.emplace(members[idx]->proTxHash);
         }
+        relayMembers = connections;
     }
     if (!connections.empty()) {
         if (!connman.HasMasternodeQuorumNodes(llmqParams.type, util_params.m_base_index->GetBlockHash()) &&
@@ -824,7 +839,9 @@ bool EnsureQuorumConnections(const Consensus::LLMQParams& llmqParams, CConnman& 
             LogPrint(BCLog::NET_NETCONN, debugMsg.c_str()); /* Continued */
         }
         connman.SetMasternodeQuorumNodes(llmqParams.type, util_params.m_base_index->GetBlockHash(), connections);
-        connman.SetMasternodeQuorumRelayMembers(llmqParams.type, util_params.m_base_index->GetBlockHash(), connections);
+    }
+    if (!relayMembers.empty()) {
+        connman.SetMasternodeQuorumRelayMembers(llmqParams.type, util_params.m_base_index->GetBlockHash(), relayMembers);
     }
     return true;
 }

--- a/test/functional/feature_llmq_signing.py
+++ b/test/functional/feature_llmq_signing.py
@@ -41,6 +41,7 @@ class LLMQSigningTest(DashTestFramework):
 
         if self.options.spork21:
             assert self.mninfo[0].get_node(self).getconnectioncount() == self.llmq_size
+            self.assert_qsendrecsigs_symmetric()
 
         id = "0000000000000000000000000000000000000000000000000000000000000001"
         msgHash = "0000000000000000000000000000000000000000000000000000000000000002"
@@ -199,6 +200,37 @@ class LLMQSigningTest(DashTestFramework):
             # Let 2 seconds pass so that the next node is used for recovery, which should succeed
             self.bump_mocktime(2)
             wait_for_sigs(True, False, True, 2)
+
+    def assert_qsendrecsigs_symmetric(self):
+        # If only one direction's QSENDRECSIGS arrives, the receiving side keeps
+        # m_wants_recsigs=false and silently drops half of all recsig pushes.
+        self.log.info("Assert QSENDRECSIGS was exchanged in both directions on every MN-MN edge")
+        mn_protxs = {mn.proTxHash for mn in self.mninfo}
+
+        def all_symmetric():
+            for mn in self.mninfo:
+                expected_peers = mn_protxs - {mn.proTxHash}
+                quorum_peers = {}
+                for p in mn.get_node(self).getpeerinfo():
+                    peer_protx = p.get("verified_proregtx_hash", "")
+                    if peer_protx not in expected_peers:
+                        continue
+                    quorum_peers.setdefault(peer_protx, []).append(p)
+
+                if set(quorum_peers.keys()) != expected_peers:
+                    return False
+
+                for peer_infos in quorum_peers.values():
+                    if not any(
+                        p.get("bytessent_per_msg", {}).get("qsendrecsigs", 0) > 0 and
+                        p.get("bytesrecv_per_msg", {}).get("qsendrecsigs", 0) > 0
+                        for p in peer_infos
+                    ):
+                        return False
+            return True
+
+        self.wait_until(all_symmetric, timeout=10)
+
 
 if __name__ == '__main__':
     LLMQSigningTest().main()


### PR DESCRIPTION
# Backport LLMQ recovered-sig relay fix

## Summary

- Backport dashpay/dash#7289 to `v23.1.x`.
- Restore full-mesh recovered-signature relay membership when
  `SPORK_21_QUORUM_ALL_CONNECTED` is active.
- Add the upstream regression check for symmetric `QSENDRECSIGS` negotiation in
  `feature_llmq_signing.py --spork21`.

Fixes dashpay/dash#7323.

## Context

`feature_llmq_signing.py --spork21` is still flaky on the `v23.1.x` CI lane
because the dashpay/dash#7289 fix is present on `develop` but not on the
release branch.

The latest hit was in dashpay/dash#7322, whose branch only changes
`.github/workflows/predict-conflicts.yml`, so the LLMQ failure is unrelated to
that PR.

## Validation

- `python3 -m py_compile test/functional/feature_llmq_signing.py`
- `git diff --check upstream/v23.1.x...test/backport-7289-v23-llmq-signing`
- Code review gate:

  ```bash
  code-review dashpay/dash \
    upstream/v23.1.x \
    test/backport-7289-v23-llmq-signing \
    "Backport PR #7289 to v23.1.x to fix the #7323 spork21 flake"
  ```

  Result: Recommendation: ship

Functional test was not run locally; this workspace does not have a configured
Dash Core build directory for the `v23.1.x` worktree.
