### PR TITLE
test: extend v19 spork sync wait

### DIFF
--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -79,7 +79,7 @@ class DIP3V19Test(DashTestFramework):
 
         self.mine_quorum(llmq_type_name='llmq_test', llmq_type=100)
 
-        self.activate_by_name('v19', expected_activation_height=200)
+        self.activate_by_name('v19', expected_activation_height=200, spork_sync_timeout=60)
         self.log.info("Activated v19 at height:" + str(self.nodes[0].getblockcount()))
 
         mn_list_after = self.nodes[0].masternodelist()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1555,7 +1555,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.v20_height = height
         self.mn_rr_height = height
 
-    def activate_by_name(self, name, expected_activation_height=None, slow_mode=True):
+    def activate_by_name(self, name, expected_activation_height=None, slow_mode=True, spork_sync_timeout=30):
         assert not softfork_active(self.nodes[0], name)
         self.log.info("Wait for " + name + " activation")
 
@@ -1563,7 +1563,7 @@ class DashTestFramework(BitcoinTestFramework):
         spork17_value = self.nodes[0].spork('show')['SPORK_17_QUORUM_DKG_ENABLED']
         self.bump_mocktime(1)
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 4070908800)
-        self.wait_for_sporks_same()
+        self.wait_for_sporks_same(timeout=spork_sync_timeout)
 
         # mine blocks in batches
         batch_size = 50 if not slow_mode else 10
@@ -1594,7 +1594,7 @@ class DashTestFramework(BitcoinTestFramework):
         # revert spork17 changes
         self.bump_mocktime(1)
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", spork17_value)
-        self.wait_for_sporks_same()
+        self.wait_for_sporks_same(timeout=spork_sync_timeout)
 
     def activate_v20(self, expected_activation_height=None):
         self.activate_by_name('v20', expected_activation_height)


### PR DESCRIPTION
# Summary

## What changed

- Add a `spork_sync_timeout` override to `activate_by_name()`.
- Preserve the existing 30-second default for all current callers.
- Use a 60-second spork sync timeout for the `feature_dip3_v19.py`
  v19 activation path after adding a dynamic masternode and mining a quorum.

Fixes #6702.

## Why

`feature_dip3_v19.py` can intermittently time out while propagating the
temporary spork17 update inside `activate_by_name('v19')` under dynamic
masternode / quorum load.

Scoping the longer wait to this test path avoids doubling timeout latency for
unrelated functional tests.

## Validation

- `python3 -m py_compile test/functional/feature_dip3_v19.py test/functional/test_framework/test_framework.py`
- `python3 test/functional/feature_dip3_v19.py --configfile=/Users/claw/Projects/dash/test/config.ini`
  — passed locally on macOS 15.6 arm64
- Pre-PR code review gate: `ship`
