### PR TITLE
test: increase v23 activation spork sync timeout

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1560,7 +1560,7 @@ class DashTestFramework(BitcoinTestFramework):
         spork17_value = self.nodes[0].spork('show')['SPORK_17_QUORUM_DKG_ENABLED']
         self.bump_mocktime(1)
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 4070908800)
-        self.wait_for_sporks_same()
+        self.wait_for_sporks_same(timeout=60)
 
         # mine blocks in batches
         batch_size = 50 if not slow_mode else 10
@@ -1591,7 +1591,7 @@ class DashTestFramework(BitcoinTestFramework):
         # revert spork17 changes
         self.bump_mocktime(1)
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", spork17_value)
-        self.wait_for_sporks_same()
+        self.wait_for_sporks_same(timeout=60)
 
     def activate_v20(self, expected_activation_height=None):
         self.activate_by_name('v20', expected_activation_height)


### PR DESCRIPTION
# Summary

## What changed

- Increase both `activate_by_name()` spork synchronization waits from 30 to
  60 seconds on `v23.1.x`.
- Preserve the shared `wait_for_sporks_same()` default for non-activation
  callers.

Refs #6702.

## Why

`feature_dip3_v19.py` is still intermittently failing on `v23.1.x` CI while
waiting for the temporary spork17 change inside `activate_by_name()` to reach
all nodes.

This is the same activation-path timeout class as the existing unmerged
`0309ae56d8` fix, and it is currently blocking clean CI reruns for release
branch PRs such as #7324.

## Validation

- `python3 -m py_compile test/functional/test_framework/test_framework.py test/functional/feature_dip3_v19.py`
- `git diff --check`
- Pre-PR code review gate: `ship`

Functional test was not run locally; this workspace does not have a configured
Dash Core build directory for the `v23.1.x` worktree.
