### PR TITLE
test: extend v19 spork sync wait

### DIFF
--- a/test/functional/feature_dip3_v19.py
+++ b/test/functional/feature_dip3_v19.py
@@ -79,7 +79,7 @@ class DIP3V19Test(DashTestFramework):
 
         self.mine_quorum(llmq_type_name='llmq_test', llmq_type=100)
 
-        self.activate_by_name('v19', expected_activation_height=200)
+        self.activate_by_name('v19', expected_activation_height=200, spork_sync_timeout=60)
         self.log.info("Activated v19 at height:" + str(self.nodes[0].getblockcount()))
 
         mn_list_after = self.nodes[0].masternodelist()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1552,7 +1552,7 @@ class DashTestFramework(BitcoinTestFramework):
         self.v20_height = height
         self.mn_rr_height = height
 
-    def activate_by_name(self, name, expected_activation_height=None, slow_mode=True):
+    def activate_by_name(self, name, expected_activation_height=None, slow_mode=True, spork_sync_timeout=30):
         assert not softfork_active(self.nodes[0], name)
         self.log.info("Wait for " + name + " activation")
 
@@ -1560,7 +1560,7 @@ class DashTestFramework(BitcoinTestFramework):
         spork17_value = self.nodes[0].spork('show')['SPORK_17_QUORUM_DKG_ENABLED']
         self.bump_mocktime(1)
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 4070908800)
-        self.wait_for_sporks_same()
+        self.wait_for_sporks_same(timeout=spork_sync_timeout)
 
         # mine blocks in batches
         batch_size = 50 if not slow_mode else 10
@@ -1591,7 +1591,7 @@ class DashTestFramework(BitcoinTestFramework):
         # revert spork17 changes
         self.bump_mocktime(1)
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", spork17_value)
-        self.wait_for_sporks_same()
+        self.wait_for_sporks_same(timeout=spork_sync_timeout)
 
     def activate_v20(self, expected_activation_height=None):
         self.activate_by_name('v20', expected_activation_height)


### PR DESCRIPTION
# Test v19 spork sync wait

## Summary

- Backport the `feature_dip3_v19.py` spork sync timeout deflake to `v23.1.x`.
- Keep the existing `activate_by_name()` default timeout for other callers.
- Let the v19 activation test opt into a 60s spork-sync wait.

## Context

`dashpay/dash#7321` hit the known `feature_dip3_v19.py` UBSAN timeout while
waiting for sporks to match after v19 activation. This mirrors the green fix
already opened for `develop` in `dashpay/dash#7325`.

## Validation

- `python3 -m py_compile test/functional/feature_dip3_v19.py test/functional/test_framework/test_framework.py`
- Code review gate: `Recommendation: ship`
