### PR TITLE
fix: remove cs_main from MaybePunishNodeForTx, missing changes from #19607

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1994,11 +1994,8 @@ bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationStat
         break;
     // The node is providing invalid data:
     case TxValidationResult::TX_CONSENSUS:
-        {
-            LOCK(cs_main);
-            Misbehaving(nodeid, 100);
-            return true;
-        }
+        Misbehaving(nodeid, 100);
+        return true;
     // Conflicting (but not necessarily invalid) data or different policy:
     case TxValidationResult::TX_RECENT_CONSENSUS_CHANGE:
     case TxValidationResult::TX_INPUTS_NOT_STANDARD:


### PR DESCRIPTION
## Issue being fixed or feature implemented
Helper MaybePunishNodeForTx has been introduced when bitcoin#19607 is done, it caused missing changes.

## What was done?
Removed cs_main from MaybePunishNodeForTx

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

