### PR TITLE
ci: tolerate conflict comment permission failures

### DIFF
--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -35,7 +35,8 @@ jobs:
         continue-on-error: true
       - name: Post conflict comment
         if: steps.validate_conflicts.outputs.has_conflicts == 'true'
-        uses: mshick/add-pr-comment@v2
+        continue-on-error: true
+        uses: mshick/add-pr-comment@v3
         with:
           message-id: conflict-prediction
           message: |
@@ -48,7 +49,8 @@ jobs:
             Please coordinate with the authors of these PRs to avoid merge conflicts.
       - name: Remove conflict comment if no conflicts
         if: steps.validate_conflicts.outputs.has_conflicts == 'false'
-        uses: mshick/add-pr-comment@v2
+        continue-on-error: true
+        uses: mshick/add-pr-comment@v3
         with:
           message-id: conflict-prediction
           message: |


### PR DESCRIPTION
# Backport predict-conflicts comment hardening

## Summary

- Update the conflict-prediction PR comment action from
  `mshick/add-pr-comment@v2` to `@v3`.
- Make both conflict-comment maintenance steps non-fatal with
  `continue-on-error: true`.
- Keep the actual conflict detector/final failure step authoritative, so real
  predicted conflicts still fail CI.

## Context

`dashpay/dash#7321` is approved and mergeable, but the `predict_conflicts`
workflow is red because comment maintenance failed with
`Resource not accessible by integration`. This backport keeps comment posting or
removal from failing the workflow when the detector itself succeeded.

## Validation

- `git diff --check upstream/v23.1.x...HEAD`
- Parsed `.github/workflows/predict-conflicts.yml` as YAML.
- Pre-PR code review:
  `code-review dashpay/dash upstream/v23.1.x ci/v23-predict-conflicts-permissions`
  → Recommendation: ship.
