### PR TITLE
refactor: remove GetBlockHash helper, use CChain::operator[] directly

### DIFF
--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -490,13 +490,13 @@ uint256 CQuorumBlockProcessor::GetQuorumBlockHash(const Consensus::LLMQParams& l
 
     int quorumStartHeight = nHeight - (nHeight % llmqParams.dkgInterval) + quorumIndex;
 
-    uint256 quorumBlockHash;
-    if (!GetBlockHash(active_chain, quorumBlockHash, quorumStartHeight)) {
+    const CBlockIndex* pindex = active_chain[quorumStartHeight];
+    if (pindex == nullptr) {
         LogPrint(BCLog::LLMQ, "[GetQuorumBlockHash] llmqType[%d] h[%d] qi[%d] quorumStartHeight[%d] quorumHash[EMPTY]\n", std23::to_underlying(llmqParams.type), nHeight, quorumIndex, quorumStartHeight);
         return {};
     }
 
-    return quorumBlockHash;
+    return pindex->GetBlockHash();
 }
 
 bool CQuorumBlockProcessor::HasMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash) const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2187,18 +2187,6 @@ void StopScriptCheckWorkerThreads()
     scriptcheckqueue.StopWorkerThreads();
 }
 
-bool GetBlockHash(const CChain& active_chain, uint256& hashRet, int nBlockHeight)
-{
-    LOCK(cs_main);
-
-    if (active_chain.Tip() == nullptr) return false;
-    if (nBlockHeight < -1 || nBlockHeight > active_chain.Height()) return false;
-    if (nBlockHeight == -1) nBlockHeight = active_chain.Height();
-    hashRet = active_chain[nBlockHeight]->GetBlockHash();
-
-    return true;
-}
-
 /**
  * Threshold condition checker that triggers when unknown versionbits are seen on the network.
  */

--- a/src/validation.h
+++ b/src/validation.h
@@ -1103,12 +1103,6 @@ bool DeploymentEnabled(const ChainstateManager& chainman, DEP dep)
     return DeploymentEnabled(chainman.GetConsensus(), dep);
 }
 
-/**
- * Return true if hash can be found in active_chain at nBlockHeight height.
- * Fills hashRet with found hash, if no nBlockHeight is specified - active_chain.Height() is used.
- */
-bool GetBlockHash(const CChain& active_chain, uint256& hashRet, int nBlockHeight = -1);
-
 using FopenFn = std::function<FILE*(const fs::path&, const char*)>;
 
 /** Dump the mempool to disk. */


### PR DESCRIPTION
## Issue being fixed or feature implemented
Single-use helper that calls `CChain::operator[]` with extra checks but it has unexpected behaviour for value -1 [it returns tip] but caller never has it.
Better to remove it to prevent misusages in the future, also to clean up global namespace.

## What was done?
Removed GetBlockHash from global namespace and its only usage replaced to operator[] call.

## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

