### PR TITLE
fix: follow-up for #7275: re-do Merge bitcoin/bitcoin#26076: Switch hardened derivation marker to h

### DIFF
--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -424,6 +424,7 @@ public:
     {
         if (m_derive == DeriveType::HARDENED) {
             out = ToString(/*normalized=*/true);
+
             return true;
         }
         // Step backwards to find the last hardened step in the path

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2023,7 +2023,7 @@ std::optional<MigrationData> LegacyScriptPubKeyMan::MigrateToDescriptor()
         const std::string xpub_str = EncodeExtPubKey(master_key.Neuter());
         for (int i = 0; i < 2; ++i) {
             const uint32_t chain_counter = (i == 1) ? acc.nInternalChainCounter : acc.nExternalChainCounter;
-            const std::string desc_str = strprintf("combo(%s/%d'/%d'/0'/%d/*)",
+            const std::string desc_str = strprintf("combo(%s/%dh/%dh/0h/%d/*)",
                 xpub_str, BIP32_PURPOSE_STANDARD, Params().ExtCoinType(), i);
             FlatSigningProvider keys;
             std::string error;

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -59,7 +59,6 @@ class WalletDescriptorTest(BitcoinTestFramework):
         addr_info = self.nodes[0].getaddressinfo(addr)
         assert addr_info['desc'].startswith('pkh(')
         assert_equal(addr_info['hdkeypath'], 'm/44h/1h/0h/1/0')
-
         # Make a wallet to receive coins at
         self.nodes[0].createwallet(wallet_name="desc2", descriptors=True)
         recv_wrpc = self.nodes[0].get_wallet_rpc("desc2")

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -48,7 +48,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         assert_equal(addr_info["address"], addr_info_old["address"])
         assert_equal(addr_info["scriptPubKey"], addr_info_old["scriptPubKey"])
         assert_equal(addr_info["ismine"], addr_info_old["ismine"])
-        assert_equal(addr_info["hdkeypath"], addr_info_old["hdkeypath"])
+        assert_equal(addr_info["hdkeypath"], addr_info_old["hdkeypath"].replace("'","h"))
         assert_equal(addr_info["solvable"], addr_info_old["solvable"])
         assert_equal(addr_info["ischange"], addr_info_old["ischange"])
         assert_equal(addr_info["hdmasterfingerprint"], addr_info_old["hdmasterfingerprint"])
@@ -90,8 +90,8 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.assert_is_sqlite("basic0")
 
         # The wallet should create the following descriptors:
-        # * BIP44 descriptors in the form of "44'/1'/0'/0/*" and "44'/1'/0'/1/*" (2 descriptors)
-        # * Inactive DIP0009 CoinJoin: pkh(xpub/9'/1'/4'/0'/0/*) (1 descriptor)
+        # * BIP44 descriptors in the form of "44h/1h/0h/0/*" and "44h/1h/0h/1/*" (2 descriptors)
+        # * Inactive DIP0009 CoinJoin: pkh(xpub/9h/1h/4h/0h/0/*) (1 descriptor)
         # * Inactive Migration descriptors for the legacy HD keys (2 combo descriptors)
         # Dash uses the same BIP44 paths for both legacy and descriptor wallets, but
         # combo descriptor can not be active
@@ -113,10 +113,10 @@ class WalletMigrationTest(BitcoinTestFramework):
         new_change = basic0.getrawchangeaddress()
         assert not new_addr == addr
         assert not new_change == change
-        assert_equal(addr_info["hdkeypath"], "m/44'/1'/0'/0/0")
-        assert_equal(change_addr_info["hdkeypath"], "m/44'/1'/0'/1/0")
-        assert_equal(basic0.getaddressinfo(new_addr)["hdkeypath"], "m/44'/1'/0'/0/2")
-        assert_equal(basic0.getaddressinfo(new_change)["hdkeypath"], "m/44'/1'/0'/1/2")
+        assert_equal(addr_info["hdkeypath"], "m/44h/1h/0h/0/0")
+        assert_equal(change_addr_info["hdkeypath"], "m/44h/1h/0h/1/0")
+        assert_equal(basic0.getaddressinfo(new_addr)["hdkeypath"], "m/44h/1h/0h/0/2")
+        assert_equal(basic0.getaddressinfo(new_change)["hdkeypath"], "m/44h/1h/0h/1/2")
 
         self.log.info("Test migration of a basic keys only wallet with a balance")
         basic1 = self.create_legacy_wallet("basic1")

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -129,14 +129,14 @@ class WalletSignerTest(BitcoinTestFramework):
         assert mock_wallet.getwalletinfo()['private_keys_enabled']
 
         result = mock_wallet.importdescriptors([{
-            "desc": "pkh([00000001/84'/1'/0']tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/0/*)#6k3x80k9",
+            "desc": "pkh([00000001/84h/1h/0']tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/0/*)#ta5h29a8",
             "timestamp": 0,
             "range": [0,1],
             "internal": False,
             "active": True
         },
         {
-            "desc": "pkh([00000001/84'/1'/0']tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/*)#tz5866xa",
+            "desc": "pkh([00000001/84h/1h/0']tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/1/*)#6f3khsdl",
             "timestamp": 0,
             "range": [0, 0],
             "internal": True,
@@ -158,7 +158,7 @@ class WalletSignerTest(BitcoinTestFramework):
         # hww4 = self.nodes[1].get_wallet_rpc("hww4")
         #
         # descriptors = [{
-        #     "desc": "wpkh([00000001/84'/1'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/*)#x30uthjs",
+        #     "desc": "wpkh([00000001/84h/1h/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/0/*)#x30uthjs",
         #     "timestamp": "now",
         #     "range": [0, 1],
         #     "internal": False,
@@ -166,7 +166,7 @@ class WalletSignerTest(BitcoinTestFramework):
         #     "active": True
         # },
         # {
-        #     "desc": "wpkh([00000001/84'/1'/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/*)#h92akzzg",
+        #     "desc": "wpkh([00000001/84h/1h/0']tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B/1/*)#h92akzzg",
         #     "timestamp": "now",
         #     "range": [0, 0],
         #     "internal": True,


### PR DESCRIPTION
## Issue being fixed or feature implemented
PRs #7275 had a logical conflict with earlier merged https://github.com/dashpay/dash/pull/7237/

PR #7275 introduces migratewallet RPC and relevant changes from bitcoin#26076 has never been backported because this code didn't exist.

## What was done?
Added couple missing changes from #26076 to fix RPC migratewallet, functional test wallet_migrate.py and couple other tiny other nits.


## How Has This Been Tested?
Run wallet_migrate.py

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone