### PR TITLE
fix: repair dash-chainstate dist sources

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1165,7 +1165,8 @@ dash_util_LDADD += $(BOOST_LIBS)
 # dash-chainstate binary #
 dash_chainstate_SOURCES = \
   bitcoin-chainstate.cpp \
-  addressindex.cpp \
+  index/addressindex.cpp \
+  index/addressindex_util.cpp \
   arith_uint256.cpp \
   base58.cpp \
   batchedlogger.cpp \
@@ -1206,12 +1207,9 @@ dash_chainstate_SOURCES = \
   evo/specialtxman.cpp \
   flatfile.cpp \
   fs.cpp \
-  governance/classes.cpp \
   governance/common.cpp \
-  governance/exceptions.cpp \
-  governance/governance.cpp \
   governance/object.cpp \
-  governance/validators.cpp \
+  governance/superblock.cpp \
   governance/vote.cpp \
   governance/votedb.cpp \
   gsl/assert.cpp \
@@ -1219,6 +1217,7 @@ dash_chainstate_SOURCES = \
   index/base.cpp \
   index/blockfilterindex.cpp \
   index/coinstatsindex.cpp \
+  index/spentindex.cpp \
   index/txindex.cpp \
   instantsend/db.cpp \
   instantsend/instantsend.cpp \

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -18,7 +18,6 @@
 #include <evo/chainhelper.h>
 #include <evo/deterministicmns.h>
 #include <evo/evodb.h>
-#include <governance/governance.h>
 #include <init/common.h>
 #include <llmq/context.h>
 #include <masternode/meta.h>
@@ -119,9 +118,6 @@ int main(int argc, char* argv[])
     std::unique_ptr<CEvoDB> evodb;
     std::unique_ptr<CDeterministicMNManager> dmnman;
     CMasternodeSync mn_sync{std::make_unique<NullNodeSyncNotifier>()};
-    // govman captures dmnman by const-ref; the unique_ptr is empty here and
-    // filled later inside DashChainstateSetup (called by LoadChainstate).
-    CGovernanceManager govman(metaman, chainman, dmnman, mn_sync);
     CSporkManager sporkman;
     chainlock::Chainlocks chainlocks(sporkman);
 
@@ -129,10 +125,10 @@ int main(int argc, char* argv[])
     std::unique_ptr<CChainstateHelper> chain_helper;
     auto rv = node::LoadChainstate(/*fReset=*/false,
                                    std::ref(chainman),
-                                   govman,
                                    metaman,
                                    sporkman,
                                    chainlocks,
+                                   mn_sync,
                                    chain_helper,
                                    dmnman,
                                    evodb,
@@ -140,9 +136,6 @@ int main(int argc, char* argv[])
                                    /*mempool=*/nullptr,
                                    gArgs.GetDataDirNet(),
                                    /*fPruneMode=*/false,
-                                   /*is_addrindex_enabled=*/false,
-                                   /*is_spentindex_enabled=*/false,
-                                   /*is_timeindex_enabled=*/false,
                                    chainparams.GetConsensus(),
                                    /*fReindexChainState=*/false,
                                    2 << 20,


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `make distdir` and `dash-chainstate` packaging/build paths referenced stale source paths after recent address index and governance refactors. This caused CI packaging/build jobs using `--enable-experimental-util-chainstate` to fail.

## What was done?

- Updated `dash_chainstate_SOURCES` to use `index/addressindex.cpp` and include its standalone helper/source dependencies.
- Replaced removed governance source entries with the current governance source files used by the tree.
- Updated `bitcoin-chainstate.cpp` to match the current `LoadChainstate` setup flow after the governance/superblock manager refactor.

## How Has This Been Tested?

- `./configure --enable-experimental-util-chainstate`
- `make -C src -j4 dash-chainstate`
- `git diff --check`
- `rm -rf dashcore-distcheck-test && mkdir dashcore-distcheck-test && (cd src && make top_distdir=../dashcore-distcheck-test distdir=../dashcore-distcheck-test/src am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)`

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
