### PR TITLE
fix(rpc): report inactive DIP3 for ProTx RPCs

### DIFF
--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -110,7 +110,7 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, llmq::CQuorumSn
         return true;
 
     if (!DeploymentActiveAfter(pindexPrev, chainman.GetConsensus(), Consensus::DEPLOYMENT_DIP0003)) {
-        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-tx-type (DIP0003 is not active)");
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-tx-type-dip3-inactive");
     }
 
     try {

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -110,7 +110,7 @@ static bool CheckSpecialTxInner(CDeterministicMNManager& dmnman, llmq::CQuorumSn
         return true;
 
     if (!DeploymentActiveAfter(pindexPrev, chainman.GetConsensus(), Consensus::DEPLOYMENT_DIP0003)) {
-        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-tx-type");
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-tx-type (DIP0003 is not active)");
     }
 
     try {

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -354,8 +354,25 @@ static std::string SignAndSendSpecialTx(const JSONRPCRequest& request, CChainsta
     {
     LOCK(::cs_main);
 
+    const CBlockIndex* tip{chainman.ActiveChain().Tip()};
+    const Consensus::Params& consensus_params{chainman.GetConsensus()};
+    if (!DeploymentActiveAfter(tip, consensus_params, Consensus::DEPLOYMENT_DIP0003)) {
+        const int current_height{tip ? tip->nHeight : -1};
+        const int next_block_height{current_height + 1};
+        const int activation_height{consensus_params.DIP0003Height};
+        const int blocks_to_mine{
+            activation_height > next_block_height ? activation_height - next_block_height : 0
+        };
+        throw JSONRPCError(RPC_VERIFY_ERROR, strprintf(
+            "DIP0003 is not active yet; ProTx transactions are valid starting at block height %d "
+            "(current chain height %d, next block height %d). Mine %d more block%s or restart "
+            "this regtest/devnet chain with DIP3 activation parameters that are already active.",
+            activation_height, current_height, next_block_height, blocks_to_mine,
+            blocks_to_mine == 1 ? "" : "s"));
+    }
+
     TxValidationState state;
-    if (!chain_helper.special_tx->CheckSpecialTx(CTransaction(tx), chainman.ActiveChain().Tip(), chainman.ActiveChainstate().CoinsTip(), true, state)) {
+    if (!chain_helper.special_tx->CheckSpecialTx(CTransaction(tx), tip, chainman.ActiveChainstate().CoinsTip(), true, state)) {
         throw std::runtime_error(state.ToString());
     }
     } // cs_main

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -62,12 +62,43 @@ class DIP3Test(BitcoinTestFramework):
         self.log.info("testing rejection of ProTx before dip3 activation")
         assert self.nodes[0].getblockchaininfo()['blocks'] < 135
 
+        def dip3_inactive_error():
+            current_height = self.nodes[0].getblockcount()
+            next_block_height = current_height + 1
+            blocks_to_mine = 135 - next_block_height
+            return (
+                f"DIP0003 is not active yet; ProTx transactions are valid starting at block height 135 "
+                f"(current chain height {current_height}, next block height {next_block_height}). "
+                f"Mine {blocks_to_mine} more block{'s' if blocks_to_mine != 1 else ''} or restart "
+                "this regtest/devnet chain with DIP3 activation parameters that are already active."
+            )
+
+        before_activation_mn: MasternodeInfo = self.prepare_mn(
+            self.nodes[0], self.num_initial_mn + 2, 'mn-before-dip3-activation'
+        )
+        self.nodes[0].sendtoaddress(
+            before_activation_mn.fundsAddr, before_activation_mn.get_collateral_value() + 0.001
+        )
+        before_activation_mn.register_fund(
+            self.nodes[0],
+            submit=True,
+            expected_assert_code=-25,
+            expected_assert_msg=dip3_inactive_error(),
+        )
+
         mns: List[MasternodeInfo] = []
 
         # prepare mn which should still be accepted later when dip3 activates
         self.log.info("creating collateral for mn-before-dip3")
         before_dip3_mn: MasternodeInfo = self.prepare_mn(self.nodes[0], 1, 'mn-before-dip3')
         self.create_mn_collateral(self.nodes[0], before_dip3_mn)
+        self.nodes[0].sendtoaddress(before_dip3_mn.fundsAddr, 0.001)
+        before_dip3_mn.register(
+            self.nodes[0],
+            submit=True,
+            expected_assert_code=-25,
+            expected_assert_msg=dip3_inactive_error(),
+        )
         mns.append(before_dip3_mn)
 
         # block 150 starts enforcing DIP3 MN payments


### PR DESCRIPTION
## Issue being fixed or feature implemented

ProTx RPCs can return a generic `bad-tx-type` error with RPC code `-1` when
used before DIP0003 is active on regtest/devnet. The underlying problem is that
special transaction validation rejects extra payload transactions before DIP3,
but the RPC response does not explain that activation height is the blocker.

This improves the Dash Core developer experience by returning an explicit
inactive-DIP3 RPC verification error with activation height context.

## What was done?

- Added an early DIP0003 activation check in the shared ProTx submission helper
  before special transaction validation.
- Return `RPC_VERIFY_ERROR` with the DIP3 activation height, current chain
  height, next block height, and a regtest/devnet hint.
- Added functional test coverage for both funded and external-collateral ProTx
  registration paths before DIP3 activation.

## How Has This Been Tested?

Tested locally on macOS arm64 with the existing depends prefix and autotools
build.

- `make -j8 src/dashd src/dash-cli`
- `test/functional/feature_dip3_deterministicmns.py --cachedir=/Users/claw/Projects/dash/worktrees/protx-dip3-error/test/cache`
- Pre-PR review gate: `ship`

## Breaking Changes

None. This only changes the RPC error returned before DIP0003 activation for
ProTx submission paths.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
