### PR TITLE
fix: guard deprecated service netInfo access

### DIFF
--- a/src/evo/core_write.cpp
+++ b/src/evo/core_write.cpp
@@ -73,6 +73,12 @@ const std::map<std::string, RPCResult> RPCRESULT_MAP{{
     RESULT_MAP_ENTRY("votingAddress", RPCResult::Type::STR, "Dash address used for voting"),
 }};
 #undef RESULT_MAP_ENTRY
+
+template <typename Obj>
+std::string GetDeprecatedServiceField(const Obj& obj)
+{
+    return CHECK_NONFATAL(obj.netInfo)->GetPrimary().ToStringAddrPort();
+}
 } // anonymous namespace
 
 RPCResult GetRpcResult(const std::string& key, bool optional, const std::string& override_name)
@@ -222,7 +228,7 @@ UniValue CDeterministicMNState::ToJson(MnType nType) const
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("version", nVersion);
     if (IsServiceDeprecatedRPCEnabled()) {
-        obj.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
+        obj.pushKV("service", GetDeprecatedServiceField(*this));
     }
     obj.pushKV("addresses", GetNetInfoWithLegacyFields(*this, nType));
     obj.pushKV("registeredHeight", nRegisteredHeight);
@@ -309,7 +315,7 @@ UniValue CProRegTx::ToJson() const
     ret.pushKV("collateralHash", collateralOutpoint.hash.ToString());
     ret.pushKV("collateralIndex", collateralOutpoint.n);
     if (IsServiceDeprecatedRPCEnabled()) {
-        ret.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
+        ret.pushKV("service", GetDeprecatedServiceField(*this));
     }
     ret.pushKV("addresses", GetNetInfoWithLegacyFields(*this, nType));
     ret.pushKV("ownerAddress", EncodeDestination(PKHash(keyIDOwner)));
@@ -402,7 +408,7 @@ UniValue CProUpServTx::ToJson() const
     ret.pushKV("type", std23::to_underlying(nType));
     ret.pushKV("proTxHash", proTxHash.ToString());
     if (IsServiceDeprecatedRPCEnabled()) {
-        ret.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
+        ret.pushKV("service", GetDeprecatedServiceField(*this));
     }
     ret.pushKV("addresses", GetNetInfoWithLegacyFields(*this, nType));
     if (CTxDestination dest; ExtractDestination(scriptOperatorPayout, dest)) {
@@ -540,7 +546,7 @@ UniValue CSimplifiedMNListEntry::ToJson(bool extended) const
     obj.pushKV("proRegTxHash", proRegTxHash.ToString());
     obj.pushKV("confirmedHash", confirmedHash.ToString());
     if (IsServiceDeprecatedRPCEnabled()) {
-        obj.pushKV("service", netInfo->GetPrimary().ToStringAddrPort());
+        obj.pushKV("service", GetDeprecatedServiceField(*this));
     }
     obj.pushKV("addresses", GetNetInfoWithLegacyFields(*this, nType));
     obj.pushKV("pubKeyOperator", pubKeyOperator.ToString());

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -8,9 +8,9 @@ from test_framework.util import assert_raises_rpc_error, assert_equal
 
 class DeprecatedRpcTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 2
+        self.num_nodes = 3
         self.setup_clean_chain = True
-        self.extra_args = [[], ["-deprecatedrpc=permissive_bool"]]
+        self.extra_args = [[], ["-deprecatedrpc=permissive_bool"], ["-deprecatedrpc=service"]]
 
     def run_test(self):
         # This test should be used to verify correct behaviour of deprecated
@@ -25,6 +25,7 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         # self.generate(self.nodes[1], 1)
         # self.log.info("No tested deprecated RPC methods")
         self.test_permissive_bool()
+        self.test_malformed_deprecated_service_rawtransactions()
 
     def test_permissive_bool(self):
         self.log.info("Test -deprecatedrpc=permissive_bool")
@@ -57,6 +58,17 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         self.log.info("Node 1 (permissive): invalid values still rejected")
         assert_raises_rpc_error(-8, "detailed must be true, false, yes, no, 1 or 0 (not '2')", self.nodes[1].protx, "list", "valid", 2)
         assert_raises_rpc_error(-8, "detailed must be true, false, yes, no, 1 or 0 (not 'notabool')", self.nodes[1].protx, "list", "valid", "notabool")
+
+    def test_malformed_deprecated_service_rawtransactions(self):
+        self.log.info("Test malformed provider payloads do not crash -deprecatedrpc=service")
+        node = self.nodes[2]
+        block_count = node.getblockcount()
+        for tx_hex in [
+            "03000100000000000000020000",  # ProRegTx with only nVersion=0 payload
+            "03000200000000000000020000",  # ProUpServTx with only nVersion=0 payload
+        ]:
+            assert_raises_rpc_error(-1, "Internal bug detected: obj.netInfo", node.decoderawtransaction, tx_hex)
+            assert_equal(node.getblockcount(), block_count)
 
 if __name__ == '__main__':
     DeprecatedRpcTest().main()


### PR DESCRIPTION
# Fix deprecated service netInfo access

## Issue being fixed or feature implemented

Malformed provider-register and provider-service-update payloads can be
decoded by raw transaction RPCs before special transaction validation has run.
When
`-deprecatedrpc=service` is enabled, the deprecated `service` JSON field
dereferenced `netInfo` directly, which could terminate the process if the
decoded provider payload left `netInfo` unset.

## What was done?

- Routed deprecated `service` JSON rendering through a small helper that applies
  `CHECK_NONFATAL` before reading `netInfo`.
- Applied the helper to masternode state, provider-register payloads,
  provider-service-update payloads, and simplified masternode list entries.
- Added functional coverage for malformed ProRegTx and ProUpServTx raw
  transaction decoding under `-deprecatedrpc=service`.

## How Has This Been Tested?

Tested on macOS 15.6 arm64 with depends-based local build:

- `git diff --check`
- `python3 -m py_compile test/functional/rpc_deprecated.py`
- `make -j8 src/dashd`
- `test/functional/rpc_deprecated.py --cachedir=/Users/claw/.openclaw/workspace/cache/dash-functional`

The focused functional test verifies both malformed provider payload types
return a nonfatal RPC error and the node remains responsive.

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
  _(for repository code-owners and collaborators only)_
