### PR TITLE
fix: handle zero secure allocator pool count

### DIFF
--- a/src/support/allocators/mt_pooled_secure.h
+++ b/src/support/allocators/mt_pooled_secure.h
@@ -25,12 +25,15 @@ struct mt_pooled_secure_allocator : public std::allocator<T> {
     using value_type = typename traits::value_type;
     mt_pooled_secure_allocator(size_type nrequested_size = 32,
                                size_type nnext_size = 32,
-                               size_type nmax_size = 0) noexcept
+                               size_type nmax_size = 0,
+                               size_type pools_count = std::thread::hardware_concurrency()) noexcept
     {
         // we add enough bytes to the requested size so that we can store the bucket as well
         nrequested_size += sizeof(size_t);
 
-        size_t pools_count = std::thread::hardware_concurrency();
+        if (pools_count == 0) {
+            pools_count = 1;
+        }
         pools.resize(pools_count);
         for (size_t i = 0; i < pools_count; i++) {
             pools[i] = std::make_unique<internal_pool>(nrequested_size, nnext_size, nmax_size);

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <support/allocators/mt_pooled_secure.h>
 #include <support/lockedpool.h>
 
 #include <limits>
@@ -232,6 +233,20 @@ BOOST_AUTO_TEST_CASE(lockedpool_tests_live)
     BOOST_CHECK(pool.stats().total <= (initial.total + LockedPool::ARENA_SIZE));
     // Usage must be back to where it started
     BOOST_CHECK(pool.stats().used == initial.used);
+}
+
+BOOST_AUTO_TEST_CASE(mt_pooled_secure_allocator_zero_pool_count)
+{
+    mt_pooled_secure_allocator<unsigned char> allocator{/*nrequested_size=*/32,
+                                                        /*nnext_size=*/32,
+                                                        /*nmax_size=*/0,
+                                                        /*pools_count=*/0};
+
+    auto* p = allocator.allocate(1);
+    BOOST_REQUIRE(p != nullptr);
+    *p = 0x42;
+    BOOST_CHECK_EQUAL(*p, 0x42);
+    allocator.deallocate(p, 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# fix: handle zero secure allocator pool count

## Issue being fixed or feature implemented

`std::thread::hardware_concurrency()` is allowed to return `0`.
`mt_pooled_secure_allocator` used that value directly as the secure pool count,
which could leave the allocator with no pools and make the first allocation
compute a bucket modulo zero.

This keeps normal behavior unchanged while making the edge case safe.

## What was done?

- Added a fallback so a zero secure allocator pool count is treated as one pool.
- Added a focused allocator unit test that forces a zero pool count and verifies
  allocation/deallocation still work.

## How Has This Been Tested?

Tested on macOS arm64 with the depends config site build environment.

- `git diff --check`
- `make -C src -j8 test/test_dash`
- Focused unit test:
  `allocator_tests/mt_pooled_secure_allocator_zero_pool_count`
- Full allocator unit suite: `allocator_tests`
- Pre-PR code review gate: `ship`

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
  _(for repository code-owners and collaborators only)_
