### PR TITLE
fix: punish invalid dstx messages

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3539,20 +3539,31 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, CDataStream& 
     m_connman.PushMessage(&node, std::move(msg));
 }
 
-// Returned score is the misbehavior penalty to apply to the relaying peer; 0 means no penalty.
+// Misbehavior penalty to apply to the relaying peer; NONE means no penalty.
+enum class DSTXValidationScore : int {
+    NONE = 0,
+    UNKNOWN_MASTERNODE = 1,
+    INVALID = 10,
+};
+
 // do_return signals the caller to stop further processing of the DSTX.
-std::pair<int /*misbehavior_score*/, bool /*do_return*/> static ValidateDSTX(CDeterministicMNManager& dmnman, CDSTXManager& dstxman, ChainstateManager& chainman,
-                                                                             CMasternodeMetaMan& mn_metaman, CTxMemPool& mempool, CCoinJoinBroadcastTx& dstx, uint256 hashTx)
+struct DSTXValidationResult {
+    DSTXValidationScore score;
+    bool do_return;
+};
+
+static DSTXValidationResult ValidateDSTX(CDeterministicMNManager& dmnman, CDSTXManager& dstxman, ChainstateManager& chainman,
+                                         CMasternodeMetaMan& mn_metaman, CTxMemPool& mempool, CCoinJoinBroadcastTx& dstx, uint256 hashTx)
 {
     assert(mn_metaman.IsValid());
 
     if (!dstx.IsValidStructure()) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Invalid DSTX structure: %s\n", hashTx.ToString());
-        return {10, true};
+        return {DSTXValidationScore::INVALID, true};
     }
     if (dstxman.GetDSTX(hashTx)) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Already have %s, skipping...\n", hashTx.ToString());
-        return {0, true}; // not an error
+        return {DSTXValidationScore::NONE, true}; // not an error
     }
 
     const CBlockIndex* pindex{nullptr};
@@ -3588,26 +3599,26 @@ std::pair<int /*misbehavior_score*/, bool /*do_return*/> static ValidateDSTX(CDe
         // We can't verify the signature here, so apply only a small penalty.
         // The MN may have been removed very recently, but a peer flooding us with
         // unverifiable DSTX-es should still eventually be discouraged.
-        return {1, true};
+        return {DSTXValidationScore::UNKNOWN_MASTERNODE, true};
     }
 
     if (!mn_metaman.IsValidForMixingTxes(dmn->proTxHash)) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Masternode %s is sending too many transactions %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
-        return {0, true};
+        return {DSTXValidationScore::NONE, true};
         // TODO: Not an error? Could it be that someone is relaying old DSTXes
         // we have no idea about (e.g we were offline)? How to handle them?
     }
 
     if (!dstx.CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
         LogPrint(BCLog::COINJOIN, "DSTX -- CheckSignature() failed for %s\n", hashTx.ToString());
-        return {10, true};
+        return {DSTXValidationScore::INVALID, true};
     }
 
     LogPrint(BCLog::COINJOIN, "DSTX -- Got Masternode transaction %s\n", hashTx.ToString());
     mempool.PrioritiseTransaction(hashTx, 0.1*COIN);
     mn_metaman.DisallowMixing(dmn->proTxHash);
 
-    return {0, false};
+    return {DSTXValidationScore::NONE, false};
 }
 
 void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, bool force_processing)
@@ -4672,10 +4683,10 @@ void PeerManagerImpl::ProcessMessage(
         // Process custom logic, no matter if tx will be accepted to mempool later or not
         if (nInvType == MSG_DSTX) {
             uint256 hashTx = tx.GetHash();
-            const auto& [misbehavior_score, bDoReturn] = ValidateDSTX(*m_dmnman, m_dstxman, m_chainman, m_mn_metaman, m_mempool, dstx, hashTx);
-            if (bDoReturn) {
-                if (misbehavior_score > 0) {
-                    Misbehaving(pfrom.GetId(), misbehavior_score, "invalid dstx");
+            const auto result = ValidateDSTX(*m_dmnman, m_dstxman, m_chainman, m_mn_metaman, m_mempool, dstx, hashTx);
+            if (result.do_return) {
+                if (result.score != DSTXValidationScore::NONE) {
+                    Misbehaving(pfrom.GetId(), static_cast<int>(result.score), "invalid dstx");
                 }
                 return;
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4666,12 +4666,15 @@ void PeerManagerImpl::ProcessMessage(
 
         // Process custom logic, no matter if tx will be accepted to mempool later or not
         if (nInvType == MSG_DSTX) {
-           // Validate DSTX and return bRet if we need to return from here
-           uint256 hashTx = tx.GetHash();
-           const auto& [bRet, bDoReturn] = ValidateDSTX(*m_dmnman, m_dstxman, m_chainman, m_mn_metaman, m_mempool, dstx, hashTx);
-           if (bDoReturn) {
-               return;
-           }
+            // Validate DSTX and return bRet if we need to return from here
+            uint256 hashTx = tx.GetHash();
+            const auto& [bRet, bDoReturn] = ValidateDSTX(*m_dmnman, m_dstxman, m_chainman, m_mn_metaman, m_mempool, dstx, hashTx);
+            if (bDoReturn) {
+                if (!bRet) {
+                    Misbehaving(pfrom.GetId(), 10, "invalid dstx");
+                }
+                return;
+            }
         }
 
         LOCK(cs_main);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3539,18 +3539,20 @@ void PeerManagerImpl::ProcessGetCFCheckPt(CNode& node, Peer& peer, CDataStream& 
     m_connman.PushMessage(&node, std::move(msg));
 }
 
-std::pair<bool /*ret*/, bool /*do_return*/> static ValidateDSTX(CDeterministicMNManager& dmnman, CDSTXManager& dstxman, ChainstateManager& chainman,
-                                                                CMasternodeMetaMan& mn_metaman, CTxMemPool& mempool, CCoinJoinBroadcastTx& dstx, uint256 hashTx)
+// Returned score is the misbehavior penalty to apply to the relaying peer; 0 means no penalty.
+// do_return signals the caller to stop further processing of the DSTX.
+std::pair<int /*misbehavior_score*/, bool /*do_return*/> static ValidateDSTX(CDeterministicMNManager& dmnman, CDSTXManager& dstxman, ChainstateManager& chainman,
+                                                                             CMasternodeMetaMan& mn_metaman, CTxMemPool& mempool, CCoinJoinBroadcastTx& dstx, uint256 hashTx)
 {
     assert(mn_metaman.IsValid());
 
     if (!dstx.IsValidStructure()) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Invalid DSTX structure: %s\n", hashTx.ToString());
-        return {false, true};
+        return {10, true};
     }
     if (dstxman.GetDSTX(hashTx)) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Already have %s, skipping...\n", hashTx.ToString());
-        return {true, true}; // not an error
+        return {0, true}; // not an error
     }
 
     const CBlockIndex* pindex{nullptr};
@@ -3583,26 +3585,29 @@ std::pair<bool /*ret*/, bool /*do_return*/> static ValidateDSTX(CDeterministicMN
 
     if (!dmn) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Can't find masternode %s to verify %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
-        return {true, true};
+        // We can't verify the signature here, so apply only a small penalty.
+        // The MN may have been removed very recently, but a peer flooding us with
+        // unverifiable DSTX-es should still eventually be discouraged.
+        return {1, true};
     }
 
     if (!mn_metaman.IsValidForMixingTxes(dmn->proTxHash)) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Masternode %s is sending too many transactions %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
-        return {true, true};
+        return {0, true};
         // TODO: Not an error? Could it be that someone is relaying old DSTXes
         // we have no idea about (e.g we were offline)? How to handle them?
     }
 
     if (!dstx.CheckSignature(dmn->pdmnState->pubKeyOperator.Get())) {
         LogPrint(BCLog::COINJOIN, "DSTX -- CheckSignature() failed for %s\n", hashTx.ToString());
-        return {false, true};
+        return {10, true};
     }
 
     LogPrint(BCLog::COINJOIN, "DSTX -- Got Masternode transaction %s\n", hashTx.ToString());
     mempool.PrioritiseTransaction(hashTx, 0.1*COIN);
     mn_metaman.DisallowMixing(dmn->proTxHash);
 
-    return {true, false};
+    return {0, false};
 }
 
 void PeerManagerImpl::ProcessBlock(CNode& node, const std::shared_ptr<const CBlock>& block, bool force_processing)
@@ -4666,12 +4671,11 @@ void PeerManagerImpl::ProcessMessage(
 
         // Process custom logic, no matter if tx will be accepted to mempool later or not
         if (nInvType == MSG_DSTX) {
-            // Validate DSTX and return bRet if we need to return from here
             uint256 hashTx = tx.GetHash();
-            const auto& [bRet, bDoReturn] = ValidateDSTX(*m_dmnman, m_dstxman, m_chainman, m_mn_metaman, m_mempool, dstx, hashTx);
+            const auto& [misbehavior_score, bDoReturn] = ValidateDSTX(*m_dmnman, m_dstxman, m_chainman, m_mn_metaman, m_mempool, dstx, hashTx);
             if (bDoReturn) {
-                if (!bRet) {
-                    Misbehaving(pfrom.GetId(), 10, "invalid dstx");
+                if (misbehavior_score > 0) {
+                    Misbehaving(pfrom.GetId(), misbehavior_score, "invalid dstx");
                 }
                 return;
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3583,7 +3583,7 @@ std::pair<bool /*ret*/, bool /*do_return*/> static ValidateDSTX(CDeterministicMN
 
     if (!dmn) {
         LogPrint(BCLog::COINJOIN, "DSTX -- Can't find masternode %s to verify %s\n", dstx.masternodeOutpoint.ToStringShort(), hashTx.ToString());
-        return {false, true};
+        return {true, true};
     }
 
     if (!mn_metaman.IsValidForMixingTxes(dmn->proTxHash)) {

--- a/test/functional/p2p_dstx.py
+++ b/test/functional/p2p_dstx.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test P2P CoinJoin broadcast transaction handling."""
+
+import time
+
+from test_framework.messages import (
+    CCoinJoinBroadcastTx,
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    msg_dstx,
+)
+from test_framework.p2p import P2PInterface
+from test_framework.script import (
+    CScript,
+    OP_CHECKSIG,
+    OP_DUP,
+    OP_EQUALVERIFY,
+    OP_HASH160,
+)
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class P2PDSTXTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [["-debug=net"]]
+
+    def make_dstx(self):
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(hash=i + 1, n=0)) for i in range(3)]
+        p2pkh = CScript([
+            OP_DUP,
+            OP_HASH160,
+            b"\x01" * 20,
+            OP_EQUALVERIFY,
+            OP_CHECKSIG,
+        ])
+        tx.vout = [CTxOut(nValue=COIN // 1000 + 1, scriptPubKey=p2pkh) for _ in tx.vin]
+        return CCoinJoinBroadcastTx(
+            tx=tx,
+            m_protxHash=1,
+            vchSig=b"\x01" * 96,
+            sigTime=int(time.time()),
+        )
+
+    def run_test(self):
+        self.log.info("Leave IBD so unsolicited DSTX is processed")
+        self.generate(self.nodes[0], 1)
+
+        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+
+        self.log.info("Unknown masternode DSTX is treated as peer misbehavior")
+        with self.nodes[0].assert_debug_log(["Misbehaving", "invalid dstx"]):
+            peer.send_and_ping(msg_dstx(self.make_dstx()))
+
+
+if __name__ == '__main__':
+    P2PDSTXTest().main()

--- a/test/functional/p2p_dstx.py
+++ b/test/functional/p2p_dstx.py
@@ -2,7 +2,13 @@
 # Copyright (c) 2026 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test P2P CoinJoin broadcast transaction handling."""
+"""Test P2P CoinJoin broadcast transaction handling.
+
+Verifies that DSTX messages with an unverifiable (unknown) masternode incur
+only a small misbehavior penalty, while clearly malformed DSTXes get the
+existing stronger penalty. Also exercises the cumulative behavior so that
+a peer flooding unknown-MN DSTXes is eventually discouraged.
+"""
 
 import time
 
@@ -25,16 +31,26 @@ from test_framework.script import (
 )
 from test_framework.test_framework import BitcoinTestFramework
 
+# Default DISCOURAGEMENT_THRESHOLD in net_processing.h.
+DISCOURAGEMENT_THRESHOLD = 100
+# Penalty applied when the relaying peer sends a DSTX whose masternode we
+# can't find in the deterministic MN list (and therefore can't verify).
+UNKNOWN_MN_SCORE = 1
+# Penalty applied when the DSTX itself is structurally bad / bad signature.
+INVALID_DSTX_SCORE = 10
+
 
 class P2PDSTXTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [["-debug=net"]]
+        self.extra_args = [["-debug=net", "-debug=coinjoin"]]
 
-    def make_dstx(self):
+    def make_dstx(self, nonce=0):
         tx = CTransaction()
-        tx.vin = [CTxIn(COutPoint(hash=i + 1, n=0)) for i in range(3)]
+        # The nonce flows into one of the prevouts so each DSTX has a distinct
+        # txid (and therefore is not deduped by dstxman.GetDSTX).
+        tx.vin = [CTxIn(COutPoint(hash=(nonce << 8) | (i + 1), n=0)) for i in range(3)]
         p2pkh = CScript([
             OP_DUP,
             OP_HASH160,
@@ -42,6 +58,8 @@ class P2PDSTXTest(BitcoinTestFramework):
             OP_EQUALVERIFY,
             OP_CHECKSIG,
         ])
+        # CoinJoin::IsDenominatedAmount requires a recognised denom; the
+        # smallest denom is 0.001 DASH + 0.0000001 fee == COIN//1000 + 1.
         tx.vout = [CTxOut(nValue=COIN // 1000 + 1, scriptPubKey=p2pkh) for _ in tx.vin]
         return CCoinJoinBroadcastTx(
             tx=tx,
@@ -51,20 +69,46 @@ class P2PDSTXTest(BitcoinTestFramework):
         )
 
     def run_test(self):
+        node = self.nodes[0]
         self.log.info("Leave IBD so unsolicited DSTX is processed")
-        self.generate(self.nodes[0], 1)
+        self.generate(node, 1)
 
-        peer = self.nodes[0].add_p2p_connection(P2PInterface())
+        self.log.info("Unknown-MN DSTX => small (+%d) misbehavior penalty", UNKNOWN_MN_SCORE)
+        peer = node.add_p2p_connection(P2PInterface())
+        # Match the substring of the Misbehaving log that identifies the score
+        # jump of a fresh peer (0 -> 1) along with our message tag.
+        with node.assert_debug_log([
+            "Can't find masternode",
+            "Misbehaving",
+            "(0 -> {})".format(UNKNOWN_MN_SCORE),
+            "invalid dstx",
+        ]):
+            peer.send_and_ping(msg_dstx(self.make_dstx(nonce=1)))
 
-        self.log.info("Unknown masternode DSTX is ignored without peer misbehavior")
-        with self.nodes[0].assert_debug_log([], unexpected_msgs=["Misbehaving", "invalid dstx"]):
-            peer.send_and_ping(msg_dstx(self.make_dstx()))
+        self.log.info("Structurally invalid DSTX => stronger (+%d) misbehavior penalty", INVALID_DSTX_SCORE)
+        peer_invalid = node.add_p2p_connection(P2PInterface())
+        bad = self.make_dstx(nonce=2)
+        bad.tx.vout.pop()  # vin.size() != vout.size() trips IsValidStructure
+        with node.assert_debug_log([
+            "Invalid DSTX structure",
+            "Misbehaving",
+            "(0 -> {})".format(INVALID_DSTX_SCORE),
+            "invalid dstx",
+        ]):
+            peer_invalid.send_and_ping(msg_dstx(bad))
 
-        self.log.info("Structurally invalid DSTX is treated as peer misbehavior")
-        invalid_dstx = self.make_dstx()
-        invalid_dstx.tx.vout.pop()
-        with self.nodes[0].assert_debug_log(["Misbehaving", "invalid dstx"]):
-            peer.send_and_ping(msg_dstx(invalid_dstx))
+        self.log.info("A peer flooding unknown-MN DSTXes is eventually discouraged")
+        peer_flood = node.add_p2p_connection(P2PInterface())
+        # +1 per unknown-MN DSTX, so DISCOURAGEMENT_THRESHOLD distinct DSTXes
+        # are enough to cross the threshold exactly once on this peer.
+        # send_message is fire-and-forget; the node disconnects once
+        # discouraged, so we wait on the threshold log line directly and then
+        # confirm the peer was dropped.
+        with node.assert_debug_log(["DISCOURAGE THRESHOLD EXCEEDED"], timeout=10):
+            for nonce in range(DISCOURAGEMENT_THRESHOLD):
+                # offset nonces to avoid txid clashes with earlier sends
+                peer_flood.send_message(msg_dstx(self.make_dstx(nonce=1000 + nonce)))
+        peer_flood.wait_for_disconnect()
 
 
 if __name__ == '__main__':

--- a/test/functional/p2p_dstx.py
+++ b/test/functional/p2p_dstx.py
@@ -56,9 +56,15 @@ class P2PDSTXTest(BitcoinTestFramework):
 
         peer = self.nodes[0].add_p2p_connection(P2PInterface())
 
-        self.log.info("Unknown masternode DSTX is treated as peer misbehavior")
-        with self.nodes[0].assert_debug_log(["Misbehaving", "invalid dstx"]):
+        self.log.info("Unknown masternode DSTX is ignored without peer misbehavior")
+        with self.nodes[0].assert_debug_log([], unexpected_msgs=["Misbehaving", "invalid dstx"]):
             peer.send_and_ping(msg_dstx(self.make_dstx()))
+
+        self.log.info("Structurally invalid DSTX is treated as peer misbehavior")
+        invalid_dstx = self.make_dstx()
+        invalid_dstx.tx.vout.pop()
+        with self.nodes[0].assert_debug_log(["Misbehaving", "invalid dstx"]):
+            peer.send_and_ping(msg_dstx(invalid_dstx))
 
 
 if __name__ == '__main__':

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1835,6 +1835,53 @@ class msg_tx:
         return "msg_tx(tx=%s)" % (repr(self.tx))
 
 
+class CCoinJoinBroadcastTx:
+    __slots__ = ("tx", "m_protxHash", "vchSig", "sigTime")
+
+    def __init__(self, tx=None, m_protxHash=0, vchSig=b"", sigTime=0):
+        self.tx = tx or CTransaction()
+        self.m_protxHash = m_protxHash
+        self.vchSig = vchSig
+        self.sigTime = sigTime
+
+    def deserialize(self, f):
+        self.tx = CTransaction()
+        self.tx.deserialize(f)
+        self.m_protxHash = deser_uint256(f)
+        self.vchSig = deser_string(f)
+        self.sigTime = struct.unpack("<q", f.read(8))[0]
+
+    def serialize(self):
+        r = b""
+        r += self.tx.serialize()
+        r += ser_uint256(self.m_protxHash)
+        r += ser_string(self.vchSig)
+        r += struct.pack("<q", self.sigTime)
+        return r
+
+    def __repr__(self):
+        return "CCoinJoinBroadcastTx(tx=%s m_protxHash=%064x)" \
+               % (repr(self.tx), self.m_protxHash)
+
+
+class msg_dstx:
+    __slots__ = ("dstx",)
+    msgtype = b"dstx"
+
+    def __init__(self, dstx=None):
+        self.dstx = dstx or CCoinJoinBroadcastTx()
+
+    def deserialize(self, f):
+        self.dstx = CCoinJoinBroadcastTx()
+        self.dstx.deserialize(f)
+
+    def serialize(self):
+        return self.dstx.serialize()
+
+    def __repr__(self):
+        return "msg_dstx(dstx=%s)" % (repr(self.dstx))
+
+
 class msg_block:
     __slots__ = ("block",)
     msgtype = b"block"

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -258,6 +258,7 @@ BASE_SCRIPTS = [
     'p2p_nobloomfilter_messages.py',
     'p2p_filter.py',
     'p2p_blocksonly.py',
+    'p2p_dstx.py',
     'rpc_setban.py --v1transport',
     'rpc_setban.py --v2transport',
     'mining_prioritisetransaction.py',


### PR DESCRIPTION
# fix: punish invalid dstx messages

## Issue being fixed or feature implemented

Invalid CoinJoin broadcast transaction (`dstx`) messages can return early from
validation without applying the same peer-accounting consequence used by other
invalid P2P messages.

This hardens DSTX handling by making invalid validation results contribute a low
misbehavior score while preserving benign early returns for duplicate or
otherwise non-error DSTX cases.

## What was done?

- Apply a low misbehavior score when DSTX validation returns an invalid/error
  result.
- Preserve existing behavior for successful validation and benign early-return
  cases.
- Add P2P test framework serialization for `dstx` messages.
- Add a focused functional test covering invalid DSTX peer accounting.

## How Has This Been Tested?

Tested on macOS arm64.

- `git diff --check`
- `python3 -m py_compile test/functional/p2p_dstx.py test/functional/test_framework/messages.py`
- Configured with depends `config.site`, `--without-gui`, `--disable-bench`,
  and `--disable-fuzz-binary`
- `make -j8 src/dashd`
- `test/functional/p2p_dstx.py --tmpdir=/tmp/dash_func_dstx`
- `test/functional/p2p_dstx.py --tmpdir=/tmp/dash_func_dstx_2`

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
