### PR TITLE
fix: empty platformP2PPort deprecated field in protx listdiff results

### DIFF
--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -86,11 +86,25 @@ UniValue CDeterministicMNStateDiff::ToJson(MnType nType) const
         if (fields & Field_platformNodeID) {
             obj.pushKV("platformNodeID", state.platformNodeID.ToString());
         }
-        if (fields & Field_platformP2PPort) {
-            obj.pushKV("platformP2PPort", state.platformP2PPort);
-        }
-        if (fields & Field_platformHTTPPort) {
-            obj.pushKV("platformHTTPPort", state.platformHTTPPort);
+        if (IsServiceDeprecatedRPCEnabled()) {
+            // platformP2PPort/platformHTTPPort are deprecated scalar duplicates of netInfo's
+            // Platform entries. From ExtAddr onwards the scalar fields are unused (always 0), so
+            // when the diff carries an ExtAddr netInfo report the live port from it to stay
+            // consistent with the "addresses" output below.
+            // TODO: remove this workaround for nodes that has been incorrectly migrated internal storage in the future
+            const bool has_ext_netinfo = (fields & Field_netInfo) && state.netInfo->CanStorePlatform();
+            if (fields & Field_platformP2PPort) {
+                obj.pushKV("platformP2PPort",
+                           has_ext_netinfo && state.netInfo->HasEntries(NetInfoPurpose::PLATFORM_P2P)
+                               ? state.netInfo->GetEntries(NetInfoPurpose::PLATFORM_P2P)[0].GetPort()
+                               : state.platformP2PPort);
+            }
+            if (fields & Field_platformHTTPPort) {
+                obj.pushKV("platformHTTPPort",
+                           has_ext_netinfo && state.netInfo->HasEntries(NetInfoPurpose::PLATFORM_HTTPS)
+                               ? state.netInfo->GetEntries(NetInfoPurpose::PLATFORM_HTTPS)[0].GetPort()
+                               : state.platformHTTPPort);
+            }
         }
     }
     {

--- a/src/evo/dmnstate.cpp
+++ b/src/evo/dmnstate.cpp
@@ -91,7 +91,6 @@ UniValue CDeterministicMNStateDiff::ToJson(MnType nType) const
             // Platform entries. From ExtAddr onwards the scalar fields are unused (always 0), so
             // when the diff carries an ExtAddr netInfo report the live port from it to stay
             // consistent with the "addresses" output below.
-            // TODO: remove this workaround for nodes that has been incorrectly migrated internal storage in the future
             const bool has_ext_netinfo = (fields & Field_netInfo) && state.netInfo->CanStorePlatform();
             if (fields & Field_platformP2PPort) {
                 obj.pushKV("platformP2PPort",

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -356,6 +356,14 @@ bool CSpecialTxProcessor::RebuildListFromBlock(const CBlock& block, gsl::not_nul
                 if (opt_proTx->nVersion < ProTxVersion::ExtAddr) {
                     newState->platformP2PPort = opt_proTx->platformP2PPort;
                     newState->platformHTTPPort = opt_proTx->platformHTTPPort;
+                } else {
+                    // From ExtAddr onwards the Platform ports are stored in netInfo. Clear the
+                    // legacy scalar fields (which a legacy registration may have left set) so the
+                    // in-memory state matches its serialized form, which omits them for ExtAddr
+                    // (see CDeterministicMNState serialization). Otherwise a stale value would
+                    // survive in diff-reconstructed lists but vanish through a snapshot round-trip.
+                    newState->platformP2PPort = 0;
+                    newState->platformHTTPPort = 0;
                 }
             }
             if (newState->IsBanned()) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

There're 2 different versions of protx's internal storages; and they are switched after v24 activation.

It seems as when version switched, the incorrect platformP2PPort / platformHTTPPort may be added to diff even if they are not used anymore and it happens only if snapshot is used; for example after node restart.

It causes strange result of `protxlistdiff A B` such as:

```
"MASTERNODE": {
    {
        "lastPaidHeight": 9204,
        "platformP2PPort": 0, <---- INVALID it should be correct port here
        "platformHTTPPort": 0, <----- INVALID it should be correct port here
        "addresses": {
          "platform_p2p": [
            <VALID>
          ],
          "platform_https": [
            <VALID>
          ]
```

It happened on devnet on block on 9216


## What was done?
Added reset of platformP2PPort and platformHTTPPort.
Added a workaround to show valid results for nodes that already have corrupted database.


## How Has This Been Tested?
Sync node with devnet palona ; restart node -> issue is reproduced.
Build a node from this PR, restart node -> issue is not reproduced.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone