### PR TITLE
backport: bitcoin/bitcoin#32693: depends: fix cmake compatibility error for freetype

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -4,12 +4,17 @@ $(package)_download_path=https://download.savannah.gnu.org/releases/$(package)
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
 $(package)_sha256_hash=8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7
 $(package)_build_subdir=build
+$(package)_patches += cmake_minimum.patch
 
 define $(package)_set_vars
   $(package)_config_opts := -DCMAKE_BUILD_TYPE=None -DBUILD_SHARED_LIBS=TRUE
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_PNG=TRUE
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_BZip2=TRUE
   $(package)_config_opts += -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec=TRUE
+endef
+
+define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/cmake_minimum.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/freetype/cmake_minimum.patch
+++ b/depends/patches/freetype/cmake_minimum.patch
@@ -1,0 +1,13 @@
+build: set minimum required CMake to 3.12
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -97,7 +97,7 @@
+ # FreeType explicitly marks the API to be exported and relies on the compiler
+ # to hide all other symbols. CMake supports a C_VISBILITY_PRESET property
+ # starting with 2.8.12.
+-cmake_minimum_required(VERSION 2.8.12)
++cmake_minimum_required(VERSION 3.12)
+
+ if (NOT CMAKE_VERSION VERSION_LESS 3.3)
+   # Allow symbol visibility settings also on static libraries. CMake < 3.3


### PR DESCRIPTION
## Issue being fixed or feature implemented
It fixes freetype dependency build on Kubuntu 26.04 which provide cmake-4 by default.

## What was done?
Backport bitcoin#32693

## How Has This Been Tested?
Build succeed

## Breaking Changes
N/A


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

