### PR TITLE
docs: clarify observed block time

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -166,6 +166,12 @@ struct Params {
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;
     bool fPowNoRetargeting;
+    /**
+     * Nominal consensus target spacing. Do not treat it as an exact
+     * user-facing wall-clock ETA: mainnet's observed spacing is about
+     * 2.626 min/block due to the historical DGW off-by-one documented by
+     * DarkGravityWave() in pow.cpp.
+     */
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
     int nPowKGWHeight;

--- a/src/masternode/sync.h
+++ b/src/masternode/sync.h
@@ -20,7 +20,7 @@ static constexpr int MASTERNODE_SYNC_GOVOBJ_VOTE     = 11;
 static constexpr int MASTERNODE_SYNC_FINISHED        = 999;
 
 static constexpr int MASTERNODE_SYNC_TICK_SECONDS    = 6;
-static constexpr int MASTERNODE_SYNC_TIMEOUT_SECONDS = 30; // our blocks are 2.5 minutes so 30 seconds should be fine
+static constexpr int MASTERNODE_SYNC_TIMEOUT_SECONDS = 30; // nominal target spacing is 2.5 minutes, so 30 seconds should be fine
 static constexpr int MASTERNODE_SYNC_RESET_SECONDS   = 900; // Reset fReachedBestHeader in CMasternodeSync::Reset if UpdateBlockTip hasn't been called for this seconds
 
 class NodeSyncNotifier

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -109,7 +109,10 @@ unsigned int static DarkGravityWave(const CBlockIndex* pindexLast, const Consens
     arith_uint256 bnNew(bnPastTargetAvg);
 
     int64_t nActualTimespan = pindexLast->GetBlockTime() - pindex->GetBlockTime();
-    // NOTE: is this accurate? nActualTimespan counts it for (nPastBlocks - 1) blocks only...
+    // nActualTimespan spans (nPastBlocks - 1) intervals, while nTargetTimespan
+    // uses nPastBlocks intervals. Preserve this historical off-by-one DGW
+    // behavior: it is consensus-critical and makes observed mainnet spacing
+    // about 2.626 minutes per block rather than the nominal 2.5 minute target.
     int64_t nTargetTimespan = nPastBlocks * params.nPowTargetSpacing;
 
     if (nActualTimespan < nTargetTimespan/3)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Clarifies that Dash Core's `nPowTargetSpacing` is the nominal consensus target
spacing, not an exact wall-clock estimate for user-facing ETAs. Mainnet's
observed spacing is about 2.626 min/block because DarkGravityWave preserves a
historical off-by-one interval count.

## What was done?

- Replaced the ambiguous DarkGravityWave timespan note with a short explanation
  of the preserved off-by-one behavior.
- Documented `nPowTargetSpacing` as a nominal consensus target, not an exact ETA
  value.
- Tightened a masternode sync comment so it refers to nominal target spacing
  instead of saying blocks are exactly 2.5 minutes.

No code behavior changes are included.

## How Has This Been Tested?

- `git diff --check upstream/develop..HEAD`
- Verified the diff is comments-only by stripping comments from base and head
  for all changed files and comparing the remaining code.
- `code-review dashpay/dash upstream/develop docs/clarify-observed-block-time
  "Pre-PR review: clarify that nPowTargetSpacing is nominal while observed
  mainnet block spacing is about 2.626 min/block due to DarkGravityWave
  historical off-by-one; comments only, no code changes"` → ship

Runtime tests were not run because this is a comments-only change.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
