### PR TITLE
docs: clarify ProTx platform address RPC help

### DIFF
--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -88,8 +88,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"coreP2PAddrs",
             {"coreP2PAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\". Must be unique on the network.\n"
-                "A legacy (MnNetInfo / version-2) ProTx accepts only a single entry; multiple entries\n"
-                "require an Extended addresses (ExtNetInfo) ProTx.\n"
+                "A legacy ProTx can only store a single entry; storing multiple entries\n"
+                "requires upgrading to a version 3 ProTx.\n"
                 "Can be set to an empty string, which will require a ProUpServTx afterwards.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
@@ -98,8 +98,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"coreP2PAddrs_update",
             {"coreP2PAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\". Must be unique on the network.\n"
-                "A legacy (MnNetInfo / version-2) ProTx accepts only a single entry; multiple entries\n"
-                "require an Extended addresses (ExtNetInfo) ProTx.",
+                "A legacy ProTx can only store a single entry; storing multiple entries\n"
+                "requires upgrading to a version 3 ProTx.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
                 }}
@@ -188,8 +188,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"platformP2PAddrs",
             {"platformP2PAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\" used by Platform for peer-to-peer connection.\n"
-                "For a legacy (MnNetInfo / version-2) ProTx, pass a bare port number instead (e.g. 26656);\n"
-                "the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx.\n"
+                "For a legacy ProTx, pass a bare port number instead (e.g. 26656);\n"
+                "the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx.\n"
                 "Must be unique on the network. Can be set to an empty string, which will require a ProUpServTx afterwards.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
@@ -198,8 +198,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"platformP2PAddrs_update",
             {"platformP2PAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\" used by Platform for peer-to-peer connection.\n"
-                "For a legacy (MnNetInfo / version-2) ProTx, pass a bare port number instead (e.g. 26656);\n"
-                "the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx.\n"
+                "For a legacy ProTx, pass a bare port number instead (e.g. 26656);\n"
+                "the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx.\n"
                 "Must be unique on the network.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
@@ -208,8 +208,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"platformHTTPSAddrs",
             {"platformHTTPSAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\" used by Platform for their HTTPS API.\n"
-                "For a legacy (MnNetInfo / version-2) ProTx, pass a bare port number instead (e.g. 443);\n"
-                "the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx.\n"
+                "For a legacy ProTx, pass a bare port number instead (e.g. 443);\n"
+                "the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx.\n"
                 "Must be unique on the network. Can be set to an empty string, which will require a ProUpServTx afterwards.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
@@ -218,8 +218,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"platformHTTPSAddrs_update",
             {"platformHTTPSAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\" used by Platform for their HTTPS API.\n"
-                "For a legacy (MnNetInfo / version-2) ProTx, pass a bare port number instead (e.g. 443);\n"
-                "the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx.\n"
+                "For a legacy ProTx, pass a bare port number instead (e.g. 443);\n"
+                "the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx.\n"
                 "Must be unique on the network.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -88,6 +88,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"coreP2PAddrs",
             {"coreP2PAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\". Must be unique on the network.\n"
+                "A legacy (MnNetInfo / version-2) ProTx accepts only a single entry; multiple entries\n"
+                "require an Extended addresses (ExtNetInfo) ProTx.\n"
                 "Can be set to an empty string, which will require a ProUpServTx afterwards.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
@@ -95,7 +97,9 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         },
         {"coreP2PAddrs_update",
             {"coreP2PAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
-                "Array of addresses in the form \"ADDR:PORT\". Must be unique on the network.",
+                "Array of addresses in the form \"ADDR:PORT\". Must be unique on the network.\n"
+                "A legacy (MnNetInfo / version-2) ProTx accepts only a single entry; multiple entries\n"
+                "require an Extended addresses (ExtNetInfo) ProTx.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
                 }}
@@ -184,6 +188,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"platformP2PAddrs",
             {"platformP2PAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\" used by Platform for peer-to-peer connection.\n"
+                "For a legacy (MnNetInfo / version-2) ProTx, pass a bare port number instead (e.g. 26656);\n"
+                "the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx.\n"
                 "Must be unique on the network. Can be set to an empty string, which will require a ProUpServTx afterwards.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
@@ -192,6 +198,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"platformP2PAddrs_update",
             {"platformP2PAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\" used by Platform for peer-to-peer connection.\n"
+                "For a legacy (MnNetInfo / version-2) ProTx, pass a bare port number instead (e.g. 26656);\n"
+                "the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx.\n"
                 "Must be unique on the network.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
@@ -200,6 +208,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"platformHTTPSAddrs",
             {"platformHTTPSAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\" used by Platform for their HTTPS API.\n"
+                "For a legacy (MnNetInfo / version-2) ProTx, pass a bare port number instead (e.g. 443);\n"
+                "the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx.\n"
                 "Must be unique on the network. Can be set to an empty string, which will require a ProUpServTx afterwards.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},
@@ -208,6 +218,8 @@ static RPCArg GetRpcArg(const std::string& strParamName)
         {"platformHTTPSAddrs_update",
             {"platformHTTPSAddrs", RPCArg::Type::ARR, RPCArg::Optional::NO,
                 "Array of addresses in the form \"ADDR:PORT\" used by Platform for their HTTPS API.\n"
+                "For a legacy (MnNetInfo / version-2) ProTx, pass a bare port number instead (e.g. 443);\n"
+                "the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx.\n"
                 "Must be unique on the network.",
                 {
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, ""},

--- a/src/rpc/evo_util.cpp
+++ b/src/rpc/evo_util.cpp
@@ -94,8 +94,13 @@ void ProcessNetInfoPlatform(ProTx& ptx, const UniValue& input_p2p, const UniValu
                 // Empty Input: We can tolerate blank values if netInfo can store platform fields, if it cannot, we are relying
                 //              on platform{HTTP,P2P}Port, where it is mandatory even if their netInfo counterpart is optional.
                 //      String: If not parsable as port and relying on platform{HTTP,P2P}Port, bail out.
-                throw JSONRPCError(RPC_INVALID_PARAMETER,
-                                   strprintf("Invalid param for %s, ProTx version only supports ports", field_name));
+                const char* example_port{purpose == NetInfoPurpose::PLATFORM_HTTPS ? "443" : "26656"};
+                throw JSONRPCError(
+                    RPC_INVALID_PARAMETER,
+                    strprintf("Invalid param for %s, this ProTx version only accepts a bare port number "
+                              "(e.g. %s); the \"ADDR:PORT\" / address-array form requires an Extended "
+                              "addresses (ExtNetInfo) ProTx",
+                              field_name, example_port));
             }
             if (input.isArray()) {
                 const UniValue& entries = input.get_array();

--- a/src/rpc/evo_util.cpp
+++ b/src/rpc/evo_util.cpp
@@ -94,13 +94,11 @@ void ProcessNetInfoPlatform(ProTx& ptx, const UniValue& input_p2p, const UniValu
                 // Empty Input: We can tolerate blank values if netInfo can store platform fields, if it cannot, we are relying
                 //              on platform{HTTP,P2P}Port, where it is mandatory even if their netInfo counterpart is optional.
                 //      String: If not parsable as port and relying on platform{HTTP,P2P}Port, bail out.
-                const char* example_port{purpose == NetInfoPurpose::PLATFORM_HTTPS ? "443" : "26656"};
                 throw JSONRPCError(
                     RPC_INVALID_PARAMETER,
-                    strprintf("Invalid param for %s, this ProTx version only accepts a bare port number "
-                              "(e.g. %s); the \"ADDR:PORT\" / address-array form requires an Extended "
-                              "addresses (ExtNetInfo) ProTx",
-                              field_name, example_port));
+                    strprintf("Invalid param for %s, this ProTx version only accepts a bare port number; the "
+                              "\"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx",
+                              field_name));
             }
             if (input.isArray()) {
                 const UniValue& entries = input.get_array();

--- a/test/functional/rpc_netinfo.py
+++ b/test/functional/rpc_netinfo.py
@@ -270,37 +270,38 @@ class NetInfoTest(BitcoinTestFramework):
                                   DEFAULT_PORT_PLATFORM_P2P, DEFAULT_PORT_PLATFORM_HTTP,
                                   -8, f"Error setting coreP2PAddrs[1] to '127.0.0.2:{self.node_evo.mn.nodePort}' (too many entries)")
 
-        # platformP2PAddrs and platformHTTPSAddrs don't accept non-numeric inputs
+        # platformP2PAddrs and platformHTTPSAddrs don't accept non-numeric inputs; the rejection should
+        # also tell users that the "ADDR:PORT" / array form needs an Extended addresses (ExtNetInfo) ProTx.
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", f"127.0.0.1:{DEFAULT_PORT_PLATFORM_P2P}", DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, ProTx version only supports ports")
+                                  -8, "this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [f"127.0.0.1:{DEFAULT_PORT_PLATFORM_P2P}"], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, f"127.0.0.1:{DEFAULT_PORT_PLATFORM_HTTP}",
-                                  -8, "Invalid param for platformHTTPSAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [f"127.0.0.1:{DEFAULT_PORT_PLATFORM_HTTP}"],
-                                  -8, "Invalid param for platformHTTPSAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
 
         # Port numbers may not be wrapped in arrays, either as integers or strings
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [DEFAULT_PORT_PLATFORM_P2P], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [f"{DEFAULT_PORT_PLATFORM_P2P}"], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [DEFAULT_PORT_PLATFORM_HTTP],
-                                  -8, "Invalid param for platformHTTPSAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [f"{DEFAULT_PORT_PLATFORM_HTTP}"],
-                                  -8, "Invalid param for platformHTTPSAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number")
 
         # coreP2PAddrs cannot be empty when registering a masternode without specifying platform fields
         self.node_evo.register_mn(self, False, "", "", "",
-                                  -8, "Invalid param for platformP2PAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
         self.node_evo.register_mn(self, False, "", "", DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", "", "",
                                   -8, "Invalid param for platformP2PAddrs, cannot be empty if other fields populated")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", "", DEFAULT_PORT_PLATFORM_HTTP,
                                   -8, "Invalid param for platformP2PAddrs, cannot be empty if other fields populated")
         self.node_evo.register_mn(self, False, "", DEFAULT_PORT_PLATFORM_P2P, "",
-                                  -8, "Invalid param for platformHTTPSAddrs, ProTx version only supports ports")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, "",
                                   -8, "Invalid param for platformHTTPSAddrs, cannot be empty if other fields populated")
 

--- a/test/functional/rpc_netinfo.py
+++ b/test/functional/rpc_netinfo.py
@@ -273,9 +273,9 @@ class NetInfoTest(BitcoinTestFramework):
         # platformP2PAddrs and platformHTTPSAddrs don't accept non-numeric inputs; the rejection should
         # also tell users that the "ADDR:PORT" / array form needs an Extended addresses (ExtNetInfo) ProTx.
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", f"127.0.0.1:{DEFAULT_PORT_PLATFORM_P2P}", DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [f"127.0.0.1:{DEFAULT_PORT_PLATFORM_P2P}"], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, f"127.0.0.1:{DEFAULT_PORT_PLATFORM_HTTP}",
                                   -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [f"127.0.0.1:{DEFAULT_PORT_PLATFORM_HTTP}"],
@@ -283,25 +283,25 @@ class NetInfoTest(BitcoinTestFramework):
 
         # Port numbers may not be wrapped in arrays, either as integers or strings
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [DEFAULT_PORT_PLATFORM_P2P], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [f"{DEFAULT_PORT_PLATFORM_P2P}"], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [DEFAULT_PORT_PLATFORM_HTTP],
-                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [f"{DEFAULT_PORT_PLATFORM_HTTP}"],
-                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
 
         # coreP2PAddrs cannot be empty when registering a masternode without specifying platform fields
         self.node_evo.register_mn(self, False, "", "", "",
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, "", "", DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", "", "",
                                   -8, "Invalid param for platformP2PAddrs, cannot be empty if other fields populated")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", "", DEFAULT_PORT_PLATFORM_HTTP,
                                   -8, "Invalid param for platformP2PAddrs, cannot be empty if other fields populated")
         self.node_evo.register_mn(self, False, "", DEFAULT_PORT_PLATFORM_P2P, "",
-                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, "",
                                   -8, "Invalid param for platformHTTPSAddrs, cannot be empty if other fields populated")
 

--- a/test/functional/rpc_netinfo.py
+++ b/test/functional/rpc_netinfo.py
@@ -271,37 +271,37 @@ class NetInfoTest(BitcoinTestFramework):
                                   -8, f"Error setting coreP2PAddrs[1] to '127.0.0.2:{self.node_evo.mn.nodePort}' (too many entries)")
 
         # platformP2PAddrs and platformHTTPSAddrs don't accept non-numeric inputs; the rejection should
-        # also tell users that the "ADDR:PORT" / array form needs an Extended addresses (ExtNetInfo) ProTx.
+        # also tell users that the "ADDR:PORT" / array form needs upgrading to a version 3 ProTx.
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", f"127.0.0.1:{DEFAULT_PORT_PLATFORM_P2P}", DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [f"127.0.0.1:{DEFAULT_PORT_PLATFORM_P2P}"], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, f"127.0.0.1:{DEFAULT_PORT_PLATFORM_HTTP}",
-                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [f"127.0.0.1:{DEFAULT_PORT_PLATFORM_HTTP}"],
-                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
 
         # Port numbers may not be wrapped in arrays, either as integers or strings
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [DEFAULT_PORT_PLATFORM_P2P], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", [f"{DEFAULT_PORT_PLATFORM_P2P}"], DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [DEFAULT_PORT_PLATFORM_HTTP],
-                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, [f"{DEFAULT_PORT_PLATFORM_HTTP}"],
-                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
 
         # coreP2PAddrs cannot be empty when registering a masternode without specifying platform fields
         self.node_evo.register_mn(self, False, "", "", "",
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, "", "", DEFAULT_PORT_PLATFORM_HTTP,
-                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number (e.g. 26656); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformP2PAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", "", "",
                                   -8, "Invalid param for platformP2PAddrs, cannot be empty if other fields populated")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", "", DEFAULT_PORT_PLATFORM_HTTP,
                                   -8, "Invalid param for platformP2PAddrs, cannot be empty if other fields populated")
         self.node_evo.register_mn(self, False, "", DEFAULT_PORT_PLATFORM_P2P, "",
-                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number (e.g. 443); the \"ADDR:PORT\" / address-array form requires an Extended addresses (ExtNetInfo) ProTx")
+                                  -8, "Invalid param for platformHTTPSAddrs, this ProTx version only accepts a bare port number; the \"ADDR:PORT\" / address-array form requires upgrading to a version 3 ProTx")
         self.node_evo.register_mn(self, False, f"127.0.0.1:{self.node_evo.mn.nodePort}", DEFAULT_PORT_PLATFORM_P2P, "",
                                   -8, "Invalid param for platformHTTPSAddrs, cannot be empty if other fields populated")
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes dashpay/dash#7370.

`protx register_evo` and `protx update_service_evo` accepted two different platform address formats depending on the ProTx net-info version, but the RPC help only described the Extended-address array form. When a legacy MnNetInfo / version-2 ProTx rejected `"ADDR:PORT"` or array input for `platformP2PAddrs` / `platformHTTPSAddrs`, the error only said the version supported ports, without showing the expected shape.

## What was done?

- Clarified the shared RPC help for `coreP2PAddrs`, `platformP2PAddrs`, `platformHTTPSAddrs`, and update variants to explain legacy MnNetInfo/version-2 bare-port input versus Extended addresses (ExtNetInfo) `"ADDR:PORT"` array input.
- Reworded the legacy platform-field rejection to explicitly say the current ProTx version expects a bare port number and that address arrays require an Extended-addresses ProTx.
- Used field-appropriate examples in the error text: `26656` for Platform P2P and `443` for Platform HTTPS.
- Updated `rpc_netinfo.py` expectations so the clearer messages are covered, including the HTTPS example-port case caught during review.

## How Has This Been Tested?

Tested on macOS arm64 in the `fix-protx-netinfo-help` worktree.

- `make -j8 src/dashd`
- `test/functional/rpc_netinfo.py`
- `code-review dashpay/dash upstream/develop fix-protx-netinfo-help "Fix issue #7370 by clarifying protx register/update platform address help and legacy v2 error messages"` → ship

## Breaking Changes

None. This changes RPC help/error text and matching functional-test expectations only; parsing behavior is unchanged.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
