### PR TITLE
fix: clamp gobject list-prepared count

### DIFF
--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -292,7 +292,8 @@ static RPCHelpMan gobject_list_prepared()
     });
 
     UniValue jsonArray(UniValue::VARR);
-    for (auto it = vecObjects.begin() + std::max<int>(0, vecObjects.size() - nCount); it != vecObjects.end(); ++it) {
+    const size_t nClampedCount = static_cast<size_t>(std::min<int64_t>(nCount, vecObjects.size()));
+    for (auto it = vecObjects.end() - nClampedCount; it != vecObjects.end(); ++it) {
         jsonArray.push_back((*it)->ToJson());
     }
 

--- a/test/functional/feature_governance_objects.py
+++ b/test/functional/feature_governance_objects.py
@@ -75,6 +75,10 @@ class DashGovernanceTest (DashTestFramework):
         # Make sure default count is 10 while there are 11 in total
         assert_equal(len(self.nodes[0].gobject("list-prepared")), 10)
         assert_equal(len(self.nodes[0].gobject("list-prepared", 12)), 11)
+        # count greater than the number of prepared objects returns all of them (no overflow)
+        assert_equal(len(self.nodes[0].gobject("list-prepared", 1000)), 11)
+        # Very large count (near INT64_MAX) must still be clamped safely
+        assert_equal(len(self.nodes[0].gobject("list-prepared", 9223372036854775807)), 11)
         # Make sure it returns 0 objects with count=0
         assert_equal(len(self.nodes[0].gobject("list-prepared", 0)), 0)
         # And test some invalid count values


### PR DESCRIPTION
## Issue being fixed or feature implemented
The wallet `gobject list-prepared` RPC accepted a `count` parameter but computed
the iterator start with mixed signed and unsigned arithmetic. Oversized counts
could wrap before iterator arithmetic and produce an invalid iterator.


## What was done?
Clamp the requested count to the number of prepared governance objects before
computing the start iterator, then iterate from `end() - clamped_count`.

Added functional test coverage for oversized and very large count values.


## How Has This Been Tested?
Ran:

```bash
git diff --check upstream/develop...HEAD
code-review dashpay/dash upstream/develop 380cb1304adffb28bc3689df38921727d86b610d "Clamp gobject list-prepared count before computing vector iterators to avoid out-of-range iterator arithmetic"
```

The pre-PR review gate returned `ship`.

I did not run the functional test locally because this worktree is not configured
or built with `dashd`.


## Breaking Changes
None.


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
