### PR TITLE
fix: reject mismatched HD chain wallet records

### DIFF
--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -6,11 +6,14 @@
 #include <clientversion.h>
 #include <streams.h>
 #include <uint256.h>
+#include <wallet/hdchain.h>
+#include <wallet/test/wallet_test_fixture.h>
+#include <wallet/walletdb.h>
 
 #include <boost/test/unit_test.hpp>
 
 namespace wallet {
-BOOST_FIXTURE_TEST_SUITE(walletdb_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(walletdb_tests, WalletTestingSetup)
 
 BOOST_AUTO_TEST_CASE(walletdb_readkeyvalue)
 {
@@ -25,6 +28,37 @@ BOOST_AUTO_TEST_CASE(walletdb_readkeyvalue)
     CDataStream ssValue(SER_DISK, CLIENT_VERSION);
     uint256 dummy;
     BOOST_CHECK_THROW(ssValue >> dummy, std::ios_base::failure);
+}
+
+// Helper: build a key/value stream pair for an HD chain DB record and run ReadKeyValue.
+static bool TryReadHDChainRecord(CWallet& wallet, const std::string& dbKey, bool fCrypted, std::string& strErrOut)
+{
+    CHDChain chain;
+    chain.SetCrypted(fCrypted);
+
+    CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+    CDataStream ssValue(SER_DISK, CLIENT_VERSION);
+    ssKey << dbKey;
+    ssValue << chain;
+
+    std::string strType;
+    LOCK(wallet.cs_wallet);
+    return ReadKeyValue(&wallet, ssKey, ssValue, strType, strErrOut);
+}
+
+BOOST_AUTO_TEST_CASE(walletdb_hdchain_type_mismatch)
+{
+    // Regression: a wallet record claiming HDCHAIN but carrying a crypted CHDChain
+    // (or vice versa) used to trigger an assert and abort the process. It must now
+    // surface as a graceful load error.
+    std::string strErr;
+
+    BOOST_CHECK(!TryReadHDChainRecord(m_wallet, DBKeys::HDCHAIN, /*fCrypted=*/true, strErr));
+    BOOST_CHECK_EQUAL(strErr, "Error reading wallet database: HD chain type mismatch");
+
+    strErr.clear();
+    BOOST_CHECK(!TryReadHDChainRecord(m_wallet, DBKeys::CRYPTED_HDCHAIN, /*fCrypted=*/false, strErr));
+    BOOST_CHECK_EQUAL(strErr, "Error reading wallet database: HD chain type mismatch");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -585,7 +585,10 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         } else if (strType == DBKeys::HDCHAIN || strType == DBKeys::CRYPTED_HDCHAIN) {
             CHDChain chain;
             ssValue >> chain;
-            assert ((strType == DBKeys::CRYPTED_HDCHAIN) == chain.IsCrypted());
+            if ((strType == DBKeys::CRYPTED_HDCHAIN) != chain.IsCrypted()) {
+                strErr = "Error reading wallet database: HD chain type mismatch";
+                return false;
+            }
             // Skip encryption check during loading as MASTER_KEY records may not be loaded yet.
             // Consistency will be validated after all records are loaded.
             if (!pwallet->GetOrCreateLegacyScriptPubKeyMan()->LoadHDChain(chain, /*skip_encryption_check=*/true)) {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Malformed wallet database records can currently trip a process assertion while
loading HD chain state. A wallet database whose HD chain key type disagrees with
the serialized chain encryption flag is corrupt input and should be reported as
a wallet load error instead of aborting the process.


## What was done?
Changed `ReadKeyValue` to validate `HDCHAIN` / `CRYPTED_HDCHAIN` records with a
normal conditional check. When the key type and serialized `CHDChain` state do
not match, wallet loading now returns a descriptive database error.

Added focused unit coverage for both mismatch directions.


## How Has This Been Tested?
Ran:

```bash
git diff --check upstream/develop...HEAD
src/test/test_dash --run_test=walletdb_hdchain_tests
code-review dashpay/dash upstream/develop e85b88f74882b2ecf437cbce56441177e1955e11 "Reject mismatched HDCHAIN/CRYPTED_HDCHAIN wallet records gracefully instead of asserting during wallet load"
```

The pre-PR review gate returned `ship`.


## Breaking Changes
None.


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
