### PR TITLE
ci: add daily sync reindex workflow

### DIFF
--- a/.github/workflows/sync-reindex.yml
+++ b/.github/workflows/sync-reindex.yml
@@ -1,0 +1,229 @@
+name: Daily Sync + Reindex
+
+# Daily regression check that a fresh build of dashd from the latest develop
+# branch can resume an existing chain, advance to tip, restart with -reindex,
+# and reach the same tip without regression.
+#
+# Runner expectations
+# -------------------
+# This workflow REQUIRES a stateful self-hosted Linux runner whose datadir
+# persists across runs (typically a Docker volume or a directory under
+# /var/lib that survives runner restarts). Hosted GitHub-Actions runners are
+# ephemeral and would re-sync from genesis on every invocation, defeating the
+# purpose of a daily regression check, so they are intentionally not allowed
+# here. The runner label is selected via the `runner` input or the
+# `RUNNER_SYNC_REINDEX` repository variable; both should resolve to a label
+# attached only to runners that have a persistent datadir mounted at the path
+# given by `SYNC_REINDEX_DATADIR` (see `doc/sync-reindex-ci.md`).
+#
+# The datadir is NOT cleaned between runs. Maintainers wanting to start over
+# should ssh to the runner and remove (or rename) the datadir before the next
+# scheduled run.
+
+on:
+  schedule:
+    # Daily at 04:17 UTC. Off-hour to avoid clashing with the weekly Guix
+    # build at 03:00 Sunday and most peak push traffic.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: 'Runner label (must be a stateful self-hosted runner)'
+        required: false
+        default: ''
+      ref:
+        description: 'Git ref to check out (default: develop)'
+        required: false
+        default: 'develop'
+      network:
+        description: 'Network to sync (main|test; devnet requires extra dashd args)'
+        required: false
+        default: 'test'
+      mode:
+        description: 'Phases to run (sync|reindex|both)'
+        required: false
+        default: 'both'
+      reindex_flag:
+        description: 'Reindex flavour (-reindex or -reindex-chainstate)'
+        required: false
+        default: '-reindex'
+      phase_timeout:
+        description: 'Per-phase timeout in seconds'
+        required: false
+        default: '21600'
+      external_tip_url:
+        description: 'HTTP endpoint returning the current network tip height'
+        required: false
+        default: ''
+      extra_args:
+        description: 'Extra dashd args, e.g. devnet -port/-rpcport settings'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize: the runner has a single shared datadir, so overlapping runs
+  # would corrupt each other's state.
+  group: sync-reindex-${{ inputs.network || 'test' }}
+  cancel-in-progress: false
+
+jobs:
+  sync-reindex:
+    name: sync-reindex (${{ inputs.network || 'test' }})
+    # The label is resolved from inputs > repo variable > a safe placeholder
+    # that will fail loudly if neither is configured.
+    runs-on: ${{ inputs.runner || vars.RUNNER_SYNC_REINDEX || 'self-hosted-sync-reindex' }}
+    timeout-minutes: 720
+    env:
+      REF: ${{ inputs.ref || 'develop' }}
+      NETWORK: ${{ inputs.network || 'test' }}
+      MODE: ${{ inputs.mode || 'both' }}
+      REINDEX_FLAG: ${{ inputs.reindex_flag || '-reindex' }}
+      PHASE_TIMEOUT: ${{ inputs.phase_timeout || '21600' }}
+      # SYNC_REINDEX_DATADIR is required on the runner: see
+      # doc/sync-reindex-ci.md for setup. The default below matches the
+      # documented FHS-friendly location but can be overridden per-runner.
+      DATADIR_BASE: ${{ vars.SYNC_REINDEX_DATADIR || '/var/lib/dashcore-ci/sync-reindex' }}
+      EXTERNAL_TIP_URL: ${{ inputs.external_tip_url || vars.SYNC_REINDEX_EXTERNAL_TIP_URL || '' }}
+      EXTRA_DASHD_ARGS: ${{ inputs.extra_args || vars.SYNC_REINDEX_EXTRA_DASHD_ARGS || '' }}
+      MAKEJOBS: ${{ vars.SYNC_REINDEX_MAKEJOBS || '-j4' }}
+
+    steps:
+      - name: Sanity check runner
+        run: |
+          set -euo pipefail
+          echo "Runner: $(uname -a)"
+          echo "Datadir base: $DATADIR_BASE"
+          if [ ! -d "$DATADIR_BASE" ]; then
+            echo "ERROR: $DATADIR_BASE does not exist. The runner must mount a persistent" >&2
+            echo "directory at this path. See doc/sync-reindex-ci.md." >&2
+            exit 1
+          fi
+          # Refuse to run on a runner that didn't reserve the directory for us.
+          if ! touch "$DATADIR_BASE/.write-test" 2>/dev/null; then
+            echo "ERROR: $DATADIR_BASE is not writable by the runner user." >&2
+            exit 1
+          fi
+          rm -f "$DATADIR_BASE/.write-test"
+          if [ -z "$EXTERNAL_TIP_URL" ]; then
+            echo "ERROR: SYNC_REINDEX_EXTERNAL_TIP_URL or dispatch external_tip_url is required." >&2
+            echo "The workflow must compare against an external tip source to prove catch-up." >&2
+            exit 1
+          fi
+
+      - name: Checkout upstream ${{ env.REF }}
+        uses: actions/checkout@v6
+        with:
+          repository: dashpay/dash
+          ref: ${{ env.REF }}
+          fetch-depth: 1
+
+      - name: Record commit under test
+        run: |
+          git log -1 --pretty=format:'commit %H%n%an <%ae>%n%s%n%n%b%n'
+
+      - name: Build depends
+        run: |
+          set -euo pipefail
+          ./autogen.sh
+          HOST_TRIPLET=$(./depends/config.guess)
+          echo "HOST_TRIPLET=$HOST_TRIPLET" >> "$GITHUB_ENV"
+          # The depends build is silent on success; fail loud on errors only.
+          make -C depends HOST="$HOST_TRIPLET" $MAKEJOBS NO_QT=1 > depends-build.log 2>&1 || {
+            echo "depends build failed; tail of log:" >&2
+            tail -n 200 depends-build.log >&2
+            exit 1
+          }
+
+      - name: Configure
+        run: |
+          set -euo pipefail
+          ./configure --prefix="$PWD/depends/$HOST_TRIPLET" \
+            --disable-bench \
+            --disable-tests \
+            --without-gui \
+            --enable-reduce-exports \
+            --enable-suppress-external-warnings \
+            > configure.log 2>&1 || {
+              tail -n 200 configure.log >&2
+              exit 1
+            }
+
+      - name: Build dashd and dash-cli
+        run: |
+          set -euo pipefail
+          make $MAKEJOBS src/dashd src/dash-cli > build.log 2>&1 || {
+            tail -n 200 build.log >&2
+            exit 1
+          }
+          ./src/dashd --version
+          ./src/dash-cli --version
+
+      - name: Run sync + reindex check
+        env:
+          DATADIR: ${{ env.DATADIR_BASE }}/${{ env.NETWORK }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$DATADIR"
+          args=(
+            ./contrib/devtools/sync_reindex_check.sh
+            --dashd ./src/dashd
+            --dash-cli ./src/dash-cli
+            --datadir "$DATADIR"
+            --network "$NETWORK"
+            --mode "$MODE"
+            --reindex-flag "$REINDEX_FLAG"
+            --timeout "$PHASE_TIMEOUT"
+          )
+          if [ -n "$EXTERNAL_TIP_URL" ]; then
+            args+=(--external-tip-url "$EXTERNAL_TIP_URL")
+          fi
+          if [ -n "$EXTRA_DASHD_ARGS" ]; then
+            args+=(--extra-args "$EXTRA_DASHD_ARGS")
+          fi
+          "${args[@]}"
+
+      - name: Collect logs on failure
+        if: failure()
+        run: |
+          set +e
+          DATADIR="$DATADIR_BASE/$NETWORK"
+          TAIL_DIR="${RUNNER_TEMP:-/tmp}/sync-reindex-log-tails"
+          mkdir -p "$TAIL_DIR"
+
+          {
+            echo "===== sync_reindex_check.log (tail) ====="
+            tail -n 500 "$DATADIR/sync_reindex_check.log" 2>/dev/null || echo "(missing)"
+          } | tee "$TAIL_DIR/sync_reindex_check.tail.log"
+
+          : > "$TAIL_DIR/debug.tail.log"
+          found_debug=0
+          while IFS= read -r debuglog; do
+            found_debug=1
+            {
+              echo "===== $debuglog (tail) ====="
+              tail -n 1000 "$debuglog" 2>/dev/null || echo "(missing $debuglog)"
+              echo
+            } | tee -a "$TAIL_DIR/debug.tail.log"
+          done < <(find "$DATADIR" -maxdepth 2 -name debug.log -type f 2>/dev/null | sort)
+          if [ "$found_debug" -eq 0 ]; then
+            {
+              echo "===== debug.log (tail) ====="
+              echo "(missing under $DATADIR)"
+            } | tee -a "$TAIL_DIR/debug.tail.log"
+          fi
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: sync-reindex-logs-${{ env.NETWORK }}-${{ github.run_id }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            ${{ runner.temp }}/sync-reindex-log-tails/*.log
+            depends-build.log
+            configure.log
+            build.log

--- a/contrib/devtools/sync_reindex_check.sh
+++ b/contrib/devtools/sync_reindex_check.sh
@@ -1,0 +1,589 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Daily sync + reindex regression check.
+#
+# Boots dashd, waits for it to reach tip, then restarts with -reindex
+# (or -reindex-chainstate when requested) and verifies the node converges back to the same
+# (or a higher) tip. Designed to run on a stateful self-hosted runner where the
+# datadir is preserved across invocations so each run resumes from yesterday's
+# state rather than syncing from scratch.
+#
+# Communicates with the node via dash-cli RPC; log scraping is only used as a
+# last resort when checking process liveness.
+#
+export LC_ALL=C
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: sync_reindex_check.sh [options]
+
+Options (all also configurable via environment variables):
+  --dashd PATH               Path to dashd (env: DASHD, default: ./src/dashd)
+  --dash-cli PATH            Path to dash-cli (env: DASH_CLI, default: ./src/dash-cli)
+  --datadir PATH             Persistent data directory (env: DATADIR, required)
+  --network NAME             test|main|devnet|regtest (env: NETWORK, default: test)
+  --mode MODE                sync|reindex|both (env: MODE, default: both)
+  --reindex-flag FLAG        -reindex or -reindex-chainstate
+                             (env: REINDEX_FLAG, default: -reindex)
+  --timeout SECONDS          Per-phase wall-clock timeout
+                             (env: PHASE_TIMEOUT, default: 21600 = 6h)
+  --poll-interval SECONDS    RPC poll interval (env: POLL_INTERVAL, default: 30)
+  --min-headers N            Minimum acceptable header count when no external
+                             tip source is available (env: MIN_HEADERS,
+                             defaults: testnet=1000000, mainnet=2000000,
+                             others=0). Ignored when --external-tip-url is set.
+  --external-tip-url URL     HTTP endpoint returning JSON with .height or a
+                             bare integer. When set, the local tip must be
+                             within --tip-tolerance of this value; a fetch or
+                             parse failure is fatal (the --min-headers floor
+                             is NOT used as a silent fallback).
+                             (env: EXTERNAL_TIP_URL)
+  --tip-tolerance N          Allowed lag vs. external tip in blocks. Applies
+                             only to the external-tip comparison; the
+                             reindex-vs-sync baseline check is strict and has
+                             no tolerance. (env: TIP_TOLERANCE, default: 50)
+  --extra-args "..."         Extra args appended to every dashd invocation.
+                             For --network=devnet, -port=<n> and -rpcport=<n>
+                             are required, and -devnet=<name> may be included
+                             to select a named devnet; -devnet=<name> and
+                             -rpcport=<n> are also forwarded to dash-cli so it
+                             can talk to the running node.
+                             (env: EXTRA_DASHD_ARGS)
+  --keep-running             Leave dashd running on success (for debugging)
+  -h, --help                 Show this help
+
+Exit codes:
+  0  success
+  1  configuration / startup failure
+  2  sync phase failed (timeout or regression)
+  3  reindex phase failed (timeout or regression)
+  4  tip verification failed (height below expectation)
+USAGE
+}
+
+# ---- defaults -----------------------------------------------------------
+
+DASHD="${DASHD:-./src/dashd}"
+DASH_CLI="${DASH_CLI:-./src/dash-cli}"
+DATADIR="${DATADIR:-}"
+NETWORK="${NETWORK:-test}"
+MODE="${MODE:-both}"
+REINDEX_FLAG="${REINDEX_FLAG:--reindex}"
+PHASE_TIMEOUT="${PHASE_TIMEOUT:-21600}"
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+MIN_HEADERS="${MIN_HEADERS:-}"
+EXTERNAL_TIP_URL="${EXTERNAL_TIP_URL:-}"
+TIP_TOLERANCE="${TIP_TOLERANCE:-50}"
+EXTRA_DASHD_ARGS="${EXTRA_DASHD_ARGS:-}"
+KEEP_RUNNING=0
+
+while (( $# > 0 )); do
+    case "$1" in
+        --dashd) DASHD="$2"; shift 2;;
+        --dash-cli) DASH_CLI="$2"; shift 2;;
+        --datadir) DATADIR="$2"; shift 2;;
+        --network) NETWORK="$2"; shift 2;;
+        --mode) MODE="$2"; shift 2;;
+        --reindex-flag) REINDEX_FLAG="$2"; shift 2;;
+        --timeout) PHASE_TIMEOUT="$2"; shift 2;;
+        --poll-interval) POLL_INTERVAL="$2"; shift 2;;
+        --min-headers) MIN_HEADERS="$2"; shift 2;;
+        --external-tip-url) EXTERNAL_TIP_URL="$2"; shift 2;;
+        --tip-tolerance) TIP_TOLERANCE="$2"; shift 2;;
+        --extra-args) EXTRA_DASHD_ARGS="$2"; shift 2;;
+        --keep-running) KEEP_RUNNING=1; shift;;
+        -h|--help) usage; exit 0;;
+        *) echo "Unknown argument: $1" >&2; usage >&2; exit 1;;
+    esac
+done
+
+# ---- validation ---------------------------------------------------------
+
+if [[ -z "$DATADIR" ]]; then
+    echo "ERROR: --datadir (or DATADIR env var) is required." >&2
+    exit 1
+fi
+if [[ ! -x "$DASHD" ]]; then
+    echo "ERROR: dashd not found or not executable at: $DASHD" >&2
+    exit 1
+fi
+if [[ ! -x "$DASH_CLI" ]]; then
+    echo "ERROR: dash-cli not found or not executable at: $DASH_CLI" >&2
+    exit 1
+fi
+case "$NETWORK" in
+    main|test|devnet|regtest) ;;
+    *) echo "ERROR: --network must be one of main|test|devnet|regtest" >&2; exit 1;;
+esac
+case "$MODE" in
+    sync|reindex|both) ;;
+    *) echo "ERROR: --mode must be one of sync|reindex|both" >&2; exit 1;;
+esac
+case "$REINDEX_FLAG" in
+    -reindex|-reindex-chainstate) ;;
+    *) echo "ERROR: --reindex-flag must be -reindex or -reindex-chainstate" >&2; exit 1;;
+esac
+
+mkdir -p "$DATADIR"
+
+if [[ -z "$MIN_HEADERS" ]]; then
+    case "$NETWORK" in
+        main) MIN_HEADERS=2000000;;
+        test) MIN_HEADERS=1000000;;
+        *) MIN_HEADERS=0;;
+    esac
+fi
+
+PIDFILE="$DATADIR/sync_reindex_check.pid"
+LOGFILE="$DATADIR/sync_reindex_check.log"
+DASHD_PID=""
+
+# shellcheck disable=SC2206  # word-splitting EXTRA_DASHD_ARGS is intentional
+EXTRA_ARGS_ARR=( $EXTRA_DASHD_ARGS )
+
+# Pick out args that dash-cli also needs to reach the node, so we can mirror
+# them when invoking the CLI. -port is a dashd-only arg and is intentionally
+# NOT forwarded. -devnet=<name> selects a named devnet (the bare -devnet flag
+# from NETWORK_FLAG would otherwise duplicate / conflict with this).
+DEVNET_NAME_ARG=""
+RPCPORT_ARG=""
+HAS_DEVNET_PORT=0
+HAS_DEVNET_RPCPORT=0
+for arg in "${EXTRA_ARGS_ARR[@]}"; do
+    case "$arg" in
+        -devnet=*) DEVNET_NAME_ARG="$arg";;
+        -port=*)   HAS_DEVNET_PORT=1;;
+        -rpcport=*)
+            HAS_DEVNET_RPCPORT=1
+            RPCPORT_ARG="$arg"
+            ;;
+    esac
+done
+
+if [[ -n "$DEVNET_NAME_ARG" && "$NETWORK" != "devnet" ]]; then
+    echo "ERROR: -devnet=<name> in --extra-args is only valid with --network=devnet." >&2
+    exit 1
+fi
+
+NETWORK_FLAG=""
+case "$NETWORK" in
+    test) NETWORK_FLAG="-testnet";;
+    devnet)
+        # If the user supplied -devnet=<name> in extras, don't also pass the
+        # bare -devnet ourselves: dashd would reject the duplicate.
+        [[ -z "$DEVNET_NAME_ARG" ]] && NETWORK_FLAG="-devnet"
+        ;;
+    regtest) NETWORK_FLAG="-regtest";;
+esac
+
+NET_SUBDIR=""
+case "$NETWORK" in
+    test) NET_SUBDIR="testnet3";;
+    devnet)
+        if [[ -n "$DEVNET_NAME_ARG" ]]; then
+            NET_SUBDIR="devnet-${DEVNET_NAME_ARG#-devnet=}"
+        else
+            NET_SUBDIR="devnet"
+        fi
+        ;;
+    regtest) NET_SUBDIR="regtest";;
+esac
+NET_DATADIR="$DATADIR"
+if [[ -n "$NET_SUBDIR" ]]; then
+    NET_DATADIR="$DATADIR/$NET_SUBDIR"
+fi
+
+if [[ "$NETWORK" == "devnet" ]]; then
+    if (( ! HAS_DEVNET_PORT || ! HAS_DEVNET_RPCPORT )); then
+        echo "ERROR: --network=devnet requires --extra-args with -port=<n> and -rpcport=<n>." >&2
+        exit 1
+    fi
+fi
+
+# ---- helpers ------------------------------------------------------------
+
+log() {
+    # All progress logging goes to stderr so that command substitutions
+    # (e.g. capturing the post-sync tip from wait_for_sync) don't see it.
+    # The launcher additionally tees stderr into $LOGFILE below.
+    printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >&2
+    if [[ -n "${LOGFILE:-}" ]]; then
+        printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOGFILE" 2>/dev/null || true
+    fi
+}
+
+cli() {
+    local args=()
+    if [[ -n "$DEVNET_NAME_ARG" ]]; then
+        args+=("$DEVNET_NAME_ARG")
+    elif [[ -n "$NETWORK_FLAG" ]]; then
+        args+=("$NETWORK_FLAG")
+    fi
+    args+=("-datadir=$DATADIR" "-rpcclienttimeout=120")
+    [[ -n "$RPCPORT_ARG" ]] && args+=("$RPCPORT_ARG")
+    "$DASH_CLI" "${args[@]}" "$@"
+}
+
+start_node() {
+    local phase="$1"
+    shift
+    local extra_phase_args=("$@")
+
+    log "Starting dashd for phase '$phase' (flags: ${extra_phase_args[*]:-none})"
+    local cmd=(
+        "$DASHD"
+        "-datadir=$DATADIR"
+        "-daemon=0"
+        "-printtoconsole=0"
+        "-debuglogfile=debug.log"
+        "-pid=$PIDFILE"
+    )
+    [[ -n "$NETWORK_FLAG" ]] && cmd+=("$NETWORK_FLAG")
+    cmd+=("${extra_phase_args[@]}")
+    if (( ${#EXTRA_ARGS_ARR[@]} > 0 )); then
+        cmd+=("${EXTRA_ARGS_ARR[@]}")
+    fi
+
+    # Run dashd in background; redirect stderr/stdout to phase log.
+    "${cmd[@]}" >> "$LOGFILE" 2>&1 &
+    local launcher_pid=$!
+    DASHD_PID="$launcher_pid"
+    echo "$launcher_pid" > "$PIDFILE.launcher"
+
+    # Wait for RPC to become responsive.
+    local waited=0
+    local rpc_warmup_timeout=600
+    while (( waited < rpc_warmup_timeout )); do
+        if ! kill -0 "$launcher_pid" 2>/dev/null; then
+            log "ERROR: dashd exited before RPC came up; tail of log:"
+            tail -n 50 "$LOGFILE" >&2 || true
+            return 1
+        fi
+        if cli getblockchaininfo >/dev/null 2>&1; then
+            log "RPC is up after ${waited}s"
+            return 0
+        fi
+        sleep 5
+        waited=$((waited + 5))
+    done
+    log "ERROR: dashd RPC did not respond within ${rpc_warmup_timeout}s"
+    return 1
+}
+
+stop_node() {
+    log "Stopping dashd"
+    if ! cli stop >/dev/null 2>&1; then
+        log "WARN: 'dash-cli stop' failed; trying SIGTERM"
+        if [[ -f "$PIDFILE" ]]; then
+            kill "$(cat "$PIDFILE")" 2>/dev/null || true
+        fi
+    fi
+    local waited=0
+    while (( waited < 300 )); do
+        if [[ ! -f "$PIDFILE" ]] || ! kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+            log "Node stopped after ${waited}s"
+            return 0
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+    log "ERROR: node did not stop cleanly within 300s; sending SIGKILL"
+    [[ -f "$PIDFILE" ]] && kill -9 "$(cat "$PIDFILE")" 2>/dev/null || true
+    return 1
+}
+
+# Fetch external tip; prints integer height on success.
+fetch_external_tip() {
+    [[ -z "$EXTERNAL_TIP_URL" ]] && return 1
+    if ! command -v curl >/dev/null 2>&1; then
+        log "ERROR: curl unavailable, cannot fetch external tip"
+        return 1
+    fi
+    local body
+    if ! body=$(curl -fsSL --max-time 30 "$EXTERNAL_TIP_URL" 2>/dev/null); then
+        log "ERROR: external tip fetch failed: $EXTERNAL_TIP_URL"
+        return 1
+    fi
+    [[ -z "$body" ]] && { log "ERROR: external tip fetch returned empty body"; return 1; }
+    # Try JSON .height first, then a bare integer. Do not strip all digits
+    # from arbitrary JSON; {"height":123,"time":456} must not become 123456.
+    local h
+    if command -v jq >/dev/null 2>&1; then
+        h=$(printf '%s' "$body" | jq -r 'if type=="number" then . elif .height then .height else empty end' 2>/dev/null || true)
+    fi
+    if [[ -z "${h:-}" ]]; then
+        if [[ "$body" =~ ^[[:space:]]*[0-9]+[[:space:]]*$ ]]; then
+            h=$(printf '%s' "$body" | tr -dc '0-9')
+        else
+            h=$(printf '%s' "$body" | sed -n 's/.*"height"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -n1)
+        fi
+    fi
+    if [[ "$h" =~ ^[0-9]+$ ]]; then
+        printf '%s' "$h"
+        return 0
+    fi
+    log "ERROR: external tip response did not contain a numeric height"
+    return 1
+}
+
+INDEX_STATUS=""
+
+indexes_synced() {
+    local target_height="$1"
+    local info
+    if ! info=$(cli getindexinfo 2>/dev/null); then
+        INDEX_STATUS="unavailable"
+        log "WARN: getindexinfo failed; will retry"
+        return 1
+    fi
+
+    local synced_values height_values
+    synced_values=$(printf '%s\n' "$info" | sed -n 's/.*"synced":[[:space:]]*\(true\|false\).*/\1/p')
+    height_values=$(printf '%s\n' "$info" | sed -n 's/.*"best_block_height":[[:space:]]*\([0-9]*\).*/\1/p')
+
+    if [[ -z "$synced_values" && -z "$height_values" ]]; then
+        INDEX_STATUS="none"
+        return 0
+    fi
+
+    INDEX_STATUS="synced=$(printf '%s' "$synced_values" | tr '\n' ',') heights=$(printf '%s' "$height_values" | tr '\n' ',')"
+
+    if printf '%s\n' "$synced_values" | grep -qx 'false'; then
+        return 1
+    fi
+
+    local h
+    while IFS= read -r h; do
+        [[ -z "$h" ]] && continue
+        if (( h < target_height )); then
+            return 1
+        fi
+    done <<< "$height_values"
+
+    return 0
+}
+
+block_hash_at_height() {
+    local height="$1"
+    if ! [[ "$height" =~ ^[0-9]+$ ]]; then
+        log "ERROR: cannot query block hash for non-numeric height: '$height'"
+        return 1
+    fi
+    cli getblockhash "$height" 2>/dev/null
+}
+
+# Poll the node until it is considered synced or timeout/regression occurs.
+wait_for_sync() {
+    local phase="$1"
+    local deadline=$(( $(date +%s) + PHASE_TIMEOUT ))
+    local last_blocks=-1
+    local last_progress=""
+    local last_index_status=""
+    local stagnant_iters=0
+    local stagnant_limit=$(( 1800 / POLL_INTERVAL ))  # ~30 min with no progress
+    (( stagnant_limit < 5 )) && stagnant_limit=5
+
+    log "Waiting for sync (phase=$phase, timeout=${PHASE_TIMEOUT}s)"
+    while true; do
+        local now
+        now=$(date +%s)
+        if (( now > deadline )); then
+            log "ERROR: phase '$phase' exceeded timeout of ${PHASE_TIMEOUT}s"
+            return 1
+        fi
+
+        local info
+        if ! info=$(cli getblockchaininfo 2>/dev/null); then
+            if [[ -n "$DASHD_PID" ]] && ! kill -0 "$DASHD_PID" 2>/dev/null; then
+                log "ERROR: dashd exited while waiting for phase '$phase'; tail of log:"
+                tail -n 50 "$LOGFILE" >&2 || true
+                return 1
+            fi
+            log "WARN: getblockchaininfo failed; will retry"
+            sleep "$POLL_INTERVAL"
+            continue
+        fi
+
+        local blocks headers ibd progress
+        blocks=$(printf '%s' "$info" | sed -n 's/.*"blocks":[[:space:]]*\([0-9]*\).*/\1/p' | head -n1)
+        headers=$(printf '%s' "$info" | sed -n 's/.*"headers":[[:space:]]*\([0-9]*\).*/\1/p' | head -n1)
+        progress=$(printf '%s' "$info" | sed -n 's/.*"verificationprogress":[[:space:]]*\([0-9.eE+-]*\).*/\1/p' | head -n1)
+        ibd=$(printf '%s' "$info" | sed -n 's/.*"initialblockdownload":[[:space:]]*\(true\|false\).*/\1/p' | head -n1)
+
+        local peers
+        peers=$(cli getconnectioncount 2>/dev/null || echo 0)
+
+        log "phase=$phase blocks=$blocks headers=$headers ibd=$ibd progress=$progress peers=$peers"
+
+        # Detect when node has converged.
+        if [[ -n "$blocks" && -n "$headers" && "$blocks" == "$headers" && "$ibd" == "false" && "$headers" -gt 0 ]]; then
+            if indexes_synced "$blocks"; then
+                if [[ -n "$EXTERNAL_TIP_URL" ]]; then
+                    local external_tip
+                    if ! external_tip=$(fetch_external_tip); then
+                        return 1
+                    fi
+                    if (( blocks + TIP_TOLERANCE < external_tip )); then
+                        log "Local chain is internally converged at $blocks, but external tip is $external_tip; continuing"
+                        sleep "$POLL_INTERVAL"
+                        continue
+                    fi
+                fi
+                log "Node reports converged: blocks=$blocks headers=$headers ibd=false indexes=$INDEX_STATUS"
+                printf '%s' "$blocks"
+                return 0
+            fi
+            log "Node chain converged but indexes are not ready: blocks=$blocks indexes=$INDEX_STATUS"
+        fi
+
+        # Stagnation check: if blocks, validation progress, or index progress
+        # changed, reset counter.
+        if [[ "$blocks" != "$last_blocks" || "$progress" != "$last_progress" || "$INDEX_STATUS" != "$last_index_status" ]]; then
+            stagnant_iters=0
+            last_blocks="$blocks"
+            last_progress="$progress"
+            last_index_status="$INDEX_STATUS"
+        else
+            stagnant_iters=$((stagnant_iters + 1))
+            if (( stagnant_iters >= stagnant_limit )); then
+                log "ERROR: no progress for ${stagnant_iters} consecutive polls (~$(( stagnant_iters * POLL_INTERVAL ))s)"
+                return 1
+            fi
+        fi
+
+        sleep "$POLL_INTERVAL"
+    done
+}
+
+verify_tip() {
+    local phase="$1"
+    local achieved="$2"
+    local baseline="${3:-}"   # tip from earlier phase, if any
+    local baseline_hash="${4:-}"
+
+    if ! [[ "$achieved" =~ ^[0-9]+$ ]]; then
+        log "ERROR: phase '$phase' produced non-numeric tip: '$achieved'"
+        return 1
+    fi
+
+    # Compare to baseline from prior phase (reindex must not regress).
+    if [[ -n "$baseline" && "$baseline" =~ ^[0-9]+$ ]]; then
+        if (( achieved < baseline )); then
+            log "ERROR: phase '$phase' tip $achieved is below baseline $baseline"
+            return 1
+        fi
+        if [[ -n "$baseline_hash" ]]; then
+            local current_baseline_hash
+            if ! current_baseline_hash=$(block_hash_at_height "$baseline"); then
+                return 1
+            fi
+            if [[ "$current_baseline_hash" != "$baseline_hash" ]]; then
+                log "ERROR: phase '$phase' hash at baseline height $baseline changed"
+                log "ERROR: expected $baseline_hash, got $current_baseline_hash"
+                return 1
+            fi
+        fi
+    fi
+
+    # Compare to external source if configured.
+    if [[ -n "$EXTERNAL_TIP_URL" ]]; then
+        local external_tip
+        if ! external_tip=$(fetch_external_tip); then
+            return 1
+        fi
+        log "External tip reports height=$external_tip; local=$achieved (tolerance=$TIP_TOLERANCE)"
+        if (( achieved + TIP_TOLERANCE < external_tip )); then
+            log "ERROR: local tip $achieved trails external tip $external_tip by more than $TIP_TOLERANCE"
+            return 1
+        fi
+        return 0
+    fi
+
+    # Conservative fallback: require headers/blocks above a minimum so that an
+    # isolated node that "synced" to height 0 with no peers does not pass.
+    if (( achieved < MIN_HEADERS )); then
+        log "ERROR: tip $achieved is below MIN_HEADERS=$MIN_HEADERS for network=$NETWORK"
+        log "Hint: set --min-headers or --external-tip-url to tune this check."
+        return 1
+    fi
+
+    log "Tip $achieved meets conservative floor of $MIN_HEADERS for $NETWORK"
+    return 0
+}
+
+# shellcheck disable=SC2329  # invoked indirectly via `trap`
+cleanup() {
+    if (( KEEP_RUNNING )) && [[ -f "$PIDFILE" ]]; then
+        return
+    fi
+    if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+        log "cleanup: stopping dashd"
+        stop_node || true
+    fi
+}
+trap cleanup EXIT
+
+# ---- main ---------------------------------------------------------------
+
+log "Config: dashd=$DASHD cli=$DASH_CLI datadir=$DATADIR net_datadir=$NET_DATADIR network=$NETWORK mode=$MODE reindex_flag=$REINDEX_FLAG"
+log "Config: phase_timeout=${PHASE_TIMEOUT}s poll=${POLL_INTERVAL}s min_headers=$MIN_HEADERS tolerance=$TIP_TOLERANCE"
+[[ -n "$EXTERNAL_TIP_URL" ]] && log "Config: external_tip_url=$EXTERNAL_TIP_URL"
+
+# Refuse to run if a stale dashd is already holding the net-specific datadir.
+if [[ -f "$NET_DATADIR/.lock" ]] && fuser "$NET_DATADIR/.lock" >/dev/null 2>&1; then
+    log "ERROR: $NET_DATADIR appears to be in use by another dashd process. Aborting."
+    exit 1
+fi
+
+SYNC_TIP=""
+SYNC_HASH=""
+if [[ "$MODE" == "sync" || "$MODE" == "both" ]]; then
+    if ! start_node "sync"; then
+        exit 1
+    fi
+    if ! SYNC_TIP=$(wait_for_sync "sync"); then
+        log "Sync phase failed"
+        stop_node || true
+        exit 2
+    fi
+    if ! verify_tip "sync" "$SYNC_TIP" ""; then
+        stop_node || true
+        exit 4
+    fi
+    if ! SYNC_HASH=$(block_hash_at_height "$SYNC_TIP"); then
+        stop_node || true
+        exit 4
+    fi
+    log "Sync baseline: height=$SYNC_TIP hash=$SYNC_HASH"
+    if ! stop_node; then
+        exit 2
+    fi
+fi
+
+REINDEX_TIP=""
+if [[ "$MODE" == "reindex" || "$MODE" == "both" ]]; then
+    if ! start_node "reindex" "$REINDEX_FLAG"; then
+        exit 1
+    fi
+    if ! REINDEX_TIP=$(wait_for_sync "reindex"); then
+        log "Reindex phase failed"
+        stop_node || true
+        exit 3
+    fi
+    if ! verify_tip "reindex" "$REINDEX_TIP" "$SYNC_TIP" "$SYNC_HASH"; then
+        stop_node || true
+        exit 4
+    fi
+    if ! stop_node; then
+        exit 3
+    fi
+fi
+
+log "OK: sync_tip=${SYNC_TIP:-skipped} reindex_tip=${REINDEX_TIP:-skipped}"
+exit 0

--- a/doc/sync-reindex-ci.md
+++ b/doc/sync-reindex-ci.md
@@ -1,0 +1,210 @@
+# Daily Sync + Reindex CI
+
+The `Daily Sync + Reindex` workflow
+(`.github/workflows/sync-reindex.yml`) runs a full-node regression check
+once per day. It rebuilds `dashd` and `dash-cli` from the latest `develop`
+of `dashpay/dash`, resumes a persistent on-disk chain, advances to tip,
+restarts the node with `-reindex`, and verifies the node
+converges back to the same or a higher tip.
+
+The validation logic lives in
+[`contrib/devtools/sync_reindex_check.sh`](../contrib/devtools/sync_reindex_check.sh)
+and can be run by hand on any host with a built tree.
+
+## Why a stateful self-hosted runner
+
+Syncing testnet or mainnet from genesis takes hours-to-days. Hosted
+GitHub-Actions runners are wiped between jobs, so they would either
+re-sync from scratch on every run (uselessly slow and prone to
+timing-based false negatives) or be skipped entirely. The workflow is
+intentionally targeted at a **stateful self-hosted Linux runner** whose
+datadir survives across runs.
+
+Each daily invocation therefore measures the day's incremental delta plus
+a fresh `-reindex` over the accumulated chain — exactly the regression
+we care about.
+
+## Runner setup
+
+### 1. Register a self-hosted runner
+
+Register a runner on the repository with a label that uniquely identifies
+it as the sync/reindex host. The workflow defaults to the label
+`self-hosted-sync-reindex`; you can override this through the
+`RUNNER_SYNC_REINDEX` repository variable or the workflow's `runner`
+dispatch input.
+
+The host should provide:
+
+* Linux x86_64 or aarch64.
+* A C++ toolchain capable of building Dash Core (see
+  [`doc/build-unix.md`](build-unix.md)). The workflow uses the in-tree
+  `depends` system to avoid relying on distro package versions.
+* At least 200 GB of free disk for mainnet, 50 GB for testnet.
+* Enough RAM/CPU to keep up with the network at idle (4 cores / 8 GB is
+  the practical floor for testnet).
+* Outbound network connectivity for peering and for fetching depends
+  sources during the build.
+
+### 2. Provision a persistent datadir
+
+Create a directory the runner user can read and write that is **not**
+inside the runner work directory (the work directory is cleaned between
+jobs). The default path expected by the workflow is:
+
+```
+/var/lib/dashcore-ci/sync-reindex
+```
+
+The workflow stores each configured run under a stable subdirectory of the
+base path (for example `test/` for `network=test`); Dash Core still creates
+its own network subdirectory such as `testnet3/` inside that datadir.
+
+Override the base path with the `SYNC_REINDEX_DATADIR` repository
+variable when the runner stores the chain elsewhere (e.g. on a mounted
+data disk).
+
+The directory must exist and be writable before the workflow runs; the
+sanity-check step fails fast otherwise.
+
+### 3. Configure an external tip oracle
+
+The workflow requires `SYNC_REINDEX_EXTERNAL_TIP_URL`, or the matching
+`external_tip_url` dispatch input. It should point at an HTTP endpoint
+that returns either a bare integer block height or JSON with a `.height`
+field.
+
+The standalone script can run without an oracle. In that fallback mode it
+considers the node "synced" once
+`getblockchaininfo` reports `blocks == headers`, `initialblockdownload`
+is `false`, all enabled indexes from `getindexinfo` are synced to at least
+the chain height, and the height is above a conservative network-specific
+floor (one million for testnet, two million for mainnet). Tune the floor
+with `--min-headers` if needed. The workflow does not allow that fallback
+because a stateful runner could otherwise pass at yesterday's local tip.
+When an oracle is set, the script requires the local tip to be within
+`--tip-tolerance` blocks of it (default: 50) before a phase is considered
+converged, and any fetch or parse failure is fatal.
+
+### 4. (Optional) Tune build parallelism and extra args
+
+`SYNC_REINDEX_MAKEJOBS` (e.g. `-j8`) overrides the default `-j4` passed
+to `make`. Keep at least one core free for the running node if the host
+is also serving other workloads.
+
+`SYNC_REINDEX_EXTRA_DASHD_ARGS` is appended to every `dashd` invocation.
+This is mainly for uncommon networks. For example, Dash requires explicit
+`-port=<n>` and `-rpcport=<n>` when running `-devnet`, and named devnets
+should include `-devnet=<name>`. The script mirrors `-devnet=<name>` and
+`-rpcport=<n>` into `dash-cli` so RPC calls target the same node.
+
+## What the workflow runs
+
+1. Checks out `dashpay/dash@develop` (or the ref supplied via dispatch).
+2. Builds `depends` (no Qt, no wallet UI) and configures the source
+   tree.
+3. Builds only `src/dashd` and `src/dash-cli`.
+4. Invokes `contrib/devtools/sync_reindex_check.sh` against the
+   persistent datadir.
+
+The script:
+
+* Starts `dashd` and waits for the RPC to come up.
+* Polls `getblockchaininfo` / `getconnectioncount` until the node
+  converges (`blocks == headers`, `ibd == false`) or a per-phase timeout
+  expires, and requires every enabled `getindexinfo` index to be synced to
+  at least that chain height. When an external tip oracle is configured,
+  local convergence at an older persisted tip is not enough; the script keeps
+  polling until the local tip is also within tolerance of the oracle.
+* Calls `dash-cli stop`, then restarts the node with the reindex flag
+  (`-reindex` by default).
+* Waits for the reindexed node to converge again.
+* Verifies the post-reindex tip has not regressed below the post-sync
+  tip and that the post-sync block hash is still present at the same height
+  after reindex. This baseline check is strict; the external-tip tolerance
+  applies only to comparison with the oracle.
+
+### Why `-reindex` by default
+
+Dash enables `-txindex` by default, and startup rejects
+`-reindex-chainstate` while `-txindex` is active because chainstate-only
+replay can corrupt indexes. The daily workflow therefore uses full
+`-reindex`: it replays existing block files end-to-end, rebuilds indexes,
+and still avoids re-downloading blocks from peers.
+
+Maintainers can dispatch with `reindex_flag=-reindex-chainstate` only for
+a datadir that has compatible index settings from the initial sync onward,
+for example with `extra_args="-txindex=0"`.
+
+## Running locally
+
+```
+DATADIR=/var/lib/dashcore-ci/sync-reindex/test \
+EXTERNAL_TIP_URL=https://example.test-explorer.invalid/status \
+./contrib/devtools/sync_reindex_check.sh \
+    --dashd ./src/dashd \
+    --dash-cli ./src/dash-cli \
+    --datadir "$DATADIR" \
+    --network test \
+    --mode both
+```
+
+All flags are also configurable via environment variables; run with
+`--help` for the full list.
+
+## Interpreting failures
+
+Each failure prints a phase label, the most recent
+`getblockchaininfo` snapshot, and a tail of the dashd log. Exit codes
+are stable and meaningful:
+
+| Exit | Meaning |
+| ---- | ------- |
+| 0    | Sync and reindex both succeeded and tip checks pass. |
+| 1    | Misconfiguration or dashd failed to start (RPC never came up). |
+| 2    | Sync phase failed — timeout or stagnation. |
+| 3    | Reindex phase failed — timeout, stagnation, or shutdown hang. |
+| 4    | A phase finished but its tip is below the expected height. |
+
+When triaging a red run:
+
+1. **Download the `sync-reindex-logs-*` artifact** from the workflow
+   run. It contains generated tail files for the script log and any
+   `debug.log` files under the network datadir, plus `depends-build.log`,
+   `configure.log`, and `build.log`.
+2. **Confirm whether the build itself broke** (exit 1 with no
+   `getblockchaininfo` output, or a non-empty configure/build log
+   tail). If so, the failure is a develop-branch build regression, not
+   a sync regression.
+3. **Check the last poll line for `peers=`.** A node that converged at
+   a low height with `peers=0` is almost always a runner-network
+   problem, not a Dash Core bug — verify the runner can still reach
+   seeds.
+4. **For exit 3 (reindex), inspect `debug.log` around the restart
+   timestamp.** Reindex regressions usually surface as either an
+   assertion in evodb/quorum code or as a stall while replaying a
+   specific block height.
+5. **Compare the post-sync and post-reindex tips** in the script log.
+   A reindex that lands below the synced tip, or reports a different hash at
+   the post-sync baseline height, indicates corruption or divergence during
+   the chainstate rebuild.
+
+If the chain on disk has become corrupt in a way that is not the bug
+under investigation, ssh to the runner and either remove the
+network-specific subdirectory of `SYNC_REINDEX_DATADIR` or rename it for
+later forensic work, then re-dispatch the workflow. The next run will
+re-sync from genesis, which is slow but self-healing.
+
+## Limitations
+
+* This workflow does not run functional tests or unit tests; that is
+  intentional — those are covered by the existing `CI` and `Guix
+  Build` workflows.
+* `mode=sync` alone is the right choice if the runner's chain is
+  already known-good and the only thing being validated is incremental
+  follow-up; `mode=reindex` alone skips the daily catch-up and only
+  exercises the reindex code path. The default `both` is what gives
+  the regression signal.
+* The conservative `MIN_HEADERS` floor is only a standalone-script
+  fallback. The scheduled workflow requires an external tip URL so it
+  cannot pass at a stale local height.


### PR DESCRIPTION
# ci: add daily sync reindex workflow

## Issue being fixed or feature implemented

Dash Core does not currently have a scheduled, stateful regression check that
verifies a fresh build from `develop` can keep an existing node synced to tip
and then complete a full reindex without falling behind or diverging.

This adds a daily workflow for that long-running node-health signal.

## What was done?

- Added `.github/workflows/sync-reindex.yml`, a scheduled and manually
  dispatchable workflow that checks out `dashpay/dash@develop`, builds
  `dashd` and `dash-cli`, and runs a sync/reindex check on a persistent
  self-hosted runner datadir.
- Added `contrib/devtools/sync_reindex_check.sh`, which starts `dashd`, waits
  for chain and enabled indexes to converge, compares against an external tip
  source, restarts with `-reindex`, then verifies the node catches up again
  and still has the same block hash at the pre-reindex baseline height.
- Added `doc/sync-reindex-ci.md` with runner setup, required repository
  variables, manual run examples, failure interpretation, and limitations.

The workflow requires a stateful self-hosted runner and an external tip
endpoint. It intentionally fails fast if `SYNC_REINDEX_EXTERNAL_TIP_URL` is not
configured so a stale local datadir cannot pass as synced.

## How Has This Been Tested?

Local validation on macOS in the Dash Core worktree:

```bash
git diff --check
shellcheck contrib/devtools/sync_reindex_check.sh
bash -n contrib/devtools/sync_reindex_check.sh
ruby -e 'require "yaml";
  YAML.load_file(".github/workflows/sync-reindex.yml");
  puts "yaml ok"'
./contrib/devtools/sync_reindex_check.sh --help
```

Also passed the pre-PR automated code-review gate against `upstream/develop`
with recommendation `ship` and no significant issues found.

I did not run the full sync/reindex workflow locally because it requires a
configured persistent self-hosted runner, a populated network datadir, and an
external tip oracle.

## Breaking Changes

None. This adds a new opt-in scheduled workflow that will only run successfully
once repository variables and a matching self-hosted runner are configured.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository
  code-owners and collaborators only)_
