### PR TITLE
fix: use certifi fallback in github-merge

### DIFF
--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -18,6 +18,7 @@ import os
 from sys import stdin,stdout,stderr
 import argparse
 import hashlib
+import ssl
 import subprocess
 import sys
 import json
@@ -51,10 +52,72 @@ def git_config_get(option, default=None):
     except subprocess.CalledProcessError:
         return default
 
+_SSL_CONTEXT = None
+_SSL_CONTEXT_INITIALIZED = False
+
+def _ssl_path_has_trust_material(path, is_dir=False):
+    if path is None:
+        return False
+    try:
+        if is_dir:
+            if not os.path.isdir(path):
+                return False
+            with os.scandir(path) as entries:
+                for entry in entries:
+                    stem, dot, suffix = entry.name.partition('.')
+                    is_hash_link = (dot and len(stem) == 8 and suffix.isdigit() and
+                                    all(c in '0123456789abcdefABCDEF' for c in stem))
+                    if is_hash_link and entry.is_file(follow_symlinks=True):
+                        return True
+            return False
+        return os.path.isfile(path) and os.path.getsize(path) > 0
+    except OSError:
+        return True
+
+def _ssl_context_with_certifi_fallback():
+    '''
+    Return an SSL context backed by certifi's CA bundle when the default
+    trust store is empty (a common cause of urllib HTTPS failures against
+    api.github.com on machines where Python's OpenSSL cannot find system
+    certificates).
+
+    Returns None — leaving urllib's default behavior untouched — when:
+      * SSL_CERT_FILE or SSL_CERT_DIR is set (respect explicit user config),
+      * the default trust store already has CA certs or CA path material, or
+      * certifi is not installed.
+    '''
+    if 'SSL_CERT_FILE' in os.environ or 'SSL_CERT_DIR' in os.environ:
+        return None
+    try:
+        default_ctx = ssl.create_default_context()
+        default_paths = ssl.get_default_verify_paths()
+        if default_ctx.cert_store_stats().get('x509_ca', 0) > 0:
+            return None
+        if _ssl_path_has_trust_material(default_paths.cafile):
+            return None
+        if _ssl_path_has_trust_material(default_paths.capath, is_dir=True):
+            return None
+    except (OSError, ssl.SSLError):
+        return None
+    try:
+        import certifi
+    except ImportError:
+        return None
+    try:
+        return ssl.create_default_context(cafile=certifi.where())
+    except (OSError, ssl.SSLError):
+        return None
+
 def get_response(req_url, ghtoken):
+    global _SSL_CONTEXT, _SSL_CONTEXT_INITIALIZED
     req = Request(req_url)
     if ghtoken is not None:
         req.add_header('Authorization', 'token ' + ghtoken)
+    if not _SSL_CONTEXT_INITIALIZED:
+        _SSL_CONTEXT = _ssl_context_with_certifi_fallback()
+        _SSL_CONTEXT_INITIALIZED = True
+    if _SSL_CONTEXT is not None:
+        return urlopen(req, context=_SSL_CONTEXT)
     return urlopen(req)
 
 def retrieve_json(req_url, ghtoken, use_pagination=False):


### PR DESCRIPTION
## Issue being fixed or feature implemented

`contrib/devtools/github-merge.py` fetches pull request metadata from
`api.github.com` using Python's default `urllib` HTTPS behavior. On machines
where Python's OpenSSL cannot find system CA certificates, maintainers currently
need to export `SSL_CERT_FILE` to the `certifi` CA bundle before every merge run.

This improves the maintainer merge workflow without requiring a global shell workaround.

## What was done?

Added a small optional SSL-context fallback for GitHub API requests:

- Leave `urllib` defaults untouched when `SSL_CERT_FILE` or `SSL_CERT_DIR` is
  explicitly set.
- Leave `urllib` defaults untouched when Python's default trust store already
  has CA certificates.
- If the default trust store is empty and `certifi` is importable, use
  `certifi.where()` for the API request SSL context.
- Keep `certifi` optional; systems without it continue using the existing behavior.

## How Has This Been Tested?

Validated locally on macOS with Python 3.9.6:

- `python3 -m py_compile contrib/devtools/github-merge.py`
- `test/lint/lint-python.py`
- Targeted monkeypatch smoke test for:
  - `SSL_CERT_FILE` set
  - `SSL_CERT_DIR` set
  - populated default trust store
  - empty default trust store without `certifi`
  - empty default trust store with `certifi`
- Pre-PR code review gate: recommendation `ship`

## Breaking Changes

None. The fallback is only used when Python reports an empty default CA store,
no explicit `SSL_CERT_*` override is set, and `certifi` is installed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository
  code-owners and collaborators only)_
