### PR TITLE
fix: compilation error with modern gcc for leveldb subtree

### DIFF
--- a/src/leveldb/db/db_impl.cc
+++ b/src/leveldb/db/db_impl.cc
@@ -803,6 +803,7 @@ Status DBImpl::OpenCompactionOutputFile(CompactionState* compact) {
     pending_outputs_.insert(file_number);
     CompactionState::Output out;
     out.number = file_number;
+    out.file_size = 0;
     out.smallest.Clear();
     out.largest.Clear();
     compact->outputs.push_back(out);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Dash Core's build fails with gcc-16:

    In copy constructor 'constexpr leveldb::DBImpl::CompactionState::Output::Output(const leveldb::DBImpl::CompactionState::Output&)',
        inlined from 'constexpr _Tp* std::construct_at(_Tp*, _Args&& ...) [with _Tp = leveldb::DBImpl::CompactionState::Output; _Args = {const leveldb::DBImpl::CompactionState::Output&}]' at /usr/include/c++/16/bits/stl_construct.h:110:9,
        inlined from 'static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = leveldb::DBImpl::CompactionState::Output; _Args = {const leveldb::DBImpl::CompactionState::Output&}; _Tp = leveldb::DBImpl::CompactionState::Output]' at /usr/include/c++/16/bits/alloc_traits.h:716:21,
        inlined from 'constexpr void std::vector<_Tp, _Alloc>::_M_realloc_append(_Args&& ...) [with _Args = {const leveldb::DBImpl::CompactionState::Output&}; _Tp = leveldb::DBImpl::CompactionState::Output; _Alloc = std::allocator<leveldb::DBImpl::CompactionState::Output>]' at /usr/include/c++/16/bits/vector.tcc:594:26,
        inlined from 'constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = leveldb::DBImpl::CompactionState::Output; _Alloc = std::allocator<leveldb::DBImpl::CompactionState::Output>]' at /usr/include/c++/16/bits/stl_vector.h:1417:21,
        inlined from 'leveldb::Status leveldb::DBImpl::OpenCompactionOutputFile(CompactionState*)' at leveldb/db/db_impl.cc:808:31:
    leveldb/db/db_impl.cc:57:10: error: 'out.leveldb::DBImpl::CompactionState::Output::file_size' may be used uninitialized [-Werror=maybe-uninitialized]
       57 |   struct Output {
          |          ^~~~~~
    leveldb/db/db_impl.cc: In member function 'leveldb::Status leveldb::DBImpl::OpenCompactionOutputFile(CompactionState*)':
    leveldb/db/db_impl.cc:804:29: note: 'out' declared here
      804 |     CompactionState::Output out;



## What was done?
Original leveldb's commit is ad9b1c989380538bfb19c5c65df0d3f72d8ed62b Backported to Bitcoin Core by bitcoin/bitcoin#34470 Though, that too many unrelated changes meanwhile. That's temporary fix until leveldb's version won't be properly updated.



## How Has This Been Tested?
Together with https://github.com/dashpay/dash/pull/7392 I finally compile dash core with gcc 16 again.


## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

