### PR TITLE
fix: stabilize par help text in manpages

### DIFF
--- a/doc/man/dash-qt.1
+++ b/doc/man/dash-qt.1
@@ -128,13 +128,13 @@ Do not keep transactions in the mempool longer than <n> hours (default:
 .HP
 \fB\-par=\fR<n>
 .IP
-Set the number of script verification threads (\fB\-12\fR to 15, 0 = auto, <0 =
-leave that many cores free, default: 0)
+Set the number of script verification threads (0 = auto, <0 = leave that many
+cores free, max: 15, default: 0)
 .HP
 \fB\-parbls=\fR<n>
 .IP
-Set the number of BLS verification threads (\fB\-12\fR to 33, 0 = auto, <0 =
-leave that many cores free, default: 0)
+Set the number of BLS verification threads (0 = auto, <0 = leave that many
+cores free, max: 33, default: 0)
 .HP
 \fB\-persistmempool\fR
 .IP

--- a/doc/man/dashd.1
+++ b/doc/man/dashd.1
@@ -126,13 +126,13 @@ Do not keep transactions in the mempool longer than <n> hours (default:
 .HP
 \fB\-par=\fR<n>
 .IP
-Set the number of script verification threads (\fB\-12\fR to 15, 0 = auto, <0 =
-leave that many cores free, default: 0)
+Set the number of script verification threads (0 = auto, <0 = leave that many
+cores free, max: 15, default: 0)
 .HP
 \fB\-parbls=\fR<n>
 .IP
-Set the number of BLS verification threads (\fB\-12\fR to 33, 0 = auto, <0 =
-leave that many cores free, default: 0)
+Set the number of BLS verification threads (0 = auto, <0 = leave that many
+cores free, max: 33, default: 0)
 .HP
 \fB\-persistmempool\fR
 .IP

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -587,10 +587,10 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-maxrecsigsage=<n>", strprintf("Number of seconds to keep LLMQ recovery sigs (default: %u)", llmq::DEFAULT_MAX_RECOVERED_SIGS_AGE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-mempoolexpiry=<n>", strprintf("Do not keep transactions in the mempool longer than <n> hours (default: %u)", DEFAULT_MEMPOOL_EXPIRY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet: %s, devnet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex(), devnetChainParams->GetConsensus().nMinimumChainWork.GetHex()), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
-        -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    argsman.AddArg("-parbls=<n>", strprintf("Set the number of BLS verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
-        -GetNumCores(), llmq::MAX_BLSCHECK_THREADS, llmq::DEFAULT_BLSCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-par=<n>", strprintf("Set the number of script verification threads (0 = auto, <0 = leave that many cores free, max: %d, default: %d)",
+        MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-parbls=<n>", strprintf("Set the number of BLS verification threads (0 = auto, <0 = leave that many cores free, max: %d, default: %d)",
+        llmq::MAX_BLSCHECK_THREADS, llmq::DEFAULT_BLSCHECK_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-persistmempool", strprintf("Whether to save the mempool on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_MEMPOOL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-pid=<file>", strprintf("Specify pid file. Relative paths will be prefixed by a net-specific datadir location. (default: %s)", BITCOIN_PID_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-prune=<n>", strprintf("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex, -addressindex, -spentindex, -rescan and -disablegovernance=false. "


### PR DESCRIPTION
# fix: stabilize par help text in manpages

## Issue being fixed or feature implemented

Regenerating manpages currently records the local machine's CPU count in the
`-par` and `-parbls` help text. That makes otherwise unrelated release
manpage regeneration change those entries depending on which machine generated
the pages.

## What was done?

Updated the `-par` and `-parbls` help text to avoid printing the dynamic lower
bound derived from `GetNumCores()`.

Runtime behavior is unchanged: negative values still mean "leave that many
cores free", `0` still auto-detects, and the existing max/default values remain
documented. The checked-in `dashd` and `dash-qt` manpages were updated to match
the new stable generated text.

## How Has This Been Tested?

Tested on macOS arm64:

```bash
git diff --check
python3 -m py_compile contrib/devtools/gen-manpages.py
rg -n -e '\\fB\\-[0-9]+\\fR to' doc/man/dashd.1 doc/man/dash-qt.1
```

The grep command returned no matches, confirming the affected generated
manpages no longer contain a CPU-count-specific lower bound.

Also ran a pre-PR code review gate against the exact worktree diff:

```text
Recommendation: ship
```

Note: this worktree did not have configured Dash Core build artifacts and
`help2man` is not installed locally, so I did not rerun full manpage generation
from rebuilt binaries here. The manpage edits mirror the changed `src/init.cpp`
help text.

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository
  code-owners and collaborators only)_
