### PR TITLE
ci: update GitHub Actions pins for Node 24

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -11,11 +11,12 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  # issues: write is required so the action can manage labels and post comments on PRs
+  issues: write
   # Enforce other not needed permissions are off
   actions: none
   checks: none
   deployments: none
-  issues: none
   #metadata: read
   packages: none
   repository-projects: none
@@ -27,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are dirty
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@v3.1.0
         with:
           dirtyLabel: "needs rebase"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/merge-check.yml
+++ b/.github/workflows/merge-check.yml
@@ -1,7 +1,10 @@
 name: Check Merge Fast-Forward Only
 
 permissions:
+  contents: read
   pull-requests: write
+  # Required so we can apply labels to PRs (labels go through the issues API)
+  issues: write
 
 on:
   push:
@@ -42,11 +45,16 @@ jobs:
           fi
 
       - name: add labels
-        uses: actions-ecosystem/action-add-labels@v1
-        if: failure()
+        uses: actions/github-script@v8
+        if: failure() && github.event.pull_request
         with:
-          labels: |
-            needs rebase
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['needs rebase']
+            });
 
       - name: comment
         uses: mshick/add-pr-comment@v3

--- a/.github/workflows/release_docker_hub.yml
+++ b/.github/workflows/release_docker_hub.yml
@@ -33,7 +33,7 @@ jobs:
         echo "build_tag=${TAG#v}" >> $GITHUB_OUTPUT
 
     - name: Set suffix
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       id: suffix
       with:
         result-encoding: string

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
# CI action Node 24 pins

## Issue being fixed or feature implemented

GitHub Actions now warns that actions targeting Node.js 20 are deprecated and
are being forced to run on Node.js 24. Dash Core `develop` already has most of
the action updates, but a few workflows still pin older JavaScript action
versions.

## What was done?

Updated the remaining workflow action pins to Node 24-compatible versions:

- `eps1lon/actions-label-merge-conflict@v3.1.0`
- `actions/github-script@v8`
- `amannn/action-semantic-pull-request@v6`

Also replaced the deprecated `actions-ecosystem/action-add-labels@v1` usage in
the merge-check workflow with `actions/github-script@v8`, and granted the
minimal `issues: write` permission needed for PR labels/comments.

## How Has This Been Tested?

- `git diff --check upstream/develop..HEAD`
- Parsed all workflow YAML files with Ruby `YAML.load_file`
- Searched `.github/workflows` for the deprecated action pins that triggered the
  warning
- Ran the pre-PR code review gate; result: ship

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
