### PR TITLE
fix: bound pending recovered sig queue to prevent remote OOM

### DIFF
--- a/src/llmq/net_signing.cpp
+++ b/src/llmq/net_signing.cpp
@@ -257,6 +257,10 @@ void NetSigning::WorkThreadSigning()
         constexpr auto CLEANUP_INTERVAL{5s};
         if (cleanupThrottler.TryCleanup(CLEANUP_INTERVAL)) {
             m_sig_manager.Cleanup();
+            // Drop pending recovered sigs queued by banned peers so a flood's backlog does not
+            // persist after the peer is banned (RemoveBannedNodeStates only cleans the sig-shares
+            // subsystem, not m_sig_manager's pending recovered sigs).
+            m_sig_manager.RemoveNodesIf([this](NodeId node_id) { return m_peer_manager->PeerIsBanned(node_id); });
         }
 
         // TODO Wakeup when pending signing is needed?

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -394,7 +394,38 @@ void CSigningManager::VerifyAndProcessRecoveredSig(NodeId from, std::shared_ptr<
         return;
     }
 
+    // Backpressure: bound the pending queue so a peer cannot enqueue faster than we drain and
+    // exhaust memory. Drop silently (no misbehaviour) — verification is deferred to a single
+    // worker thread, so an honest peer can legitimately outrun the drain during a burst.
+    size_t total_pending{0};
+    for (const auto& node_entry : pendingRecoveredSigs) {
+        total_pending += node_entry.second.size();
+    }
+    if (total_pending >= MAX_PENDING_RECSIGS_TOTAL) {
+        LogPrint(BCLog::LLMQ, "CSigningManager::%s -- global pending recovered sigs cap reached (%d), dropping sig from node=%d\n",
+                 __func__, MAX_PENDING_RECSIGS_TOTAL, from);
+        return;
+    }
+    if (auto it = pendingRecoveredSigs.find(from);
+        it != pendingRecoveredSigs.end() && it->second.size() >= MAX_PENDING_RECSIGS_PER_NODE) {
+        LogPrint(BCLog::LLMQ, "CSigningManager::%s -- per-node pending recovered sigs cap reached (%d), dropping sig from node=%d\n",
+                 __func__, MAX_PENDING_RECSIGS_PER_NODE, from);
+        return;
+    }
+
     pendingRecoveredSigs[from].emplace_back(std::move(recoveredSig));
+}
+
+void CSigningManager::RemoveNodesIf(const std::function<bool(NodeId)>& predicate)
+{
+    LOCK(cs_pending);
+    for (auto it = pendingRecoveredSigs.begin(); it != pendingRecoveredSigs.end();) {
+        if (predicate(it->first)) {
+            it = pendingRecoveredSigs.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 bool CSigningManager::CollectPendingRecoveredSigsToVerify(
@@ -427,6 +458,17 @@ bool CSigningManager::CollectPendingRecoveredSigsToVerify(
             ns.erase(ns.begin());
             return !ns.empty();
         }, rnd);
+
+        // Prune drained (now-empty) node entries so the map only holds nodes with pending sigs.
+        // This keeps VerifyAndProcessRecoveredSig's global-cap scan cheap and reclaims the queues
+        // of disconnected nodes once drained, without waiting for them to be banned.
+        for (auto it = pendingRecoveredSigs.begin(); it != pendingRecoveredSigs.end();) {
+            if (it->second.empty()) {
+                it = pendingRecoveredSigs.erase(it);
+            } else {
+                ++it;
+            }
+        }
 
         if (retSigShares.empty()) {
             return false;

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -397,11 +397,7 @@ void CSigningManager::VerifyAndProcessRecoveredSig(NodeId from, std::shared_ptr<
     // Backpressure: bound the pending queue so a peer cannot enqueue faster than we drain and
     // exhaust memory. Drop silently (no misbehaviour) — verification is deferred to a single
     // worker thread, so an honest peer can legitimately outrun the drain during a burst.
-    size_t total_pending{0};
-    for (const auto& node_entry : pendingRecoveredSigs) {
-        total_pending += node_entry.second.size();
-    }
-    if (total_pending >= MAX_PENDING_RECSIGS_TOTAL) {
+    if (pendingRecoveredSigsCount >= MAX_PENDING_RECSIGS_TOTAL) {
         LogPrint(BCLog::LLMQ, "CSigningManager::%s -- global pending recovered sigs cap reached (%d), dropping sig from node=%d\n",
                  __func__, MAX_PENDING_RECSIGS_TOTAL, from);
         return;
@@ -414,6 +410,7 @@ void CSigningManager::VerifyAndProcessRecoveredSig(NodeId from, std::shared_ptr<
     }
 
     pendingRecoveredSigs[from].emplace_back(std::move(recoveredSig));
+    ++pendingRecoveredSigsCount;
 }
 
 void CSigningManager::RemoveNodesIf(const std::function<bool(NodeId)>& predicate)
@@ -421,6 +418,7 @@ void CSigningManager::RemoveNodesIf(const std::function<bool(NodeId)>& predicate
     LOCK(cs_pending);
     for (auto it = pendingRecoveredSigs.begin(); it != pendingRecoveredSigs.end();) {
         if (predicate(it->first)) {
+            pendingRecoveredSigsCount -= it->second.size();
             it = pendingRecoveredSigs.erase(it);
         } else {
             ++it;
@@ -442,6 +440,7 @@ bool CSigningManager::CollectPendingRecoveredSigsToVerify(
 
         // TODO: refactor it to remove duplicated code with `CSigSharesManager::CollectPendingSigSharesToVerify`
         std::unordered_set<std::pair<NodeId, uint256>, StaticSaltedHasher> uniqueSignHashes;
+        size_t erasedCount{0};
         IterateNodesRandom(pendingRecoveredSigs, [&]() {
             return uniqueSignHashes.size() < maxUniqueSessions;
         }, [&](NodeId nodeId, std::list<std::shared_ptr<const CRecoveredSig>>& ns) {
@@ -456,11 +455,13 @@ bool CSigningManager::CollectPendingRecoveredSigsToVerify(
                 retSigShares[nodeId].emplace_back(recSig);
             }
             ns.erase(ns.begin());
+            ++erasedCount;
             return !ns.empty();
         }, rnd);
+        pendingRecoveredSigsCount -= erasedCount;
 
         // Prune drained (now-empty) node entries so the map only holds nodes with pending sigs.
-        // This keeps VerifyAndProcessRecoveredSig's global-cap scan cheap and reclaims the queues
+        // This keeps VerifyAndProcessRecoveredSig's global-cap check cheap and reclaims the queues
         // of disconnected nodes once drained, without waiting for them to be banned.
         for (auto it = pendingRecoveredSigs.begin(); it != pendingRecoveredSigs.end();) {
             if (it->second.empty()) {

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -14,6 +14,7 @@
 #include <sync.h>
 #include <unordered_lru_cache.h>
 
+#include <functional>
 #include <memory>
 #include <string_view>
 #include <unordered_map>
@@ -159,6 +160,15 @@ public:
     [[nodiscard]] virtual RecoveredSigResult HandleNewRecoveredSig(const CRecoveredSig& recoveredSig) = 0;
 };
 
+// Backpressure bounds for the pending (not-yet-verified) recovered sig queue. Verification of an
+// incoming recovered sig is deferred to a single worker thread doing batched BLS verification,
+// while ingestion happens on the network threads without any crypto cost. Without a bound, a peer
+// (or several) can enqueue faster than the queue drains, growing memory without limit. These caps
+// bound the queue; over-cap messages are dropped silently (no misbehaviour) since an honest peer
+// can legitimately relay recovered sigs faster than we drain them during a burst.
+static constexpr size_t MAX_PENDING_RECSIGS_PER_NODE{1000};
+static constexpr size_t MAX_PENDING_RECSIGS_TOTAL{10000};
+
 class CSigningManager
 {
 private:
@@ -207,6 +217,9 @@ public:
         size_t maxUniqueSessions, std::unordered_map<NodeId, std::list<std::shared_ptr<const CRecoveredSig>>>& retSigShares,
         std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CBLSPublicKey, StaticSaltedHasher>& ret_pubkeys)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pending);
+    // Drop the pending (not-yet-verified) recovered sigs of any node matching the predicate, e.g.
+    // banned peers. Without this, a flooded peer's backlog would persist even after it is banned.
+    void RemoveNodesIf(const std::function<bool(NodeId)>& predicate) EXCLUSIVE_LOCKS_REQUIRED(!cs_pending);
     [[nodiscard]] std::vector<CRecoveredSigsListener*> GetListeners() const EXCLUSIVE_LOCKS_REQUIRED(!cs_listeners);
     // Returns true if recovered sigs should be send to listeners
     [[nodiscard]] bool ProcessRecoveredSig(const std::shared_ptr<const CRecoveredSig>& recoveredSig)

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -179,6 +179,9 @@ private:
     mutable Mutex cs_pending;
     // Incoming and not verified yet
     std::unordered_map<NodeId, std::list<std::shared_ptr<const CRecoveredSig>>> pendingRecoveredSigs GUARDED_BY(cs_pending);
+    // Running total of entries across all of pendingRecoveredSigs, kept in sync with it so the
+    // MAX_PENDING_RECSIGS_TOTAL check doesn't need to rescan the map on every incoming message.
+    size_t pendingRecoveredSigsCount GUARDED_BY(cs_pending){0};
     Uint256HashMap<std::shared_ptr<const CRecoveredSig>> pendingReconstructedRecoveredSigs GUARDED_BY(cs_pending);
 
     FastRandomContext rnd GUARDED_BY(cs_pending);


### PR DESCRIPTION
## Issue

Incoming `QSIGREC` (recovered signature) P2P messages are deserialized and appended to the per-node queue `CSigningManager::pendingRecoveredSigs` after only cheap gating checks (quorum exists/active, dedup by full hash). Actual verification is expensive (BLS) and is deferred to a single worker thread that drains only ~32 unique sign-hash sessions per cycle, whereas ingestion is crypto-free and happens on the network threads in parallel across connections.

Two problems compound:

- **No size bound.** `pendingRecoveredSigs` had no per-node or global cap, and the dedup check keys on the full message hash (which includes the signature), so it does not constrain a peer sending many distinct messages. Ingestion structurally outruns the drain.
- **No cleanup on ban/disconnect.** `RemoveBannedNodeStates` only cleans the separate sig-shares subsystem (`CSigSharesManager::nodeStates`); nothing purged `pendingRecoveredSigs` for banned or disconnected peers.

Net effect: a peer (or several) can grow the queue faster than it drains, increasing RSS until the node is OOM-killed — a remote, unauthenticated memory-exhaustion DoS. Highest impact against masternodes, which accept many inbound connections and run the LLMQ signing behind ChainLocks / InstantSend.

## Fix

- **Bound the queue** in `VerifyAndProcessRecoveredSig` with a per-node cap (`MAX_PENDING_RECSIGS_PER_NODE = 1000`) and a global cap (`MAX_PENDING_RECSIGS_TOTAL = 10000`). Over-cap messages are dropped **silently, without a misbehaviour score** — verification is single-threaded, so an honest peer can legitimately outrun the drain during a burst, and this is queue-depth backpressure rather than a protocol violation (contrast the per-message structural caps for sig-shares, which do ban).
- **Purge banned peers' queues** via a new `CSigningManager::RemoveNodesIf(predicate)` (mirroring `CSigSharesManager::RemoveNodesIf`), invoked from `WorkThreadSigning`'s periodic cleanup using `PeerIsBanned`.
- **Prune drained (empty) node entries** during collection, so the global-cap scan stays cheap and disconnected nodes' queues are reclaimed once drained without waiting for a ban.

With these caps the attacker-controllable pending queue is bounded to roughly **8 MB** worst case (10,000 entries × ~750 bytes resident per entry; the in-memory `CRecoveredSig` is 696 bytes vs. 193 on the wire, dominated by `CBLSLazySignature`). Previously it was unbounded.

## Testing

- `make check` targets build clean; full `dashd` builds and links.
- `feature_llmq_signing.py` passes — normal recovered-sig relay across masternodes is unaffected by the caps.
- `lint-whitespace`, `lint-includes`, `lint-circular-dependencies` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
