### PR TITLE
ci: hand built depends to source jobs via artifacts

### DIFF
--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -29,6 +29,9 @@ on:
       dep-opts:
         description: "DEP_OPTS used to build depends"
         value: ${{ jobs.check-cache.outputs.dep-opts }}
+      built-artifact:
+        description: "Artifact holding freshly built depends (empty when restored from cache)"
+        value: ${{ jobs.build.outputs.built-artifact }}
 
 jobs:
   check-cache:
@@ -100,6 +103,8 @@ jobs:
     needs: [check-cache]
     if: needs.check-cache.outputs.cache-hit != 'true'
     runs-on: ${{ inputs.runs-on }}
+    outputs:
+      built-artifact: depends-built-${{ inputs.build-target }}
     container:
       image: ${{ inputs.container-path }}
       options: --user root
@@ -139,7 +144,23 @@ jobs:
           env ${{ needs.check-cache.outputs.dep-opts }} make -j$(nproc) -C depends
 
       - name: Save depends cache
+        # Cache tokens on untrusted triggers are read-only (GitHub change,
+        # June 2026), so only trusted events can save the persistent cache
+        # for later read-only restores.
+        if: github.event_name != 'pull_request_target'
         uses: actions/cache/save@v5
         with:
           path: depends/built/${{ needs.check-cache.outputs.host }}
           key: ${{ needs.check-cache.outputs.cache-key }}
+
+      - name: Upload built depends
+        # Same-run handoff to build-src.yml for runs that cannot save the
+        # cache. Uploaded on every fresh build (cache/save only warns when
+        # the write is denied), so src jobs never depend on a save landing.
+        uses: actions/upload-artifact@v6
+        with:
+          name: depends-built-${{ inputs.build-target }}
+          path: depends/built/${{ needs.check-cache.outputs.host }}
+          compression-level: 0
+          retention-days: 1
+          overwrite: true

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: ""
+      depends-artifact:
+        description: "Artifact holding freshly built depends, used if the cache restore misses"
+        required: false
+        type: string
+        default: ""
       runs-on:
         description: "Runner label to use (e.g., ubuntu-24.04 or ubuntu-24.04-arm)"
         required: true
@@ -70,11 +75,29 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Restore depends cache
+        id: depends-cache
         uses: actions/cache/restore@v5
         with:
           path: depends/built/${{ inputs.depends-host }}
           key: ${{ inputs.depends-key }}
-          fail-on-cache-miss: true
+
+      - name: Download built depends
+        # Same-run handoff from build-depends.yml: pull_request_target runs
+        # have read-only cache tokens (GitHub change, June 2026), so freshly
+        # built depends arrive as an artifact instead of a cache entry. Also
+        # covers trusted runs whose cache save was denied (save only warns).
+        if: steps.depends-cache.outputs.cache-hit != 'true' && inputs.depends-artifact != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.depends-artifact }}
+          path: depends/built/${{ inputs.depends-host }}
+
+      - name: Check built depends are present
+        if: steps.depends-cache.outputs.cache-hit != 'true' && inputs.depends-artifact == ''
+        run: |
+          echo "::error::Depends cache restore missed and no built depends artifact was provided"
+          exit 1
+        shell: bash
 
       - name: Rebuild depends prefix
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,7 @@ jobs:
       depends-key: ${{ needs.depends-aarch64-linux.outputs.key }}
       depends-host: ${{ needs.depends-aarch64-linux.outputs.host }}
       depends-dep-opts: ${{ needs.depends-aarch64-linux.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-aarch64-linux.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   src-linux64:
@@ -215,6 +216,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64.outputs.key }}
       depends-host: ${{ needs.depends-linux64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-linux64.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   src-linux64_fuzz:
@@ -228,6 +230,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64.outputs.key }}
       depends-host: ${{ needs.depends-linux64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-linux64.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   src-linux64_multiprocess:
@@ -241,6 +244,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_multiprocess.outputs.key }}
       depends-host: ${{ needs.depends-linux64_multiprocess.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_multiprocess.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-linux64_multiprocess.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-arm64'] }}
 
   src-linux64_nowallet:
@@ -253,6 +257,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_nowallet.outputs.key }}
       depends-host: ${{ needs.depends-linux64_nowallet.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_nowallet.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-linux64_nowallet.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   src-linux64_sqlite:
@@ -266,6 +271,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64.outputs.key }}
       depends-host: ${{ needs.depends-linux64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-linux64.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   src-linux64_tsan:
@@ -279,6 +285,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64_multiprocess.outputs.key }}
       depends-host: ${{ needs.depends-linux64_multiprocess.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64_multiprocess.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-linux64_multiprocess.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-arm64'] }}
 
   src-linux64_ubsan:
@@ -292,6 +299,7 @@ jobs:
       depends-key: ${{ needs.depends-linux64.outputs.key }}
       depends-host: ${{ needs.depends-linux64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-linux64.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-linux64.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   src-mac:
@@ -304,6 +312,7 @@ jobs:
       depends-key: ${{ needs.depends-mac.outputs.key }}
       depends-host: ${{ needs.depends-mac.outputs.host }}
       depends-dep-opts: ${{ needs.depends-mac.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-mac.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   src-win64:
@@ -316,6 +325,7 @@ jobs:
       depends-key: ${{ needs.depends-win64.outputs.key }}
       depends-host: ${{ needs.depends-win64.outputs.host }}
       depends-dep-opts: ${{ needs.depends-win64.outputs.dep-opts }}
+      depends-artifact: ${{ needs.depends-win64.outputs.built-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   test-linux64:


### PR DESCRIPTION
## Summary

GitHub changed Actions cache behavior on June 26, 2026: untrusted triggers now receive read-only Actions cache tokens. See GitHub's changelog entry, ["Read-only Actions cache for untrusted triggers"](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/).

For `pull_request_target` runs, a depends job can still build dependencies successfully, but `actions/cache/save` only warns when the token cannot reserve/write the cache. The later source-build jobs then fail if their depends cache restore misses.

This PR keeps `build.yml` least-privileged (`actions: read`) and adds a same-run handoff for freshly built depends trees:

- trusted runs still save and reuse the persistent Actions cache;
- `pull_request_target` runs skip the denied cache save path;
- fresh depends builds are uploaded as short-lived artifacts;
- source jobs first try the cache, then download the artifact on cache miss;
- source jobs fail only if both the cache and the artifact are unavailable.

## Why

The old workflow assumed that if a depends job built `depends/built/<host>`, the result could be saved to the Actions cache for downstream source jobs. That is no longer true for low-trust PR-triggered runs: restore may be allowed, while save is denied.

The previous attempted fix granted `actions: write` at the top level. That was reverted because the workflow checks out and executes PR-controlled code, and writable Actions scope is the wrong security model for `pull_request_target`.

## Implementation

- `.github/workflows/build-depends.yml`
  - exposes a new `built-artifact` output;
  - skips persistent cache save on `pull_request_target`;
  - uploads `depends/built/<host>` as `depends-built-<target>` when a fresh build was needed.

- `.github/workflows/build-src.yml`
  - adds an optional `depends-artifact` input;
  - restores the persistent cache when present;
  - downloads the built-depends artifact when the cache misses;
  - errors only when there is no cache hit and no artifact to use.

- `.github/workflows/build.yml`
  - forwards each depends job's `built-artifact` output to the matching source jobs;
  - documents why the workflow stays at `actions: read`.

## Current CI caveat

The PR's own `pull_request_target` run cannot fully validate these reusable workflow changes yet, because GitHub runs reusable workflows from the base branch in this context. The current failing run shows source jobs using:

```text
dashpay/dash/.github/workflows/build-src.yml@refs/heads/develop
```

That means the red source jobs are still using `develop`'s old `fail-on-cache-miss: true` restore path, not this PR's artifact fallback.

## References

- [GitHub Changelog: Read-only Actions cache for untrusted triggers](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/)
- [GitHub dependency caching reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)
- [actions/cache README](https://github.com/actions/cache)

## Test plan

- [ ] After merge, trigger or observe a `pull_request_target` run that needs a fresh depends build.
- [ ] Confirm depends jobs skip the denied persistent cache save on `pull_request_target`.
- [ ] Confirm those depends jobs upload `depends-built-<target>` artifacts.
- [ ] Confirm source jobs restore from cache when available.
- [ ] Confirm source jobs download the built-depends artifact when the cache misses.
- [ ] Confirm trusted `push` runs still save persistent depends caches.
