### PR TITLE
test: fix LLMQ commitment log capture race

### DIFF
--- a/src/test/llmq_commitment_tests.cpp
+++ b/src/test/llmq_commitment_tests.cpp
@@ -21,6 +21,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <optional>
 
 using namespace llmq;
 using namespace llmq::testutils;
@@ -124,7 +125,7 @@ BOOST_FIXTURE_TEST_CASE(commitment_check_undersized_bitset_debug_log_test, RegTe
     };
 
     std::vector<std::string> log_lines;
-    LogCaptureGuard guard{log_lines};
+    std::optional<LogCaptureGuard> guard{std::in_place, log_lines};
     BOOST_REQUIRE(LogAcceptDebug(BCLog::LLMQ));
 
     CFinalCommitmentTxPayload payload;
@@ -167,6 +168,12 @@ BOOST_FIXTURE_TEST_CASE(commitment_check_undersized_bitset_debug_log_test, RegTe
     BOOST_CHECK(!llmq::CheckLLMQCommitment(util_params, tx, state));
     BOOST_CHECK(state.IsInvalid());
     BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-qc-height");
+
+    // Remove the callback before reading log_lines: callbacks run under the
+    // logger mutex from whichever thread logs, and RegTestingSetup has
+    // background threads that log concurrently. DeleteCallback takes the same
+    // mutex, so after this reset no thread can still be mutating log_lines.
+    guard.reset();
 
     // Locate the validMembers debug line emitted by CheckLLMQCommitment and
     // assert the loop was clamped: with an empty bitset the rendered list must


### PR DESCRIPTION
# Fix LLMQ Commitment Log Capture Race

## Issue being fixed or feature implemented

Fixes a flaky unit-test crash seen in `linux64_multiprocess-build / Build source`
while running `llmq_commitment_tests/commitment_check_undersized_bitset_debug_log_test`.

The failure was a segmentation fault, not a Boost assertion failure. The test
captured log lines into a local vector through `LogInstance().PushBackCallback`
and then scanned that vector while the callback was still registered. In
`RegTestingSetup`, background scheduler/LLMQ threads can log concurrently, so a
background callback could append to the vector while the test thread was
iterating it.

## What was done?

Held the log-capture guard in a `std::optional` and reset it immediately after
`CheckLLMQCommitment` returns, before reading `log_lines`.

`DeleteCallback` takes the same logger mutex used for callback dispatch, so once
the reset returns the test knows no logging thread is still mutating the vector.
Exception paths still get the existing RAII cleanup through the guard destructor.

## How Has This Been Tested?

Tested locally on macOS arm64:

```text
git diff --check
make -j8 -C src test/test_dash
TARGET=llmq_commitment_tests/commitment_check_undersized_bitset_debug_log_test
./test/test_dash \
  --run_test="$TARGET" \
  --catch_system_errors=no \
  -l test_suite \
  -- DEBUG_LOG_OUT
code-review \
  dashpay/dash \
  upstream/develop \
  fix/llmq-commitment-log-capture-crash \
  "Fix flaky LLMQ commitment unit-test segfault"
```

The pre-PR review gate returned `ship`.

## Breaking Changes

None. This is test-only.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
