### PR TITLE
fix: bound DKG contribution blob intake

### DIFF
--- a/src/llmq/net_dkg.cpp
+++ b/src/llmq/net_dkg.cpp
@@ -82,6 +82,7 @@ size_t MaxDKGMessageSize(std::string_view msg_type, const Consensus::LLMQParams&
 bool CheckDKGMessageStructure(std::string_view msg_type, const CDataStream& vRecv, const Consensus::LLMQParams& params)
 {
     const size_t size = params.size > 0 ? static_cast<size_t>(params.size) : 0;
+    const size_t min_size = params.minSize > 0 ? static_cast<size_t>(params.minSize) : 0;
     const size_t threshold = params.threshold > 0 ? static_cast<size_t>(params.threshold) : 0;
     try {
         CDataStream s(vRecv); // copy; deserialization does not advance the caller's stream
@@ -90,7 +91,7 @@ bool CheckDKGMessageStructure(std::string_view msg_type, const CDataStream& vRec
             s >> qc;
             return qc.vvec != nullptr && qc.vvec->size() == threshold &&
                    qc.contributions != nullptr &&
-                   qc.contributions->blobs.size() >= static_cast<size_t>(params.minSize) &&
+                   qc.contributions->blobs.size() >= min_size &&
                    qc.contributions->blobs.size() <= size;
         } else if (msg_type == NetMsgType::QCOMPLAINT) {
             CDKGComplaint qc;

--- a/src/llmq/net_dkg.cpp
+++ b/src/llmq/net_dkg.cpp
@@ -89,7 +89,9 @@ bool CheckDKGMessageStructure(std::string_view msg_type, const CDataStream& vRec
             CDKGContribution qc;
             s >> qc;
             return qc.vvec != nullptr && qc.vvec->size() == threshold &&
-                   qc.contributions != nullptr && qc.contributions->blobs.size() <= size;
+                   qc.contributions != nullptr &&
+                   qc.contributions->blobs.size() >= static_cast<size_t>(params.minSize) &&
+                   qc.contributions->blobs.size() <= size;
         } else if (msg_type == NetMsgType::QCOMPLAINT) {
             CDKGComplaint qc;
             s >> qc;

--- a/test/functional/feature_llmq_dkg_intake.py
+++ b/test/functional/feature_llmq_dkg_intake.py
@@ -16,7 +16,7 @@ Adversarial P2P tests for DKG message-intake hardening:
 The node must not crash; the sending peer must be scored (Misbehaving).
 """
 
-from test_framework.messages import ser_uint256
+from test_framework.messages import ser_compact_size, ser_uint256
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import DashTestFramework
 from test_framework.util import wait_until_helper
@@ -83,6 +83,21 @@ class DkgIntakeTest(DashTestFramework):
         # real in-progress quorum and reach the size/structural checks.
         return bytes([LLMQ_TEST]) + ser_uint256(int(self.quorum_hash, 16))
 
+    def qcontrib_payload(self, blob_count):
+        # CDKGContribution: llmqType, quorumHash, proTxHash, vvec, contributions, sig.
+        # LLMQ_TEST uses threshold=2/minSize=2 by default, so blob_count=1 is
+        # well-formed enough to deserialize but below the contribution lower bound.
+        r = self.quorum_hash_prefix()
+        r += ser_uint256(0)  # proTxHash
+        r += ser_compact_size(2) + b"\x00" * (2 * 48)  # BLSVerificationVector
+        r += b"\x00" * 48  # CBLSIESMultiRecipientBlobs::ephemeralPubKey
+        r += b"\x00" * 32  # CBLSIESMultiRecipientBlobs::ivSeed
+        r += ser_compact_size(blob_count)
+        for _ in range(blob_count):
+            r += ser_compact_size(32) + b"\x00" * 32
+        r += b"\x00" * 96  # sig
+        return r
+
     def add_verified_peer(self, node):
         peer = node.add_p2p_connection(P2PInterface())
         peer_id = get_p2p_id(node)
@@ -103,6 +118,7 @@ class DkgIntakeTest(DashTestFramework):
         self.test_unverified_sender_rejected(mn_node)
         self.test_oversized_rejected(mn_node)
         self.test_malformed_rejected(mn_node)
+        self.test_under_min_contribution_blobs_rejected(mn_node)
 
     def test_unverified_sender_rejected(self, node):
         self.log.info("Pushed DKG messages from a non-verified peer are rejected (Misbehaving 10 each)")
@@ -140,6 +156,16 @@ class DkgIntakeTest(DashTestFramework):
         payload = self.quorum_hash_prefix() + b"\x00\x00\x00\x00"
         with node.assert_debug_log(["malformed DKG message"]):
             peer.send_message(msg_dkg_raw(b"qcontrib", payload))
+            peer.sync_with_ping()
+        wait_for_banscore(node, peer_id, 100)
+        node.disconnect_p2ps()
+
+    def test_under_min_contribution_blobs_rejected(self, node):
+        self.log.info("QCONTRIB with fewer than minSize encrypted blobs is rejected (Misbehaving 100)")
+        peer, peer_id = self.add_verified_peer(node)
+        wait_for_banscore(node, peer_id, 0)
+        with node.assert_debug_log(["malformed DKG message"]):
+            peer.send_message(msg_dkg_raw(b"qcontrib", self.qcontrib_payload(blob_count=1)))
             peer.sync_with_ping()
         wait_for_banscore(node, peer_id, 100)
         node.disconnect_p2ps()


### PR DESCRIPTION
## Issue being fixed or feature implemented

The DKG intake hardening on `develop` pre-validates pushed `qcontrib` messages before retaining them. The valid configured envelope is `params.minSize <= actual members <= params.size`; the later DKG session worker still checks the exact `members.size()` once it has session context.

Without the lower bound, structurally well-formed but undersized qcontrib payloads can pass the cheap intake check and reach retention before the worker rejects them.

## What was done?

Tightened the cheap qcontrib structure check in `NetDKG` so encrypted contribution blob counts must be within the configured quorum bounds:

- at least `params.minSize`
- at most `params.size`

The exact member-count validation remains in the DKG worker.

Also added functional coverage for a qcontrib payload that deserializes cleanly but has fewer encrypted contribution blobs than `params.minSize`.

## How Has This Been Tested?

Run feature_asset_locks.py multiple times that has been faulty in the first place (by knst).

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
