### PR TITLE
fix(net): throttle per-object governance vote sync requests

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -34,6 +34,12 @@ constexpr std::chrono::seconds GOVERNANCE_ORPHAN_EXPIRATION_TIME{10min};
 constexpr std::chrono::seconds MAX_TIME_FUTURE_DEVIATION{1h};
 using governance::RELIABLE_PROPAGATION_TIME;
 
+bool IsSyncableObject(const std::shared_ptr<CGovernanceObject>& govobj)
+{
+    const auto& obj = *Assert(govobj);
+    return !obj.IsSetCachedDelete() && !obj.IsSetExpired();
+}
+
 class ScopedLockBool
 {
     bool& ref;
@@ -135,6 +141,38 @@ bool CGovernanceManager::HaveObjectForHash(const uint256& nHash) const
 {
     LOCK(cs_store);
     return (mapObjects.count(nHash) == 1 || mapPostponedObjects.count(nHash) == 1);
+}
+
+bool CGovernanceManager::HaveObjectForFetch(const uint256& nHash) const
+{
+    LOCK(cs_store);
+
+    if (mapErasedGovernanceObjects.count(nHash) != 0) {
+        return false;
+    }
+
+    auto it = mapObjects.find(nHash);
+    if (it != mapObjects.end()) {
+        return IsSyncableObject(it->second);
+    }
+
+    it = mapPostponedObjects.find(nHash);
+    if (it != mapPostponedObjects.end()) {
+        return IsSyncableObject(it->second);
+    }
+
+    return false;
+}
+
+bool CGovernanceManager::HaveSyncableObjectForHash(const uint256& nHash) const
+{
+    LOCK(cs_store);
+    const auto it = mapObjects.find(nHash);
+    if (it == mapObjects.end()) {
+        return false;
+    }
+
+    return IsSyncableObject(it->second);
 }
 
 bool CGovernanceManager::SerializeObjectForHash(const uint256& nHash, CDataStream& ss) const
@@ -332,6 +370,13 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, const st
 {
     LOCK2(::cs_main, cs_store);
     AddGovernanceObjectInternal(govobj, peer_str);
+}
+
+void CGovernanceManager::AddGovernanceObjectForTesting(const CGovernanceObject& govobj)
+{
+    AssertLockNotHeld(cs_store);
+    LOCK(cs_store);
+    mapObjects.emplace(govobj.GetHash(), std::make_shared<CGovernanceObject>(govobj));
 }
 
 void CGovernanceManager::CheckAndRemove()
@@ -624,14 +669,14 @@ std::vector<CInv> CGovernanceManager::GetSyncableVoteInvs(const uint256& nProp, 
         return {};
     }
 
-    const auto& govobj = *Assert(it->second);
-    if (govobj.IsSetCachedDelete() || govobj.IsSetExpired()) {
+    if (!IsSyncableObject(it->second)) {
         return {};
     }
 
     std::vector<CInv> invs;
     const auto tip_mn_list = m_dmnman.GetListAtChainTip();
 
+    const auto& govobj = *Assert(it->second);
     LOCK(govobj.cs);
     const auto& fileVotes = govobj.GetVoteFile();
     for (const auto& vote : fileVotes.GetVotes()) {
@@ -656,7 +701,7 @@ std::vector<CInv> CGovernanceManager::GetSyncableObjectInvs() const
     invs.reserve(mapObjects.size());
 
     for (const auto& [nHash, govobj] : mapObjects) {
-        if (Assert(govobj)->IsSetCachedDelete() || govobj->IsSetExpired()) {
+        if (!IsSyncableObject(govobj)) {
             continue;
         }
         invs.emplace_back(MSG_GOVERNANCE_OBJECT, nHash);

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -323,9 +323,17 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
     void AddGovernanceObject(CGovernanceObject& govobj, const std::string& peer_str)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store, !cs_relay);
+    /** Test-only helper: inserts an object into the syncable object store without
+     *  running collateral or chain validation. */
+    void AddGovernanceObjectForTesting(const CGovernanceObject& govobj)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
 
     // Thread-safe accessors
     bool HaveObjectForHash(const uint256& nHash) const
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
+    bool HaveObjectForFetch(const uint256& nHash) const
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
+    bool HaveSyncableObjectForHash(const uint256& nHash) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
     bool HaveVoteForHash(const uint256& nHash) const
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);

--- a/src/governance/net_governance.cpp
+++ b/src/governance/net_governance.cpp
@@ -15,8 +15,26 @@
 #include <netfulfilledman.h>
 #include <netmessagemaker.h>
 #include <scheduler.h>
+#include <streams.h>
+#include <version.h>
+
+#include <vector>
 
 class CConnman;
+
+namespace {
+bool IsEmptyBloomFilter(const CBloomFilter& filter)
+{
+    // CBloomFilter does not expose its backing bytes. Governance uses an empty
+    // filter as an object-fetch signal, so inspect the serialized vector field.
+    CDataStream serialized_filter{SER_NETWORK, PROTOCOL_VERSION};
+    serialized_filter << filter;
+
+    std::vector<unsigned char> filter_data;
+    serialized_filter >> filter_data;
+    return filter_data.empty();
+}
+} // namespace
 
 void NetGovernance::Schedule(CScheduler& scheduler)
 {
@@ -86,17 +104,39 @@ void NetGovernance::ProcessMessage(CNode& peer, const std::string& msg_type, CDa
         }
 
         LogPrint(BCLog::GOBJECT, "MNGOVERNANCESYNC -- syncing governance objects to our peer %s\n", peer.GetLogString());
-        if (nProp == uint256()) {
-            // Full sync of all governance objects
-            assert(m_netfulfilledman.IsValid());
-            if (m_netfulfilledman.HasFulfilledRequest(peer.addr, NetMsgType::MNGOVERNANCESYNC)) {
-                // Asking for the whole list multiple times in a short period of time is no good
-                LogPrint(BCLog::GOBJECT, "MNGOVERNANCESYNC -- peer already asked me for the list\n");
-                m_peer_manager->PeerMisbehaving(peer.GetId(), 20);
-                return;
-            }
-            m_netfulfilledman.AddFulfilledRequest(peer.addr, NetMsgType::MNGOVERNANCESYNC);
+        const bool full_sync{nProp == uint256()};
+        const bool object_fetch{!full_sync && IsEmptyBloomFilter(filter)};
+        // Nonzero govsync with an empty filter is used to retry missing-object
+        // fetches for orphan votes. Only full sync and actual known-object vote
+        // sync are fulfilled-request limited.
+        const bool track_request{full_sync || (!object_fetch && m_gov_manager.HaveSyncableObjectForHash(nProp))};
+        const std::string fulfilled_request{full_sync ?
+                                                NetMsgType::MNGOVERNANCESYNC :
+                                                strprintf("%s-votes-%s", NetMsgType::MNGOVERNANCESYNC,
+                                                          nProp.ToString())};
+        assert(m_netfulfilledman.IsValid());
+        if (track_request && m_netfulfilledman.HasFulfilledRequest(peer.addr, fulfilled_request)) {
+            // Asking for the same governance data multiple times in a short period of time is no good
+            LogPrint(BCLog::GOBJECT, "MNGOVERNANCESYNC -- peer already asked me for %s\n",
+                     full_sync ? "the list" : strprintf("votes for %s", nProp.ToString()));
+            m_peer_manager->PeerMisbehaving(peer.GetId(), 20);
+            return;
+        }
+        if (track_request) {
+            m_netfulfilledman.AddFulfilledRequest(peer.addr, fulfilled_request);
+        }
 
+        if (object_fetch) {
+            if (m_gov_manager.HaveObjectForFetch(nProp)) {
+                CNetMsgMaker msgMaker(peer.GetCommonVersion());
+                m_connman.PushMessage(&peer, msgMaker.Make(NetMsgType::INV,
+                                                           std::vector<CInv>{CInv{MSG_GOVERNANCE_OBJECT, nProp}}));
+            }
+            return;
+        }
+
+        if (full_sync) {
+            // Full sync of all governance objects
             auto invs = m_gov_manager.GetSyncableObjectInvs();
             LogPrint(BCLog::GOBJECT, "MNGOVERNANCESYNC -- syncing %d objects to peer=%d\n", invs.size(), peer.GetId());
 

--- a/src/test/governance_inv_tests.cpp
+++ b/src/test/governance_inv_tests.cpp
@@ -2,8 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/bloom.h>
 #include <governance/governance.h>
 #include <governance/net_governance.h>
+#include <governance/object.h>
 #include <masternode/meta.h>
 #include <masternode/sync.h>
 #include <net.h>
@@ -17,6 +19,7 @@
 #include <util/time.h>
 #include <version.h>
 
+#include <test/util/net.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
@@ -102,6 +105,38 @@ void CheckInvExpirationCycle(CGovernanceManager& govman, const CInv& inv)
     // After eviction the same inv must be accepted and recorded again.
     BOOST_CHECK(govman.ConfirmInventoryRequest(inv));
     BOOST_CHECK_EQUAL(govman.RequestedHashCacheSizeForTesting(), 1U);
+}
+
+size_t CountQueuedMessages(const CNode& peer, const std::string& msg_type)
+{
+    LOCK(peer.cs_vSend);
+    size_t count{0};
+    for (const auto& msg : peer.vSendMsg) {
+        if (msg.m_type == msg_type) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+size_t CountQueuedInventory(const CNode& peer, const CInv& expected_inv)
+{
+    LOCK(peer.cs_vSend);
+    size_t count{0};
+    for (const auto& msg : peer.vSendMsg) {
+        if (msg.m_type != NetMsgType::INV) {
+            continue;
+        }
+        CDataStream stream{msg.data, SER_NETWORK, PROTOCOL_VERSION};
+        std::vector<CInv> invs;
+        stream >> invs;
+        for (const auto& inv : invs) {
+            if (inv.type == expected_inv.type && inv.hash == expected_inv.hash) {
+                ++count;
+            }
+        }
+    }
+    return count;
 }
 } // namespace
 
@@ -214,6 +249,169 @@ BOOST_AUTO_TEST_CASE(net_governance_schedule_drives_check_and_remove)
     worker.join();
 
     BOOST_CHECK_EQUAL(m_node.govman->RequestedHashCacheSizeForTesting(), 0U);
+}
+
+BOOST_AUTO_TEST_CASE(per_object_vote_sync_is_fulfilled_request_limited)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    // NetGovernance::ProcessMessage ignores MNGOVERNANCESYNC until sync is
+    // fully finished; advance from GOVERNANCE to FINISHED.
+    m_node.mn_sync->SwitchToNextAsset();
+    BOOST_REQUIRE(m_node.mn_sync->IsSynced());
+
+    in_addr peer_in_addr{};
+    peer_in_addr.s_addr = htonl(0x01020305);
+    CNode peer{/*id=*/1,
+               /*sock=*/nullptr,
+               /*addrIn=*/CAddress{CService{peer_in_addr, 8333}, NODE_NETWORK},
+               /*nKeyedNetGroupIn=*/0,
+               /*nLocalHostNonceIn=*/0,
+               /*addrBindIn=*/CAddress{},
+               /*addrNameIn=*/std::string{},
+               /*conn_type_in=*/ConnectionType::INBOUND,
+               /*inbound_onion=*/false};
+    peer.nVersion = PROTOCOL_VERSION;
+    peer.SetCommonVersion(PROTOCOL_VERSION);
+    m_node.peerman->InitializeNode(peer, NODE_NETWORK);
+    peer.fSuccessfullyConnected = true;
+
+    auto make_request_stream = [](const uint256& object_hash, const CBloomFilter& filter) {
+        CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+        stream << object_hash << filter;
+        return stream;
+    };
+
+    NetGovernance net_gov(m_node.peerman.get(), *m_node.govman, *m_node.mn_sync,
+                          *m_node.netfulfilledman, *m_node.connman);
+    auto& connman = static_cast<ConnmanTestMsg&>(*m_node.connman);
+    CNodeStateStats stats;
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 0);
+
+    const CBloomFilter vote_filter{1, 0.001, 0, BLOOM_UPDATE_NONE};
+    CGovernanceObject postponed_object{uint256(), /*revision=*/1, GetTime(), uint256::ONE, /*data=*/{}};
+    m_node.govman->AddPostponedObject(postponed_object);
+
+    const uint256 postponed_object_hash{postponed_object.GetHash()};
+    const std::string postponed_vote_sync_request{strprintf("%s-votes-%s", NetMsgType::MNGOVERNANCESYNC,
+                                                            postponed_object_hash.ToString())};
+    auto postponed_stream = make_request_stream(postponed_object_hash, vote_filter);
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, postponed_stream);
+
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, postponed_vote_sync_request));
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 0);
+
+    auto duplicate_postponed_stream = make_request_stream(postponed_object_hash, vote_filter);
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, duplicate_postponed_stream);
+
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 0);
+
+    CGovernanceObject syncable_object{uint256(), /*revision=*/1, GetTime() + 1, uint256S("02"), /*data=*/{}};
+    m_node.govman->AddGovernanceObjectForTesting(syncable_object);
+
+    const uint256 syncable_object_hash{syncable_object.GetHash()};
+    const std::string syncable_vote_sync_request{strprintf("%s-votes-%s", NetMsgType::MNGOVERNANCESYNC,
+                                                           syncable_object_hash.ToString())};
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, syncable_vote_sync_request));
+
+    connman.FlushSendBuffer(peer);
+    auto syncable_object_fetch_stream = make_request_stream(syncable_object_hash, CBloomFilter{});
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, syncable_object_fetch_stream);
+
+    BOOST_CHECK_EQUAL(CountQueuedInventory(peer, CInv{MSG_GOVERNANCE_OBJECT, syncable_object_hash}), 1U);
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, syncable_vote_sync_request));
+    BOOST_CHECK_EQUAL(CountQueuedMessages(peer, NetMsgType::SYNCSTATUSCOUNT), 0U);
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 0);
+
+    connman.FlushSendBuffer(peer);
+    auto duplicate_syncable_object_fetch_stream = make_request_stream(syncable_object_hash, CBloomFilter{});
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, duplicate_syncable_object_fetch_stream);
+
+    BOOST_CHECK_EQUAL(CountQueuedInventory(peer, CInv{MSG_GOVERNANCE_OBJECT, syncable_object_hash}), 1U);
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, syncable_vote_sync_request));
+    BOOST_CHECK_EQUAL(CountQueuedMessages(peer, NetMsgType::SYNCSTATUSCOUNT), 0U);
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 0);
+
+    connman.FlushSendBuffer(peer);
+    auto syncable_stream = make_request_stream(syncable_object_hash, vote_filter);
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, syncable_stream);
+
+    BOOST_CHECK(m_node.netfulfilledman->HasFulfilledRequest(peer.addr, syncable_vote_sync_request));
+    BOOST_CHECK_EQUAL(CountQueuedMessages(peer, NetMsgType::SYNCSTATUSCOUNT), 1U);
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 0);
+
+    auto duplicate_syncable_stream = make_request_stream(syncable_object_hash, vote_filter);
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, duplicate_syncable_stream);
+
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 20);
+
+    connman.FlushSendBuffer(peer);
+    CGovernanceObject empty_filter_object{uint256(), /*revision=*/1, GetTime() + 2, uint256S("03"), /*data=*/{}};
+    m_node.govman->AddPostponedObject(empty_filter_object);
+    const uint256 empty_filter_object_hash{empty_filter_object.GetHash()};
+    const std::string empty_filter_vote_request{strprintf("%s-votes-%s", NetMsgType::MNGOVERNANCESYNC,
+                                                          empty_filter_object_hash.ToString())};
+    auto empty_filter_stream = make_request_stream(empty_filter_object_hash, CBloomFilter{});
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, empty_filter_stream);
+
+    BOOST_CHECK_EQUAL(CountQueuedInventory(peer, CInv{MSG_GOVERNANCE_OBJECT, empty_filter_object_hash}), 1U);
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, empty_filter_vote_request));
+    BOOST_CHECK_EQUAL(CountQueuedMessages(peer, NetMsgType::SYNCSTATUSCOUNT), 0U);
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 20);
+
+    connman.FlushSendBuffer(peer);
+    auto duplicate_empty_filter_stream = make_request_stream(empty_filter_object_hash, CBloomFilter{});
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, duplicate_empty_filter_stream);
+
+    BOOST_CHECK_EQUAL(CountQueuedInventory(peer, CInv{MSG_GOVERNANCE_OBJECT, empty_filter_object_hash}), 1U);
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, empty_filter_vote_request));
+    BOOST_CHECK_EQUAL(CountQueuedMessages(peer, NetMsgType::SYNCSTATUSCOUNT), 0U);
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 20);
+
+    const uint256 unknown_vote_hash{uint256S("09")};
+    const std::string unknown_vote_request{strprintf("%s-votes-%s", NetMsgType::MNGOVERNANCESYNC,
+                                                     unknown_vote_hash.ToString())};
+    auto unknown_vote_stream = make_request_stream(unknown_vote_hash, vote_filter);
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, unknown_vote_stream);
+
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, unknown_vote_request));
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 20);
+
+    auto duplicate_unknown_vote_stream = make_request_stream(unknown_vote_hash, vote_filter);
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, duplicate_unknown_vote_stream);
+
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, unknown_vote_request));
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 20);
+
+    const uint256 object_fetch_hash{uint256S("0a")};
+    const std::string object_fetch_request{strprintf("%s-votes-%s", NetMsgType::MNGOVERNANCESYNC,
+                                                     object_fetch_hash.ToString())};
+    auto object_fetch_stream = make_request_stream(object_fetch_hash, CBloomFilter{});
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, object_fetch_stream);
+
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, object_fetch_request));
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 20);
+
+    auto duplicate_object_fetch_stream = make_request_stream(object_fetch_hash, CBloomFilter{});
+    net_gov.ProcessMessage(peer, NetMsgType::MNGOVERNANCESYNC, duplicate_object_fetch_stream);
+
+    BOOST_CHECK(!m_node.netfulfilledman->HasFulfilledRequest(peer.addr, object_fetch_request));
+    BOOST_REQUIRE(m_node.peerman->GetNodeStateStats(peer.GetId(), stats));
+    BOOST_CHECK_EQUAL(stats.m_misbehavior_score, 20);
+
+    m_node.peerman->FinalizeNode(peer);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Issue being fixed or feature implemented
- Per-object `MNGOVERNANCESYNC` vote requests were not recorded in `NetFulfilledRequestManager`, unlike full governance sync requests.
- A peer could repeatedly ask for votes for the same governance object and make the node rescan/build the same vote inventory again. This is a low-cost CPU/lock-work concern, not a crash/OOM primitive.

## What was done?
- Add a fulfilled-request key for per-object vote sync requests: `MNGOVERNANCESYNC-votes-<object hash>`.
- Return early and score repeat requests from the same peer/address.
- Add unit coverage asserting the per-object request is registered as fulfilled.

## How Has This Been Tested?
- `git diff --check upstream/develop..HEAD`
- `COMMIT_RANGE=upstream/develop..HEAD test/lint/lint-whitespace.py`
- Not run locally: `src/test/test_dash --run_test=governance_inv_tests/per_object_vote_sync_is_fulfilled_request_limited` because this fresh worktree has no configured build/test binary.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_