### PR TITLE
fix(net): bound quorum rotation base hash requests

### DIFF
--- a/src/llmq/snapshot.h
+++ b/src/llmq/snapshot.h
@@ -98,7 +98,7 @@ public:
 
     std::vector<uint256> baseBlockHashes;
     uint256 blockRequestHash;
-    bool extraShare;
+    bool extraShare{false};
 
     template <typename Stream>
     void Serialize(Stream& s) const

--- a/src/llmq/snapshot.h
+++ b/src/llmq/snapshot.h
@@ -92,13 +92,34 @@ public:
 class CGetQuorumRotationInfo
 {
 public:
+    // 256 entries cover more than ten days of hourly DIP0024 rotation bases
+    // while bounding peer-controlled allocation and cs_main work.
+    static constexpr size_t MAX_BASE_BLOCK_HASHES{256};
+
     std::vector<uint256> baseBlockHashes;
     uint256 blockRequestHash;
     bool extraShare;
 
-    SERIALIZE_METHODS(CGetQuorumRotationInfo, obj)
+    template <typename Stream>
+    void Serialize(Stream& s) const
     {
-        READWRITE(obj.baseBlockHashes, obj.blockRequestHash, obj.extraShare);
+        s << baseBlockHashes << blockRequestHash << extraShare;
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        const size_t base_block_hashes_size{ReadCompactSize(s)};
+        if (base_block_hashes_size > MAX_BASE_BLOCK_HASHES) {
+            throw std::ios_base::failure("CGetQuorumRotationInfo::baseBlockHashes size too large");
+        }
+        baseBlockHashes.clear();
+        baseBlockHashes.reserve(base_block_hashes_size);
+        while (baseBlockHashes.size() < base_block_hashes_size) {
+            baseBlockHashes.emplace_back();
+            s >> baseBlockHashes.back();
+        }
+        s >> blockRequestHash >> extraShare;
     }
 };
 

--- a/src/test/llmq_snapshot_tests.cpp
+++ b/src/test/llmq_snapshot_tests.cpp
@@ -245,6 +245,16 @@ BOOST_AUTO_TEST_CASE(get_quorum_rotation_info_serialization_test)
     BOOST_CHECK(TestSerializationRoundtrip(emptyInfo));
 }
 
+BOOST_AUTO_TEST_CASE(get_quorum_rotation_info_rejects_oversized_base_block_hashes)
+{
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    WriteCompactSize(stream, CGetQuorumRotationInfo::MAX_BASE_BLOCK_HASHES + 1);
+
+    CGetQuorumRotationInfo getInfo;
+    BOOST_CHECK_THROW(stream >> getInfo, std::ios_base::failure);
+    BOOST_CHECK(getInfo.baseBlockHashes.empty());
+}
+
 BOOST_AUTO_TEST_CASE(quorum_rotation_info_serialization_test)
 {
     // Note: mnListDiff{smth} testing requires proper CSimplifiedMNListDiff setup


### PR DESCRIPTION
## Issue being fixed or feature implemented

`GETQUORUMROTATIONINFO` accepts a peer-provided `baseBlockHashes` vector and later uses it for quorum rotation work. This adds an explicit request-size bound before materializing the vector.

## What was done?

- Add `CGetQuorumRotationInfo::MAX_BASE_BLOCK_HASHES`.
- Bound `baseBlockHashes` during deserialization.
- Add unit coverage for rejecting oversized base-hash vectors.

## How Has This Been Tested?

- `git diff --check upstream/develop..HEAD`
- `COMMIT_RANGE=upstream/develop..HEAD test/lint/lint-whitespace.py`
- `git diff --check f2ae9f0362fe6e5e3a01554631c8231e3cecf8bf..HEAD`

CI passed on the prior code-equivalent head `ce59cd9eb3360232e6b2e565dc26a60d83fce63d`; the latest push only adds a source comment explaining the bound.

## Breaking Changes

None for normal supported peers. This tightens P2P request deserialization and should be treated as develop-only, not a v23.1.x backport, unless maintainers explicitly approve the protocol behavior change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
