### PR TITLE
ci: split blacksmith runner selection by architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
       runner-amd64: ${{ steps.select-runner.outputs.runner_amd64 }}
       runner-arm64: ${{ steps.select-runner.outputs.runner_arm64 }}
       use-blacksmith: ${{ steps.select-runner.outputs.use_blacksmith }}
+      use-blacksmith-amd64: ${{ steps.select-runner.outputs.use_blacksmith_amd64 }}
+      use-blacksmith-arm64: ${{ steps.select-runner.outputs.use_blacksmith_arm64 }}
       backlog-count: ${{ steps.select-runner.outputs.backlog_count }}
       decision-reason: ${{ steps.select-runner.outputs.decision_reason }}
       base-image-digest: ${{ steps.base-image.outputs.digest }}
@@ -54,6 +56,7 @@ jobs:
         if: ${{ steps.skip-check.outputs.skip == 'false' }}
         env:
           BACKLOG_THRESHOLD: "10"
+          BACKLOG_THRESHOLD_ARM64: "30"
           GH_TOKEN: ${{ github.token }}
           RUNNER_AMD64_VAR: ${{ vars.RUNNER_AMD64 }}
           RUNNER_ARM64_VAR: ${{ vars.RUNNER_ARM64 }}

--- a/.github/workflows/select_dynamic_runner.py
+++ b/.github/workflows/select_dynamic_runner.py
@@ -135,6 +135,7 @@ def select_runners(
     event_name: str,
     event: Dict,
     threshold: int,
+    arm64_threshold: int,
     runner_amd64_var: str,
     runner_arm64_var: str,
     fetch_json: Callable[[str], Tuple[Dict, Dict[str, str]]],
@@ -158,30 +159,46 @@ def select_runners(
     except Exception as exc:  # noqa: BLE001
         measurement_error = "{}: {}".format(type(exc).__name__, exc)
 
-    use_blacksmith = False
     decision_parts = []
 
     if label_override:
-        use_blacksmith = True
         decision_parts.append("label:blacksmith-ci")
     elif measurement_error is not None:
         decision_parts.append("metric-unavailable")
-    elif backlog_count_value > threshold:
-        use_blacksmith = True
-        decision_parts.append("backlog:{}>{}".format(backlog_count_value, threshold))
     else:
-        decision_parts.append("backlog:{}<={}".format(backlog_count_value, threshold))
+        decision_parts.append(
+            "amd64:backlog:{}{}".format(
+                backlog_count_value,
+                ">{}".format(threshold)
+                if backlog_count_value > threshold else "<={}".format(threshold),
+            )
+        )
+        decision_parts.append(
+            "arm64:backlog:{}{}".format(
+                backlog_count_value,
+                ">{}".format(arm64_threshold)
+                if backlog_count_value > arm64_threshold else "<={}".format(arm64_threshold),
+            )
+        )
+
+    use_blacksmith_amd64 = label_override or (
+        measurement_error is None and backlog_count_value > threshold
+    )
+    use_blacksmith_arm64 = label_override or (
+        measurement_error is None and backlog_count_value > arm64_threshold
+    )
 
     runner_amd64 = DEFAULT_RUNNER_AMD64
     runner_arm64 = DEFAULT_RUNNER_ARM64
     fallback_parts: List[str] = []
 
-    if use_blacksmith:
+    if use_blacksmith_amd64:
         if runner_amd64_var:
             runner_amd64 = runner_amd64_var
         else:
             fallback_parts.append("amd64-github-fallback")
 
+    if use_blacksmith_arm64:
         if runner_arm64_var:
             runner_arm64 = runner_arm64_var
         else:
@@ -194,7 +211,9 @@ def select_runners(
     return {
         "runner_amd64": runner_amd64,
         "runner_arm64": runner_arm64,
-        "use_blacksmith": "true" if use_blacksmith else "false",
+        "use_blacksmith": "true" if use_blacksmith_amd64 or use_blacksmith_arm64 else "false",
+        "use_blacksmith_amd64": "true" if use_blacksmith_amd64 else "false",
+        "use_blacksmith_arm64": "true" if use_blacksmith_arm64 else "false",
         "backlog_count": backlog_count,
         "decision_reason": ";".join(decision_parts),
         "label_override": "true" if label_override else "false",
@@ -225,8 +244,13 @@ def write_step_summary(path: Optional[str], outputs: Dict[str, str]) -> None:
         )
         fh.write("- Aggregated queued jobs: {}\n".format(outputs["backlog_count"]))
         fh.write(
-            "- Use Blacksmith: {}\n".format(
-                "yes" if outputs["use_blacksmith"] == "true" else "no"
+            "- Use Blacksmith amd64: {}\n".format(
+                "yes" if outputs["use_blacksmith_amd64"] == "true" else "no"
+            )
+        )
+        fh.write(
+            "- Use Blacksmith arm64: {}\n".format(
+                "yes" if outputs["use_blacksmith_arm64"] == "true" else "no"
             )
         )
         fh.write("- amd64 runner: `{}`\n".format(outputs["runner_amd64"]))
@@ -234,7 +258,15 @@ def write_step_summary(path: Optional[str], outputs: Dict[str, str]) -> None:
         fh.write("- Decision: `{}`\n".format(outputs["decision_reason"]))
 
 
+def env_int(name: str, default: int) -> int:
+    value = os.environ.get(name, "")
+    if value == "":
+        return default
+    return int(value)
+
+
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    default_backlog_threshold = env_int("BACKLOG_THRESHOLD", 10)
     parser = argparse.ArgumentParser(description="Select GitHub Actions runners dynamically.")
     parser.add_argument(
         "--event-name",
@@ -249,8 +281,14 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--backlog-threshold",
         type=int,
-        default=int(os.environ.get("BACKLOG_THRESHOLD", "10")),
+        default=default_backlog_threshold,
         help="Queued job threshold for switching to Blacksmith",
+    )
+    parser.add_argument(
+        "--arm64-backlog-threshold",
+        type=int,
+        default=env_int("BACKLOG_THRESHOLD_ARM64", default_backlog_threshold * 3),
+        help="Queued job threshold for switching arm64 jobs to Blacksmith",
     )
     parser.add_argument(
         "--runner-amd64-var",
@@ -299,6 +337,7 @@ def main(argv: Sequence[str]) -> int:
         event_name=args.event_name,
         event=event,
         threshold=args.backlog_threshold,
+        arm64_threshold=args.arm64_backlog_threshold,
         runner_amd64_var=args.runner_amd64_var,
         runner_arm64_var=args.runner_arm64_var,
         fetch_json=fetch_json,

--- a/.github/workflows/test_select_dynamic_runner.py
+++ b/.github/workflows/test_select_dynamic_runner.py
@@ -81,6 +81,7 @@ class SelectDynamicRunnerTest(unittest.TestCase):
             event_name="pull_request_target",
             event={"pull_request": {"labels": [{"name": "blacksmith-ci"}]}},
             threshold=10,
+            arm64_threshold=30,
             runner_amd64_var="blacksmith-amd64",
             runner_arm64_var="blacksmith-arm64",
             fetch_json=lambda _url: ({"workflow_runs": []}, {}),
@@ -88,11 +89,13 @@ class SelectDynamicRunnerTest(unittest.TestCase):
         )
 
         self.assertEqual(outputs["use_blacksmith"], "true")
+        self.assertEqual(outputs["use_blacksmith_amd64"], "true")
+        self.assertEqual(outputs["use_blacksmith_arm64"], "true")
         self.assertEqual(outputs["runner_amd64"], "blacksmith-amd64")
         self.assertEqual(outputs["runner_arm64"], "blacksmith-arm64")
         self.assertIn("label:blacksmith-ci", outputs["decision_reason"])
 
-    def test_backlog_threshold_selects_blacksmith(self):
+    def test_backlog_threshold_selects_blacksmith_amd64_only(self):
         repo = "dashpay/dash"
         queued_url = (
             "https://api.github.com/repos/{}/actions/runs?status=queued&per_page=100"
@@ -114,6 +117,7 @@ class SelectDynamicRunnerTest(unittest.TestCase):
             event_name="push",
             event={},
             threshold=10,
+            arm64_threshold=30,
             runner_amd64_var="blacksmith-amd64",
             runner_arm64_var="blacksmith-arm64",
             fetch_json=lambda url: responses[url],
@@ -121,8 +125,51 @@ class SelectDynamicRunnerTest(unittest.TestCase):
         )
 
         self.assertEqual(outputs["use_blacksmith"], "true")
+        self.assertEqual(outputs["use_blacksmith_amd64"], "true")
+        self.assertEqual(outputs["use_blacksmith_arm64"], "false")
         self.assertEqual(outputs["backlog_count"], "11")
-        self.assertIn("backlog:11>10", outputs["decision_reason"])
+        self.assertEqual(outputs["runner_amd64"], "blacksmith-amd64")
+        self.assertEqual(outputs["runner_arm64"], MODULE.DEFAULT_RUNNER_ARM64)
+        self.assertIn("amd64:backlog:11>10", outputs["decision_reason"])
+        self.assertIn("arm64:backlog:11<=30", outputs["decision_reason"])
+
+    def test_arm64_requires_higher_backlog_threshold(self):
+        repo = "dashpay/dash"
+        queued_url = (
+            "https://api.github.com/repos/{}/actions/runs?status=queued&per_page=100"
+        ).format(repo)
+        in_progress_url = (
+            "https://api.github.com/repos/{}/actions/runs?status=in_progress&per_page=100"
+        ).format(repo)
+        jobs_url = (
+            "https://api.github.com/repos/{}/actions/runs/101/jobs?per_page=100"
+        ).format(repo)
+
+        responses = {
+            queued_url: ({"workflow_runs": [{"id": 101}]}, {}),
+            in_progress_url: ({"workflow_runs": []}, {}),
+            jobs_url: ({"jobs": [{"status": "queued", "labels": ["ubuntu-24.04"]}] * 31}, {}),
+        }
+
+        outputs = MODULE.select_runners(
+            event_name="push",
+            event={},
+            threshold=10,
+            arm64_threshold=30,
+            runner_amd64_var="blacksmith-amd64",
+            runner_arm64_var="blacksmith-arm64",
+            fetch_json=lambda url: responses[url],
+            repos=[repo],
+        )
+
+        self.assertEqual(outputs["use_blacksmith"], "true")
+        self.assertEqual(outputs["use_blacksmith_amd64"], "true")
+        self.assertEqual(outputs["use_blacksmith_arm64"], "true")
+        self.assertEqual(outputs["backlog_count"], "31")
+        self.assertEqual(outputs["runner_amd64"], "blacksmith-amd64")
+        self.assertEqual(outputs["runner_arm64"], "blacksmith-arm64")
+        self.assertIn("amd64:backlog:31>10", outputs["decision_reason"])
+        self.assertIn("arm64:backlog:31>30", outputs["decision_reason"])
 
     def test_measurement_failure_falls_back_to_github(self):
         def fetch_json(_url):
@@ -132,6 +179,7 @@ class SelectDynamicRunnerTest(unittest.TestCase):
             event_name="push",
             event={},
             threshold=10,
+            arm64_threshold=30,
             runner_amd64_var="blacksmith-amd64",
             runner_arm64_var="blacksmith-arm64",
             fetch_json=fetch_json,
@@ -139,6 +187,8 @@ class SelectDynamicRunnerTest(unittest.TestCase):
         )
 
         self.assertEqual(outputs["use_blacksmith"], "false")
+        self.assertEqual(outputs["use_blacksmith_amd64"], "false")
+        self.assertEqual(outputs["use_blacksmith_arm64"], "false")
         self.assertEqual(outputs["runner_amd64"], MODULE.DEFAULT_RUNNER_AMD64)
         self.assertEqual(outputs["runner_arm64"], MODULE.DEFAULT_RUNNER_ARM64)
         self.assertEqual(outputs["backlog_count"], "unknown")
@@ -149,6 +199,7 @@ class SelectDynamicRunnerTest(unittest.TestCase):
             event_name="pull_request_target",
             event={"pull_request": {"labels": [{"name": "blacksmith-ci"}]}},
             threshold=10,
+            arm64_threshold=30,
             runner_amd64_var="",
             runner_arm64_var="blacksmith-arm64",
             fetch_json=lambda _url: ({"workflow_runs": []}, {}),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Issue being fixed or feature implemented

Dash Core CI currently selects Blacksmith runners with one shared backlog
decision for both amd64 and arm64 jobs. Recent CI runtime data shows
Blacksmith amd64 jobs are faster, while Blacksmith arm64 is slower or neutral
for the expensive TSAN and multiprocess lanes.

This change lets CI use Blacksmith for amd64 at the normal backlog threshold
while keeping arm64 jobs on GitHub-hosted runners until the GitHub-hosted
backlog is much higher.

## What was done?

- Split the dynamic runner selector into independent amd64 and arm64
  Blacksmith decisions.
- Kept the existing `blacksmith-ci` PR label as a manual override that forces
  both architectures to Blacksmith.
- Added `BACKLOG_THRESHOLD_ARM64=30` in the CI workflow, while retaining the
  existing amd64 threshold of `10`.
- Kept the legacy `use_blacksmith` output and added per-architecture summary
  outputs for visibility.
- Updated runner selector tests for:
  - label override forcing both architectures;
  - backlog `11 > 10` selecting Blacksmith for amd64 only;
  - backlog `31 > 30` selecting Blacksmith for arm64 too;
  - measurement failures falling back to GitHub-hosted runners.

## How Has This Been Tested?

Validated locally on macOS:

```bash
python3 .github/workflows/test_select_dynamic_runner.py
python3 -m py_compile .github/workflows/select_dynamic_runner.py .github/workflows/test_select_dynamic_runner.py
git diff --check
```

Pre-PR review gate was run against `upstream/develop..HEAD` for the three
changed workflow files and returned: `No issues found. Recommendation: ship.`

## Breaking Changes

None. This only changes CI runner selection policy and preserves existing
output names used by downstream jobs.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository
  code-owners and collaborators only)_
