### PR TITLE
ci: make conflict prediction advisory

### DIFF
--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -1,186 +1,567 @@
 #!/usr/bin/env python3
-# Copyright (c) 2022-2025 The Dash Core developers
+# Copyright (c) 2022-2026 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 """
+Validate candidate PR conflicts and maintain advisory PR comments.
 
 Usage:
-    $ ./handle_potential_conflicts.py <conflicts>
+    $ ./handle_potential_conflicts.py --pr-number <number>
 
-Where <conflicts> is a json string which looks like
-    {   pull_number: 26,
-        conflictPrs:
-            [ { number: 15,
-                files: [ 'testfile1', `testfile2` ],
-                conflicts: [ 'testfile1' ] },
-                ...
-            ]}
+The overlap pass only finds same-base PRs that touch the same files. This
+script checks whether each candidate PR can still merge after the current PR is
+pre-merged, then updates one managed comment per affected PR.
 """
 
-import sys
-import os
+from __future__ import annotations
+
+import argparse
+import base64
 import json
-import uuid
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
 import requests
 
-# need to install via pip
-try:
-    import hjson
-except ImportError:
-    print("Error: hjson module not found. Please install it with: pip install hjson", file=sys.stderr)
-    sys.exit(1)
 
-def get_pr_json(pr_num):
-    # Get repository from environment or default to dashpay/dash
-    repo = os.environ.get('GITHUB_REPOSITORY', 'dashpay/dash')
+COMMENT_MARKER = "dash-potential-conflicts:v1"
+COMMENT_START = f"<!-- {COMMENT_MARKER}"
+COMMENT_END = "-->"
+TRUSTED_COMMENT_AUTHORS = {"github-actions[bot]"}
+MAX_FILE_DETAILS = 12
+
+
+@dataclass
+class ManagedComment:
+    comment_id: int | None
+    body: str
+    state: dict[str, Any]
+
+
+def github_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    return headers
+
+
+def repo_name() -> str:
+    return os.environ.get("GITHUB_REPOSITORY", "dashpay/dash")
+
+
+def api_url(path: str) -> str:
+    return f"https://api.github.com/repos/{repo_name()}/{path.lstrip('/')}"
+
+
+def github_get(path_or_url: str) -> Any:
+    url = path_or_url if path_or_url.startswith("https://") else api_url(path_or_url)
+    response = requests.get(url, headers=github_headers(), timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def github_get_paginated(path: str) -> list[dict[str, Any]]:
+    url = api_url(path)
+    items = []
+
+    while url:
+        response = requests.get(url, headers=github_headers(), timeout=30)
+        response.raise_for_status()
+        page = response.json()
+        if not isinstance(page, list):
+            raise ValueError(f"Expected a list response from {url}")
+        items.extend(page)
+        url = response.links.get("next", {}).get("url")
+
+    return items
+
+
+def github_patch(path: str, payload: dict[str, Any]) -> None:
+    response = requests.patch(api_url(path), headers=github_headers(), json=payload, timeout=30)
+    response.raise_for_status()
+
+
+def github_post(path: str, payload: dict[str, Any]) -> None:
+    response = requests.post(api_url(path), headers=github_headers(), json=payload, timeout=30)
+    response.raise_for_status()
+
+
+def github_delete(path: str) -> None:
+    response = requests.delete(api_url(path), headers=github_headers(), timeout=30)
+    response.raise_for_status()
+
+
+def normalize_state(state: Any) -> dict[str, Any]:
+    if not isinstance(state, dict):
+        state = {}
+
+    outbound = state.get("outbound", [])
+    inbound = state.get("inbound", {})
+
+    if not isinstance(outbound, list):
+        outbound = []
+    if not isinstance(inbound, dict):
+        inbound = {}
+
+    return {
+        "outbound": outbound,
+        "inbound": {str(key): value for key, value in inbound.items() if isinstance(value, dict)},
+    }
+
+
+def extract_state(body: str) -> dict[str, Any]:
+    marker_index = body.find(COMMENT_START)
+    if marker_index == -1:
+        return normalize_state({})
+
+    json_start = body.find("\n", marker_index)
+    marker_end = body.find(COMMENT_END, marker_index)
+    if json_start == -1 or marker_end == -1 or json_start > marker_end:
+        return normalize_state({})
+
+    encoded_state = body[json_start:marker_end].strip()
+    if not encoded_state:
+        return normalize_state({})
 
     try:
-        response = requests.get(f'https://api.github.com/repos/{repo}/pulls/{pr_num}')
-        response.raise_for_status()
-        pr_data = response.json()
+        raw_state = base64.b64decode(encoded_state).decode("utf8")
+        return normalize_state(json.loads(raw_state))
+    except (ValueError, json.JSONDecodeError):
+        print("Warning: managed conflict comment has invalid state; replacing it", file=sys.stderr)
+        return normalize_state({})
 
-        # Check if we got an error response
-        if 'message' in pr_data and 'head' not in pr_data:
-            print(f"Warning: GitHub API error for PR {pr_num}: {pr_data.get('message', 'Unknown error')}", file=sys.stderr)
-            return None
 
-        return pr_data
+def state_is_empty(state: dict[str, Any]) -> bool:
+    normalized = normalize_state(state)
+    return not normalized["outbound"] and not normalized["inbound"]
+
+
+def compact_title(title: str) -> str:
+    return " ".join(str(title).split())
+
+
+def format_files(files: list[str]) -> str:
+    if not files:
+        return ""
+
+    visible_files = files[:MAX_FILE_DETAILS]
+    formatted = ", ".join(f"`{filename}`" for filename in visible_files)
+    remaining = len(files) - len(visible_files)
+    if remaining > 0:
+        formatted = f"{formatted}, and {remaining} more"
+
+    return f" Changed files: {formatted}."
+
+
+def format_pr_line(item: dict[str, Any]) -> str:
+    number = int(item["number"])
+    title = compact_title(item.get("title", "Unknown title"))
+    url = item.get("url") or f"https://github.com/{repo_name()}/pull/{number}"
+    files = [str(filename) for filename in item.get("files", [])]
+    return f"- [#{number}: {title}]({url}){format_files(files)}"
+
+
+def render_comment_body(state: dict[str, Any]) -> str:
+    state = normalize_state(state)
+    state_json = json.dumps(state, sort_keys=True, separators=(",", ":"))
+    state_encoded = base64.b64encode(state_json.encode("utf8")).decode("ascii")
+    lines = [
+        COMMENT_START,
+        state_encoded,
+        COMMENT_END,
+        "## Potential PR merge conflicts",
+        "",
+        "This is advisory only. It does not block CI, but it marks PRs that will likely need a rebase depending on merge order.",
+    ]
+
+    if state["outbound"]:
+        lines.extend([
+            "",
+            "### If this PR merges first",
+            "",
+            "These open PRs will likely need a rebase:",
+            "",
+        ])
+        lines.extend(format_pr_line(item) for item in sorted(state["outbound"], key=lambda item: int(item["number"])))
+
+    if state["inbound"]:
+        lines.extend([
+            "",
+            "### If these PRs merge first",
+            "",
+            "This PR will likely need a rebase:",
+            "",
+        ])
+        inbound_items = sorted(state["inbound"].values(), key=lambda item: int(item["number"]))
+        lines.extend(format_pr_line(item) for item in inbound_items)
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def get_pr_json(pr_num: int) -> dict[str, Any] | None:
+    try:
+        return github_get(f"pulls/{pr_num}")
     except requests.RequestException as e:
         print(f"Warning: Error fetching PR {pr_num}: {e}", file=sys.stderr)
         return None
-    except json.JSONDecodeError as e:
-        print(f"Warning: Error parsing JSON for PR {pr_num}: {e}", file=sys.stderr)
-        return None
 
-def set_github_output(name, value):
-    """Set GitHub Actions output"""
-    if 'GITHUB_OUTPUT' not in os.environ:
-        print(f"Warning: GITHUB_OUTPUT not set, skipping output: {name}={value}", file=sys.stderr)
+
+def list_issue_comments(pr_num: int) -> list[dict[str, Any]]:
+    return github_get_paginated(f"issues/{pr_num}/comments?per_page=100")
+
+
+def is_trusted_comment_author(comment: dict[str, Any]) -> bool:
+    user = comment.get("user")
+    if not isinstance(user, dict):
+        return False
+    return user.get("login") in TRUSTED_COMMENT_AUTHORS
+
+
+def find_managed_comments(pr_num: int) -> list[ManagedComment]:
+    managed_comments = []
+
+    for comment in list_issue_comments(pr_num):
+        if not is_trusted_comment_author(comment):
+            continue
+
+        body = comment.get("body") or ""
+        if COMMENT_START in body:
+            managed_comments.append(ManagedComment(
+                comment_id=comment.get("id"),
+                body=body,
+                state=extract_state(body),
+            ))
+
+    return managed_comments
+
+
+def select_managed_comment(managed_comments: list[ManagedComment]) -> ManagedComment:
+    if managed_comments:
+        return managed_comments[-1]
+    return ManagedComment(comment_id=None, body="", state=normalize_state({}))
+
+
+def get_managed_comment(pr_num: int) -> ManagedComment:
+    return select_managed_comment(find_managed_comments(pr_num))
+
+
+def save_managed_comment(pr_num: int, state: dict[str, Any]) -> None:
+    managed_comments = find_managed_comments(pr_num)
+    managed_comment = select_managed_comment(managed_comments)
+    state = normalize_state(state)
+
+    if state_is_empty(state):
+        for comment in managed_comments:
+            if comment.comment_id is not None:
+                github_delete(f"issues/comments/{comment.comment_id}")
+        if managed_comments:
+            print(f"Deleted stale conflict comments on PR #{pr_num}", file=sys.stderr)
         return
 
+    body = render_comment_body(state)
+    if managed_comment.comment_id is None:
+        github_post(f"issues/{pr_num}/comments", {"body": body})
+        print(f"Created conflict comment on PR #{pr_num}", file=sys.stderr)
+    elif managed_comment.body != body:
+        github_patch(f"issues/comments/{managed_comment.comment_id}", {"body": body})
+        print(f"Updated conflict comment on PR #{pr_num}", file=sys.stderr)
+    else:
+        print(f"Conflict comment on PR #{pr_num} is already up to date", file=sys.stderr)
+
+    for comment in managed_comments:
+        if comment.comment_id is not None and comment.comment_id != managed_comment.comment_id:
+            github_delete(f"issues/comments/{comment.comment_id}")
+            print(f"Deleted duplicate conflict comment on PR #{pr_num}", file=sys.stderr)
+
+
+def build_pr_item(pr_json: dict[str, Any], files: list[str]) -> dict[str, Any]:
+    return {
+        "number": int(pr_json["number"]),
+        "title": compact_title(pr_json.get("title", "Unknown title")),
+        "url": pr_json.get("html_url") or f"https://github.com/{repo_name()}/pull/{pr_json['number']}",
+        "files": sorted(set(str(filename) for filename in files)),
+    }
+
+
+def item_number(item: dict[str, Any]) -> int | None:
     try:
-        with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf8') as f:
-            # For multiline values, use the delimiter syntax
-            if '\n' in str(value):
-                delimiter = f"EOF_{uuid.uuid4()}"
-                f.write(f"{name}<<{delimiter}\n{value}\n{delimiter}\n")
-            else:
-                f.write(f"{name}={value}\n")
-    except IOError as e:
-        print(f"Error writing to GITHUB_OUTPUT: {e}", file=sys.stderr)
+        return int(item["number"])
+    except (KeyError, TypeError, ValueError):
+        return None
 
-def main():
-    if len(sys.argv) != 2:
-        print(f'Usage: {sys.argv[0]} <conflicts>', file=sys.stderr)
-        sys.exit(1)
 
-    conflict_input = sys.argv[1]
+def file_names_from_pr_file(file_info: dict[str, Any]) -> set[str]:
+    names = set()
+
+    filename = file_info.get("filename")
+    if filename:
+        names.add(str(filename))
+
+    previous_filename = file_info.get("previous_filename")
+    if previous_filename:
+        names.add(str(previous_filename))
+
+    return names
+
+
+def get_pr_files(pr_num: int) -> set[str]:
+    files = set()
+    for file_info in github_get_paginated(f"pulls/{pr_num}/files?per_page=100"):
+        files.update(file_names_from_pr_file(file_info))
+    return files
+
+
+def discover_conflict_candidates(our_pr_json: dict[str, Any]) -> list[dict[str, Any]]:
+    """Find same-base open PRs that touch at least one of the same files."""
+    our_pr_num = int(our_pr_json["number"])
+    our_base = our_pr_json["base"]["ref"]
+    our_files = get_pr_files(our_pr_num)
+
+    if not our_files:
+        print(f"PR #{our_pr_num} has no changed files", file=sys.stderr)
+        return []
+
+    candidates = []
+    open_prs = github_get_paginated(f"pulls?state=open&base={quote(our_base, safe='')}&per_page=100")
+    for pr_json in open_prs:
+        conflict_pr_num = int(pr_json["number"])
+        if conflict_pr_num == our_pr_num:
+            continue
+        if pr_json.get("draft", False):
+            print(f"PR #{conflict_pr_num} is a draft. Skipping conflict check", file=sys.stderr)
+            continue
+
+        conflict_files = get_pr_files(conflict_pr_num)
+        overlap = sorted(our_files & conflict_files)
+        if not overlap:
+            continue
+
+        candidates.append({
+            "number": conflict_pr_num,
+            "files": sorted(conflict_files),
+            "conflicts": overlap,
+        })
+
+    return candidates
+
+
+def branches_can_merge(our_pr_label: str, conflict_pr_label: str) -> bool | None:
+    merge_check_url = f"https://github.com/{repo_name()}/branches/pre_mergeable/{our_pr_label}...{conflict_pr_label}"
+    headers = {"User-Agent": "dash-potential-conflicts"}
 
     try:
-        j_input = hjson.loads(conflict_input)
-    except Exception as e:
-        print(f"Error parsing input JSON: {e}", file=sys.stderr)
-        sys.exit(1)
+        response = requests.get(merge_check_url, headers=headers, timeout=30)
+        response.raise_for_status()
+    except requests.RequestException as e:
+        print(f"Error checking mergeability at {merge_check_url}: {e}", file=sys.stderr)
+        return None
 
-    # Validate required fields
-    if 'pull_number' not in j_input:
-        print("Error: 'pull_number' field missing from input", file=sys.stderr)
-        sys.exit(1)
-    if 'conflictPrs' not in j_input:
-        print("Error: 'conflictPrs' field missing from input", file=sys.stderr)
-        sys.exit(1)
+    if "These branches can be automatically merged." in response.text:
+        return True
+    if "Can't automatic" in response.text or "octicon octicon-x" in response.text:
+        return False
 
-    our_pr_num = j_input['pull_number']
+    print(f"Warning: Unexpected mergeability response: {merge_check_url}", file=sys.stderr)
+    return None
+
+
+def validate_conflicts(candidates: list[dict[str, Any]], our_pr_json: dict[str, Any]) -> list[dict[str, Any]]:
+    our_pr_label = our_pr_json["head"]["label"]
+    validated_conflicts = []
+
+    for conflict in candidates:
+        if "number" not in conflict:
+            print("Warning: Skipping conflict entry without 'number' field", file=sys.stderr)
+            continue
+
+        conflict_pr_num = int(conflict["number"])
+        conflict_pr_json = get_pr_json(conflict_pr_num)
+        if conflict_pr_json is None:
+            print(f"Warning: Failed to fetch PR {conflict_pr_num}, skipping", file=sys.stderr)
+            continue
+
+        if "head" not in conflict_pr_json or "label" not in conflict_pr_json["head"]:
+            print(f"Warning: Invalid PR data structure for PR {conflict_pr_num}, skipping", file=sys.stderr)
+            continue
+
+        if conflict_pr_json.get("mergeable_state") == "dirty":
+            print(f"PR #{conflict_pr_num} already needs rebase. Skipping conflict check", file=sys.stderr)
+            continue
+
+        if conflict_pr_json.get("draft", False):
+            print(f"PR #{conflict_pr_num} is a draft. Skipping conflict check", file=sys.stderr)
+            continue
+
+        can_merge = branches_can_merge(our_pr_label, conflict_pr_json["head"]["label"])
+        if can_merge is True:
+            print(f"PR #{conflict_pr_num} still merges after PR #{our_pr_json['number']}", file=sys.stderr)
+            continue
+        if can_merge is None:
+            continue
+
+        files = conflict.get("conflicts", [])
+        item = build_pr_item(conflict_pr_json, files if isinstance(files, list) else [])
+        validated_conflicts.append(item)
+
+    return validated_conflicts
+
+
+def update_comments(our_pr_json: dict[str, Any], validated_conflicts: list[dict[str, Any]]) -> None:
+    our_pr_num = int(our_pr_json["number"])
+    our_managed_comment = get_managed_comment(our_pr_num)
+    previous_outbound_numbers = {
+        number
+        for item in our_managed_comment.state["outbound"]
+        if isinstance(item, dict)
+        for number in [item_number(item)]
+        if number is not None
+    }
+    current_outbound_numbers = {int(item["number"]) for item in validated_conflicts}
+
+    our_state = normalize_state(our_managed_comment.state)
+    our_state["outbound"] = validated_conflicts
+    save_managed_comment(our_pr_num, our_state)
+
+    targets_to_update = previous_outbound_numbers | current_outbound_numbers
+    our_item_by_target = {
+        int(item["number"]): build_pr_item(our_pr_json, [str(filename) for filename in item.get("files", [])])
+        for item in validated_conflicts
+    }
+
+    for target_pr_num in sorted(targets_to_update):
+        target_comment = get_managed_comment(target_pr_num)
+        target_state = normalize_state(target_comment.state)
+        inbound = target_state["inbound"]
+
+        if target_pr_num in our_item_by_target:
+            inbound[str(our_pr_num)] = our_item_by_target[target_pr_num]
+        else:
+            inbound.pop(str(our_pr_num), None)
+
+        target_state["inbound"] = inbound
+        save_managed_comment(target_pr_num, target_state)
+
+
+def remove_outbound_reference(state: dict[str, Any], pr_num: int) -> dict[str, Any]:
+    state = normalize_state(state)
+    outbound = []
+
+    for item in state["outbound"]:
+        if not isinstance(item, dict):
+            continue
+        if item_number(item) == pr_num:
+            continue
+        outbound.append(item)
+
+    state["outbound"] = outbound
+    return state
+
+
+def cleanup_closed_pr_comments(pr_num: int) -> None:
+    managed_comment = get_managed_comment(pr_num)
+    state = normalize_state(managed_comment.state)
+    outbound_numbers = {
+        number
+        for item in state["outbound"]
+        if isinstance(item, dict)
+        for number in [item_number(item)]
+        if number is not None
+    }
+    inbound_numbers = {
+        int(number)
+        for number in state["inbound"]
+        if str(number).isdigit()
+    }
+
+    for target_pr_num in sorted(outbound_numbers):
+        target_comment = get_managed_comment(target_pr_num)
+        target_state = normalize_state(target_comment.state)
+        target_state["inbound"].pop(str(pr_num), None)
+        save_managed_comment(target_pr_num, target_state)
+
+    for source_pr_num in sorted(inbound_numbers):
+        source_comment = get_managed_comment(source_pr_num)
+        source_state = remove_outbound_reference(source_comment.state, pr_num)
+        save_managed_comment(source_pr_num, source_state)
+
+    deleted_comment = False
+    for comment in find_managed_comments(pr_num):
+        if comment.comment_id is not None:
+            github_delete(f"issues/comments/{comment.comment_id}")
+            deleted_comment = True
+    if deleted_comment:
+        print(f"Deleted conflict comment on closed PR #{pr_num}", file=sys.stderr)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate potential PR conflicts and maintain advisory comments.",
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        required=True,
+        help="Pull request number to inspect.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the current PR comment body instead of creating, updating, or deleting comments.",
+    )
+    parser.add_argument(
+        "--cleanup-closed",
+        action="store_true",
+        help="Remove advisory state for a PR that has been closed.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    our_pr_num = args.pr_number
+
+    if args.cleanup_closed:
+        if args.dry_run:
+            print(f"Would clean advisory conflict comments for closed PR #{our_pr_num}")
+        else:
+            cleanup_closed_pr_comments(our_pr_num)
+        return
+
     our_pr_json = get_pr_json(our_pr_num)
 
     if our_pr_json is None:
         print(f"Error: Failed to fetch PR {our_pr_num}", file=sys.stderr)
         sys.exit(1)
 
-    if 'head' not in our_pr_json or 'label' not in our_pr_json['head']:
+    if "head" not in our_pr_json or "label" not in our_pr_json["head"]:
         print(f"Error: Invalid PR data structure for PR {our_pr_num}", file=sys.stderr)
         sys.exit(1)
 
-    our_pr_label = our_pr_json['head']['label']
-    conflict_prs = j_input['conflictPrs']
-
-    good = []
-    bad = []
-    conflict_details = []
-
-    for conflict in conflict_prs:
-        if 'number' not in conflict:
-            print("Warning: Skipping conflict entry without 'number' field", file=sys.stderr)
-            continue
-
-        conflict_pr_num = conflict['number']
-
-        conflict_pr_json = get_pr_json(conflict_pr_num)
-
-        if conflict_pr_json is None:
-            print(f"Warning: Failed to fetch PR {conflict_pr_num}, skipping", file=sys.stderr)
-            continue
-
-        if 'head' not in conflict_pr_json or 'label' not in conflict_pr_json['head']:
-            print(f"Warning: Invalid PR data structure for PR {conflict_pr_num}, skipping", file=sys.stderr)
-            continue
-
-        conflict_pr_label = conflict_pr_json['head']['label']
-
-        if conflict_pr_json.get('mergeable_state') == "dirty":
-            print(f'PR #{conflict_pr_num} needs rebase. Skipping conflict check', file=sys.stderr)
-            continue
-
-        if conflict_pr_json.get('draft', False):
-            print(f'PR #{conflict_pr_num} is a draft. Skipping conflict check', file=sys.stderr)
-            continue
-
-        # Get repository from environment
-        repo = os.environ.get('GITHUB_REPOSITORY', 'dashpay/dash')
-        merge_check_url = f'https://github.com/{repo}/branches/pre_mergeable/{our_pr_label}...{conflict_pr_label}'
-
-        try:
-            pre_mergeable = requests.get(merge_check_url)
-            pre_mergeable.raise_for_status()
-        except requests.RequestException as e:
-            print(f"Error checking mergeability for PR {conflict_pr_num}: {e}", file=sys.stderr)
-            continue
-
-        if "These branches can be automatically merged." in pre_mergeable.text:
-            good.append(conflict_pr_num)
-        elif "Can't automatic" in pre_mergeable.text or "octicon octicon-x" in pre_mergeable.text:
-            # Check for partial text or the X icon which indicates conflicts
-            bad.append(conflict_pr_num)
-            conflict_details.append({
-                'number': conflict_pr_num,
-                'title': conflict_pr_json.get('title', 'Unknown'),
-                'url': conflict_pr_json.get('html_url', f'https://github.com/{repo}/pull/{conflict_pr_num}')
-            })
+    if our_pr_json.get("draft", False):
+        if args.dry_run:
+            print(f"Would clean advisory conflict comments for draft PR #{our_pr_num}")
         else:
-            print(f"Warning: Unexpected response for PR {conflict_pr_num} mergeability check. URL: {pre_mergeable.url}", file=sys.stderr)
+            cleanup_closed_pr_comments(our_pr_num)
+        return
 
-    print(f"Not conflicting PRs: {good}", file=sys.stderr)
-    print(f"Conflicting PRs: {bad}", file=sys.stderr)
+    candidates = discover_conflict_candidates(our_pr_json)
+    validated_conflicts = validate_conflicts(candidates, our_pr_json)
+    print(f"Conflicting PRs after validation: {[item['number'] for item in validated_conflicts]}", file=sys.stderr)
 
-    # Set GitHub Actions outputs
-    if 'GITHUB_OUTPUT' in os.environ:
-        set_github_output('has_conflicts', 'true' if len(bad) > 0 else 'false')
-
-        # Format conflict details as markdown list
-        if conflict_details:
-            markdown_list = []
-            for conflict in conflict_details:
-                markdown_list.append(f"- #{conflict['number']} - [{conflict['title']}]({conflict['url']})")
-            conflict_markdown = '\n'.join(markdown_list)
-            set_github_output('conflict_details', conflict_markdown)
-        else:
-            set_github_output('conflict_details', '')
-
-        set_github_output('conflicting_prs', ','.join(map(str, bad)))
-
-    if len(bad) > 0:
-        sys.exit(1)
+    if args.dry_run:
+        print(render_comment_body({"outbound": validated_conflicts, "inbound": {}}))
+    else:
+        update_comments(our_pr_json, validated_conflicts)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/handle_potential_conflicts.py
+++ b/.github/workflows/handle_potential_conflicts.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import html
 import json
 import os
 import sys
@@ -101,6 +102,27 @@ def github_delete(path: str) -> None:
     response.raise_for_status()
 
 
+def normalize_state_item(item: Any) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+
+    try:
+        number = int(item["number"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    files = item.get("files", [])
+    if not isinstance(files, list):
+        files = []
+
+    return {
+        "number": number,
+        "title": " ".join(str(item.get("title", "Unknown title")).split()),
+        "url": str(item.get("url") or f"https://github.com/{repo_name()}/pull/{number}"),
+        "files": [str(filename) for filename in files],
+    }
+
+
 def normalize_state(state: Any) -> dict[str, Any]:
     if not isinstance(state, dict):
         state = {}
@@ -113,9 +135,21 @@ def normalize_state(state: Any) -> dict[str, Any]:
     if not isinstance(inbound, dict):
         inbound = {}
 
+    normalized_outbound = []
+    for item in outbound:
+        normalized_item = normalize_state_item(item)
+        if normalized_item is not None:
+            normalized_outbound.append(normalized_item)
+
+    normalized_inbound = {}
+    for key, value in inbound.items():
+        normalized_item = normalize_state_item(value)
+        if normalized_item is not None:
+            normalized_inbound[str(key)] = normalized_item
+
     return {
-        "outbound": outbound,
-        "inbound": {str(key): value for key, value in inbound.items() if isinstance(value, dict)},
+        "outbound": normalized_outbound,
+        "inbound": normalized_inbound,
     }
 
 
@@ -150,12 +184,20 @@ def compact_title(title: str) -> str:
     return " ".join(str(title).split())
 
 
+def escape_markdown_link_text(text: str) -> str:
+    return str(text).replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
+def format_code_span(text: str) -> str:
+    return f"<code>{html.escape(str(text), quote=False)}</code>"
+
+
 def format_files(files: list[str]) -> str:
     if not files:
         return ""
 
     visible_files = files[:MAX_FILE_DETAILS]
-    formatted = ", ".join(f"`{filename}`" for filename in visible_files)
+    formatted = ", ".join(format_code_span(filename) for filename in visible_files)
     remaining = len(files) - len(visible_files)
     if remaining > 0:
         formatted = f"{formatted}, and {remaining} more"
@@ -165,7 +207,7 @@ def format_files(files: list[str]) -> str:
 
 def format_pr_line(item: dict[str, Any]) -> str:
     number = int(item["number"])
-    title = compact_title(item.get("title", "Unknown title"))
+    title = escape_markdown_link_text(compact_title(item.get("title", "Unknown title")))
     url = item.get("url") or f"https://github.com/{repo_name()}/pull/{number}"
     files = [str(filename) for filename in item.get("files", [])]
     return f"- [#{number}: {title}]({url}){format_files(files)}"
@@ -356,7 +398,10 @@ def discover_conflict_candidates(our_pr_json: dict[str, Any]) -> list[dict[str, 
 
 
 def branches_can_merge(our_pr_label: str, conflict_pr_label: str) -> bool | None:
-    merge_check_url = f"https://github.com/{repo_name()}/branches/pre_mergeable/{our_pr_label}...{conflict_pr_label}"
+    merge_check_url = (
+        f"https://github.com/{repo_name()}/branches/pre_mergeable/"
+        f"{quote(our_pr_label, safe='')}...{quote(conflict_pr_label, safe='')}"
+    )
     headers = {"User-Agent": "dash-potential-conflicts"}
 
     try:

--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -30,15 +30,16 @@ jobs:
         uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - name: Install Python dependencies
-        run: python3 -m pip install requests
       - name: Validate potential conflicts and update advisory comments
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ "${{ github.event.action }}" = "closed" ]; then
-            .github/workflows/handle_potential_conflicts.py --pr-number "${{ github.event.pull_request.number }}" --cleanup-closed
+          python3 -m pip install requests
+          if [ "$EVENT_ACTION" = "closed" ]; then
+            .github/workflows/handle_potential_conflicts.py --pr-number "$PR_NUMBER" --cleanup-closed
           else
-            .github/workflows/handle_potential_conflicts.py --pr-number "${{ github.event.pull_request.number }}"
+            .github/workflows/handle_potential_conflicts.py --pr-number "$PR_NUMBER"
           fi
-        continue-on-error: true

--- a/.github/workflows/predict-conflicts.yml
+++ b/.github/workflows/predict-conflicts.yml
@@ -2,13 +2,14 @@ name: "Check Potential Conflicts"
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, closed]
   pull_request_review:
     types: [submitted]
 
 permissions:
   contents: read
   pull-requests: write
-  issues: write # mshick/add-pr-comment updates PR conversation comments via the Issues API
+  issues: write # PR conversation comments use the Issues API
   # Enforce other not needed permissions are off
   actions: none
   checks: none
@@ -21,42 +22,23 @@ permissions:
 jobs:
   predict_conflicts:
     runs-on: ubuntu-latest
+    concurrency:
+      group: predict-conflicts
+      cancel-in-progress: false
     steps:
-      - name: check for potential conflicts
-        id: check_conflicts
-        uses: PastaPastaPasta/potential-conflicts-checker-action@v0.1.10
-        with:
-          ghToken: "${{ secrets.GITHUB_TOKEN }}"
       - name: Checkout
         uses: actions/checkout@v6
-      - name: validate potential conflicts
-        id: validate_conflicts
-        run: pip3 install hjson && .github/workflows/handle_potential_conflicts.py "$conflicts"
-        continue-on-error: true
-      - name: Post conflict comment
-        if: steps.validate_conflicts.outputs.has_conflicts == 'true'
-        continue-on-error: true
-        uses: mshick/add-pr-comment@v3
         with:
-          message-id: conflict-prediction
-          message: |
-            ## ⚠️ Potential Merge Conflicts Detected
-
-            This PR has potential conflicts with the following open PRs:
-
-            ${{ steps.validate_conflicts.outputs.conflict_details }}
-
-            Please coordinate with the authors of these PRs to avoid merge conflicts.
-      - name: Remove conflict comment if no conflicts
-        if: steps.validate_conflicts.outputs.has_conflicts == 'false'
+          persist-credentials: false
+      - name: Install Python dependencies
+        run: python3 -m pip install requests
+      - name: Validate potential conflicts and update advisory comments
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event.action }}" = "closed" ]; then
+            .github/workflows/handle_potential_conflicts.py --pr-number "${{ github.event.pull_request.number }}" --cleanup-closed
+          else
+            .github/workflows/handle_potential_conflicts.py --pr-number "${{ github.event.pull_request.number }}"
+          fi
         continue-on-error: true
-        uses: mshick/add-pr-comment@v3
-        with:
-          message-id: conflict-prediction
-          message: |
-            ## ✅ No Merge Conflicts Detected
-
-            This PR currently has no conflicts with other open PRs.
-      - name: Fail if conflicts exist
-        if: steps.validate_conflicts.outputs.has_conflicts == 'true'
-        run: exit 1

--- a/.github/workflows/test_handle_potential_conflicts.py
+++ b/.github/workflows/test_handle_potential_conflicts.py
@@ -105,6 +105,38 @@ not-json
         self.assertEqual(state, extracted)
         self.assertNotIn("title with --> marker-like text", body.split("-->")[0])
 
+    def test_rendered_comment_escapes_markdown_content(self):
+        body = handle_potential_conflicts.render_comment_body({
+            "outbound": [
+                {
+                    "number": 12,
+                    "title": "fix [link] title",
+                    "url": "https://github.com/dashpay/dash/pull/12",
+                    "files": ["src/`odd`.cpp"],
+                },
+            ],
+            "inbound": {},
+        })
+
+        self.assertIn(r"[#12: fix \[link\] title](https://github.com/dashpay/dash/pull/12)", body)
+        self.assertIn("<code>src/`odd`.cpp</code>", body)
+
+    def test_normalize_state_filters_malformed_entries(self):
+        state = handle_potential_conflicts.normalize_state({
+            "outbound": [
+                {"number": "12", "title": "valid", "url": "https://example.test/12", "files": ["src/a.cpp"]},
+                {"title": "missing number"},
+                "not-a-dict",
+            ],
+            "inbound": {
+                "bad": {"title": "missing number"},
+                "13": {"number": "13", "title": "valid inbound", "url": "https://example.test/13", "files": []},
+            },
+        })
+
+        self.assertEqual([12], [item["number"] for item in state["outbound"]])
+        self.assertEqual(["13"], list(state["inbound"].keys()))
+
     def test_state_is_empty_only_when_both_directions_are_empty(self):
         self.assertTrue(handle_potential_conflicts.state_is_empty({"outbound": [], "inbound": {}}))
         self.assertFalse(handle_potential_conflicts.state_is_empty({"outbound": [{"number": 1}], "inbound": {}}))
@@ -356,8 +388,8 @@ not-json
         formatted = handle_potential_conflicts.format_files(files)
 
         self.assertIn("and 2 more", formatted)
-        self.assertIn("`src/file_0.cpp`", formatted)
-        self.assertNotIn(f"`src/file_{handle_potential_conflicts.MAX_FILE_DETAILS}.cpp`", formatted)
+        self.assertIn("<code>src/file_0.cpp</code>", formatted)
+        self.assertNotIn(f"<code>src/file_{handle_potential_conflicts.MAX_FILE_DETAILS}.cpp</code>", formatted)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/test_handle_potential_conflicts.py
+++ b/.github/workflows/test_handle_potential_conflicts.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Dash Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import importlib.util
+from pathlib import Path
+import argparse
+import requests
+import sys
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).with_name("handle_potential_conflicts.py")
+SPEC = importlib.util.spec_from_file_location("handle_potential_conflicts", SCRIPT_PATH)
+handle_potential_conflicts = importlib.util.module_from_spec(SPEC)
+sys.modules["handle_potential_conflicts"] = handle_potential_conflicts
+SPEC.loader.exec_module(handle_potential_conflicts)
+
+
+BOT_USER = {"login": "github-actions[bot]", "type": "Bot"}
+USER = {"login": "contributor", "type": "User"}
+
+
+def comment(comment_id, body, user=None):
+    return {
+        "id": comment_id,
+        "body": body,
+        "user": user or BOT_USER,
+    }
+
+
+class TestPotentialConflictComments(unittest.TestCase):
+    def test_extract_state_from_managed_comment(self):
+        body = handle_potential_conflicts.render_comment_body({
+            "outbound": [
+                {"number": 2, "title": "two", "url": "https://example.test/2", "files": []},
+            ],
+            "inbound": {
+                "3": {"number": 3, "title": "three", "url": "https://example.test/3", "files": ["src/a.cpp"]},
+            },
+        })
+
+        state = handle_potential_conflicts.extract_state(body)
+
+        self.assertEqual(2, state["outbound"][0]["number"])
+        self.assertEqual(3, state["inbound"]["3"]["number"])
+
+    def test_invalid_state_is_treated_as_empty(self):
+        body = """<!-- dash-potential-conflicts:v1
+not-json
+-->
+## Potential PR merge conflicts
+"""
+
+        state = handle_potential_conflicts.extract_state(body)
+
+        self.assertEqual([], state["outbound"])
+        self.assertEqual({}, state["inbound"])
+
+    def test_render_comment_body_has_one_marker_and_both_sections(self):
+        state = {
+            "outbound": [
+                {
+                    "number": 12,
+                    "title": "fix: target",
+                    "url": "https://github.com/dashpay/dash/pull/12",
+                    "files": ["src/net.cpp"],
+                }
+            ],
+            "inbound": {
+                "9": {
+                    "number": 9,
+                    "title": "refactor: source",
+                    "url": "https://github.com/dashpay/dash/pull/9",
+                    "files": ["src/net.cpp"],
+                }
+            },
+        }
+
+        body = handle_potential_conflicts.render_comment_body(state)
+
+        self.assertEqual(1, body.count("dash-potential-conflicts:v1"))
+        self.assertIn("If this PR merges first", body)
+        self.assertIn("If these PRs merge first", body)
+        self.assertIn("[#12: fix: target](https://github.com/dashpay/dash/pull/12)", body)
+        self.assertIn("[#9: refactor: source](https://github.com/dashpay/dash/pull/9)", body)
+
+    def test_rendered_comment_state_round_trips(self):
+        state = {
+            "outbound": [
+                {
+                    "number": 12,
+                    "title": "title with --> marker-like text",
+                    "url": "https://github.com/dashpay/dash/pull/12",
+                    "files": ["src/net.cpp"],
+                }
+            ],
+            "inbound": {},
+        }
+
+        body = handle_potential_conflicts.render_comment_body(state)
+        extracted = handle_potential_conflicts.extract_state(body)
+
+        self.assertEqual(state, extracted)
+        self.assertNotIn("title with --> marker-like text", body.split("-->")[0])
+
+    def test_state_is_empty_only_when_both_directions_are_empty(self):
+        self.assertTrue(handle_potential_conflicts.state_is_empty({"outbound": [], "inbound": {}}))
+        self.assertFalse(handle_potential_conflicts.state_is_empty({"outbound": [{"number": 1}], "inbound": {}}))
+        self.assertFalse(handle_potential_conflicts.state_is_empty({"outbound": [], "inbound": {"2": {"number": 2}}}))
+
+    def test_user_forged_managed_comment_is_ignored(self):
+        body = handle_potential_conflicts.render_comment_body({
+            "outbound": [{"number": 12, "title": "forged", "url": "https://example.test/12", "files": []}],
+            "inbound": {},
+        })
+        comments = [comment(123, body, USER)]
+        original_list_issue_comments = handle_potential_conflicts.list_issue_comments
+        handle_potential_conflicts.list_issue_comments = lambda pr_num: comments
+        try:
+            managed_comments = handle_potential_conflicts.find_managed_comments(1)
+        finally:
+            handle_potential_conflicts.list_issue_comments = original_list_issue_comments
+
+        self.assertEqual([], managed_comments)
+
+    def test_update_comments_replaces_reciprocal_entries(self):
+        our_pr_json = {
+            "number": 10,
+            "title": "fix: source",
+            "html_url": "https://github.com/dashpay/dash/pull/10",
+        }
+        validated_conflicts = [
+            {
+                "number": 12,
+                "title": "fix: new target",
+                "url": "https://github.com/dashpay/dash/pull/12",
+                "files": ["src/net.cpp"],
+            }
+        ]
+        comments = {
+            10: handle_potential_conflicts.ManagedComment(
+                comment_id=1,
+                body="",
+                state={
+                    "outbound": [
+                        {
+                            "number": 11,
+                            "title": "fix: stale target",
+                            "url": "https://github.com/dashpay/dash/pull/11",
+                            "files": ["src/old.cpp"],
+                        }
+                    ],
+                    "inbound": {
+                        "8": {
+                            "number": 8,
+                            "title": "fix: incoming",
+                            "url": "https://github.com/dashpay/dash/pull/8",
+                            "files": ["src/in.cpp"],
+                        }
+                    },
+                },
+            ),
+            11: handle_potential_conflicts.ManagedComment(comment_id=2, body="", state={"outbound": [], "inbound": {"10": {"number": 10}}}),
+            12: handle_potential_conflicts.ManagedComment(comment_id=3, body="", state={"outbound": [], "inbound": {}}),
+        }
+        saved = {}
+        original_get_managed_comment = handle_potential_conflicts.get_managed_comment
+        original_save_managed_comment = handle_potential_conflicts.save_managed_comment
+        handle_potential_conflicts.get_managed_comment = lambda pr_num: comments[pr_num]
+        handle_potential_conflicts.save_managed_comment = lambda pr_num, state: saved.setdefault(pr_num, state)
+        try:
+            handle_potential_conflicts.update_comments(our_pr_json, validated_conflicts)
+        finally:
+            handle_potential_conflicts.get_managed_comment = original_get_managed_comment
+            handle_potential_conflicts.save_managed_comment = original_save_managed_comment
+
+        self.assertEqual([12], [item["number"] for item in saved[10]["outbound"]])
+        self.assertIn("8", saved[10]["inbound"])
+        self.assertNotIn("10", saved[11]["inbound"])
+        self.assertEqual(10, saved[12]["inbound"]["10"]["number"])
+
+    def test_cleanup_closed_pr_removes_bidirectional_state(self):
+        comments = {
+            10: handle_potential_conflicts.ManagedComment(
+                comment_id=10,
+                body="managed",
+                state={
+                    "outbound": [
+                        {
+                            "number": 12,
+                            "title": "fix: target",
+                            "url": "https://github.com/dashpay/dash/pull/12",
+                            "files": ["src/net.cpp"],
+                        }
+                    ],
+                    "inbound": {
+                        "8": {
+                            "number": 8,
+                            "title": "fix: source",
+                            "url": "https://github.com/dashpay/dash/pull/8",
+                            "files": ["src/net.cpp"],
+                        }
+                    },
+                },
+            ),
+            8: handle_potential_conflicts.ManagedComment(
+                comment_id=8,
+                body="managed",
+                state={
+                    "outbound": [
+                        {"number": 10, "title": "fix: closed target", "url": "https://github.com/dashpay/dash/pull/10", "files": []},
+                        {"number": 11, "title": "fix: other target", "url": "https://github.com/dashpay/dash/pull/11", "files": []},
+                    ],
+                    "inbound": {},
+                },
+            ),
+            12: handle_potential_conflicts.ManagedComment(
+                comment_id=12,
+                body="managed",
+                state={"outbound": [], "inbound": {"10": {"number": 10}}},
+            ),
+        }
+        saved = {}
+        deleted = []
+        original_get_managed_comment = handle_potential_conflicts.get_managed_comment
+        original_find_managed_comments = handle_potential_conflicts.find_managed_comments
+        original_save_managed_comment = handle_potential_conflicts.save_managed_comment
+        original_github_delete = handle_potential_conflicts.github_delete
+        handle_potential_conflicts.get_managed_comment = lambda pr_num: comments[pr_num]
+        handle_potential_conflicts.find_managed_comments = lambda pr_num: [comments[pr_num]]
+        handle_potential_conflicts.save_managed_comment = lambda pr_num, state: saved.setdefault(pr_num, state)
+        handle_potential_conflicts.github_delete = lambda path: deleted.append(path)
+        try:
+            handle_potential_conflicts.cleanup_closed_pr_comments(10)
+        finally:
+            handle_potential_conflicts.get_managed_comment = original_get_managed_comment
+            handle_potential_conflicts.find_managed_comments = original_find_managed_comments
+            handle_potential_conflicts.save_managed_comment = original_save_managed_comment
+            handle_potential_conflicts.github_delete = original_github_delete
+
+        self.assertEqual([11], [item["number"] for item in saved[8]["outbound"]])
+        self.assertNotIn("10", saved[12]["inbound"])
+        self.assertEqual(["issues/comments/10"], deleted)
+
+    def test_comment_fetch_failure_prevents_comment_creation(self):
+        posted = []
+        original_list_issue_comments = handle_potential_conflicts.list_issue_comments
+        original_github_post = handle_potential_conflicts.github_post
+        handle_potential_conflicts.list_issue_comments = lambda pr_num: (_ for _ in ()).throw(requests.RequestException("boom"))
+        handle_potential_conflicts.github_post = lambda path, payload: posted.append((path, payload))
+        try:
+            with self.assertRaises(requests.RequestException):
+                handle_potential_conflicts.save_managed_comment(
+                    10,
+                    {
+                        "outbound": [
+                            {
+                                "number": 12,
+                                "title": "fix: target",
+                                "url": "https://github.com/dashpay/dash/pull/12",
+                                "files": [],
+                            }
+                        ],
+                        "inbound": {},
+                    },
+                )
+        finally:
+            handle_potential_conflicts.list_issue_comments = original_list_issue_comments
+            handle_potential_conflicts.github_post = original_github_post
+
+        self.assertEqual([], posted)
+
+    def test_main_cleans_current_draft_pr(self):
+        cleaned = []
+        original_parse_args = handle_potential_conflicts.parse_args
+        original_get_pr_json = handle_potential_conflicts.get_pr_json
+        original_cleanup_closed_pr_comments = handle_potential_conflicts.cleanup_closed_pr_comments
+        handle_potential_conflicts.parse_args = lambda: argparse.Namespace(
+            pr_number=10,
+            dry_run=False,
+            cleanup_closed=False,
+        )
+        handle_potential_conflicts.get_pr_json = lambda pr_num: {
+            "number": pr_num,
+            "draft": True,
+            "head": {"label": "contributor:branch"},
+        }
+        handle_potential_conflicts.cleanup_closed_pr_comments = lambda pr_num: cleaned.append(pr_num)
+        try:
+            handle_potential_conflicts.main()
+        finally:
+            handle_potential_conflicts.parse_args = original_parse_args
+            handle_potential_conflicts.get_pr_json = original_get_pr_json
+            handle_potential_conflicts.cleanup_closed_pr_comments = original_cleanup_closed_pr_comments
+
+        self.assertEqual([10], cleaned)
+
+    def test_save_managed_comment_deletes_duplicate_managed_comments(self):
+        comments = [
+            comment(
+                1,
+                handle_potential_conflicts.render_comment_body({
+                    "outbound": [{"number": 11, "title": "old", "url": "https://example.test/11", "files": []}],
+                    "inbound": {},
+                }),
+            ),
+            comment(
+                3,
+                handle_potential_conflicts.render_comment_body({
+                    "outbound": [{"number": 12, "title": "old", "url": "https://example.test/12", "files": []}],
+                    "inbound": {},
+                }),
+            ),
+        ]
+        patched = []
+        deleted = []
+        posted = []
+        original_list_issue_comments = handle_potential_conflicts.list_issue_comments
+        original_github_patch = handle_potential_conflicts.github_patch
+        original_github_delete = handle_potential_conflicts.github_delete
+        original_github_post = handle_potential_conflicts.github_post
+        handle_potential_conflicts.list_issue_comments = lambda pr_num: comments
+        handle_potential_conflicts.github_patch = lambda path, payload: patched.append((path, payload))
+        handle_potential_conflicts.github_delete = lambda path: deleted.append(path)
+        handle_potential_conflicts.github_post = lambda path, payload: posted.append((path, payload))
+        try:
+            handle_potential_conflicts.save_managed_comment(
+                10,
+                {
+                    "outbound": [
+                        {
+                            "number": 13,
+                            "title": "new",
+                            "url": "https://example.test/13",
+                            "files": [],
+                        }
+                    ],
+                    "inbound": {},
+                },
+            )
+        finally:
+            handle_potential_conflicts.list_issue_comments = original_list_issue_comments
+            handle_potential_conflicts.github_patch = original_github_patch
+            handle_potential_conflicts.github_delete = original_github_delete
+            handle_potential_conflicts.github_post = original_github_post
+
+        self.assertEqual(["issues/comments/3"], [path for path, _payload in patched])
+        self.assertEqual(["issues/comments/1"], deleted)
+        self.assertEqual([], posted)
+
+    def test_format_files_limits_long_file_lists(self):
+        files = [f"src/file_{i}.cpp" for i in range(handle_potential_conflicts.MAX_FILE_DETAILS + 2)]
+
+        formatted = handle_potential_conflicts.format_files(files)
+
+        self.assertIn("and 2 more", formatted)
+        self.assertIn("`src/file_0.cpp`", formatted)
+        self.assertNotIn(f"`src/file_{handle_potential_conflicts.MAX_FILE_DETAILS}.cpp`", formatted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# ci: make conflict prediction advisory

## Issue being fixed or feature implemented

The existing potential-conflicts workflow is hard to act on because it can fail
CI and only reports the conflict from the triggering PR's side. For review and
merge planning, maintainers need an advisory comment on both affected PRs that
explains which PR would force the other to rebase if merged first.

## What was done?

Reworked the potential-conflicts workflow to:

- Replace the external conflict-checker and sticky-comment actions with a
  repository-local Python handler.
- Discover same-base open PRs with overlapping changed files through the GitHub
  API.
- Validate overlap candidates with GitHub's pre-mergeability page before
  reporting them.
- Maintain one GitHub Actions-owned advisory comment per affected PR.
- Show both directions in that comment:
  - "If this PR merges first"
  - "If these PRs merge first"
- Update reciprocal comments on the conflicting PRs so both sides show the
  merge-order risk.
- Keep the workflow advisory-only with `continue-on-error`, so conflicts do not
  make CI red.
- Clean stale reciprocal state when conflicts disappear, PRs close, or PRs are
  converted to draft.
- Ignore user-authored comments that forge the managed marker; only
  `github-actions[bot]` comments are treated as workflow-owned state.
- Serialize the workflow globally to avoid reciprocal comment write races.

## How Has This Been Tested?

Validated locally on macOS with:

```bash
python3 .github/workflows/test_handle_potential_conflicts.py
python3 -m py_compile \
  .github/workflows/handle_potential_conflicts.py \
  .github/workflows/test_handle_potential_conflicts.py
python3 test/lint/lint-python.py \
  .github/workflows/handle_potential_conflicts.py \
  .github/workflows/test_handle_potential_conflicts.py
git diff --check 25aeb5f9b5ebd0c121593dd3d60d253b32c0401a..HEAD
```

Ran a live read-only dry-run against `dashpay/dash#7419`:

```bash
GITHUB_TOKEN=$(gh auth token) \
  GITHUB_REPOSITORY=dashpay/dash \
  .github/workflows/handle_potential_conflicts.py \
  --pr-number 7419 \
  --dry-run
```

- The dry-run found `dashpay/dash#7052` as the validated advisory conflict
  and rendered the managed comment body without writing comments.

Also ran an Opus sidecar design pass and multiple Codex review-gate passes. The
final blocker-only review returned `No issues found`.

## Breaking Changes

None. The workflow remains advisory-only and does not fail CI when conflicts are
found or when comment updates fail.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository
  code-owners and collaborators only)_
