### PR TITLE
refactor: drop usages of govman from regression tests

### DIFF
--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -69,7 +69,6 @@
 #include <evo/specialtx.h>
 #include <evo/specialtxman.h>
 #include <flat-database.h>
-#include <governance/governance.h>
 #include <llmq/context.h>
 #include <llmq/signing.h>
 #include <masternode/meta.h>
@@ -347,8 +346,6 @@ void ChainTestingSetup::LoadVerifyActivateChainstate()
                                            llmq::DEFAULT_MAX_RECOVERED_SIGS_AGE);
     assert(!maybe_load_error.has_value());
 
-    m_node.govman = std::make_unique<CGovernanceManager>(*m_node.mn_metaman, *m_node.chainman, *m_node.chain_helper->superblocks, *m_node.dmnman, *m_node.mn_sync);
-
     auto maybe_verify_error = VerifyLoadedChainstate(
         chainman,
         *Assert(m_node.evodb.get()),
@@ -431,11 +428,6 @@ TestingSetup::~TestingSetup()
     if (m_node.connman) {
         m_node.connman->Stop();
     }
-
-    // govman holds a reference to chain_helper->superblocks, so it must be reset
-    // before DashChainstateSetupClose() destroys chain_helper (matches PrepareShutdown
-    // ordering in init.cpp).
-    m_node.govman.reset();
 
     // DashChainstateSetup() is called by LoadChainstate() internally but
     // winding them down is our responsibility


### PR DESCRIPTION
## Issue being fixed or feature implemented
It's unused and useless. Should be tested by functional tests or explicitely created for some regression test but not as a part of each node.

## What was done?
Removed govman from NodeContext initialization for regtest.

## How Has This Been Tested?
Run unit & functional tets.

## Breaking Changes
N/A

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

