### PR TITLE
backport: Merge bitcoin#27151, 25849

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -21,11 +21,11 @@
 #include <algorithm>
 #include <limits>
 #include <stdexcept>
+#include <utility>
 #ifdef ARENA_DEBUG
 #include <iomanip>
 #include <iostream>
 #endif
-#include <utility>
 
 LockedPoolManager* LockedPoolManager::_instance = nullptr;
 

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -223,8 +223,8 @@ RPCHelpMan sendtoaddress()
                     {"use_is", RPCArg::Type::BOOL, RPCArg::Default{false}, "Deprecated and ignored"},
                     {"use_cj", RPCArg::Type::BOOL, RPCArg::Default{false}, "Use CoinJoin funds only"},
                     {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
-                    {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
-                    "       \"" + FeeModes("\"\n\"") + "\""},
+                    {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
+                     "\"" + FeeModes("\"\n\"") + "\""},
                     {"avoid_reuse", RPCArg::Type::BOOL, RPCArg::Default{true}, "(only available if avoid_reuse wallet flag is set) Avoid spending from dirty addresses; addresses are considered\n"
                                          "dirty if they have previously been used in a transaction."},
                     {"fee_rate", RPCArg::Type::AMOUNT, RPCArg::DefaultHint{"not set, fall back to wallet fee estimation"}, "Specify a fee rate in " + CURRENCY_ATOM + "/B."},
@@ -335,8 +335,8 @@ RPCHelpMan sendmany()
                     {"use_is", RPCArg::Type::BOOL, RPCArg::Default{false}, "Deprecated and ignored"},
                     {"use_cj", RPCArg::Type::BOOL, RPCArg::Default{false}, "Use CoinJoin funds only"},
                     {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
-                    {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
-            "       \"" + FeeModes("\"\n\"") + "\""},
+                    {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
+                    "\"" + FeeModes("\"\n\"") + "\""},
                     {"fee_rate", RPCArg::Type::AMOUNT, RPCArg::DefaultHint{"not set, fall back to wallet fee estimation"}, "Specify a fee rate in " + CURRENCY_ATOM + "/B."},
                     {"verbose", RPCArg::Type::BOOL, RPCArg::Default{false}, "If true, return extra information about the transaction."},
                 },
@@ -450,8 +450,8 @@ static std::vector<RPCArg> FundTxDoc(bool solving_data = true)
 {
     std::vector<RPCArg> args = {
         {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
-        {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
-            "         \"" + FeeModes("\"\n\"") + "\""},
+        {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
+                    "\"" + FeeModes("\"\n\"") + "\""},
     };
     if (solving_data) {
         args.push_back({"solving_data", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED_NAMED_ARG, "Keys and scripts needed for producing a final transaction with a dummy signature.\n"
@@ -920,8 +920,8 @@ RPCHelpMan send()
                 },
             },
             {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
-            {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
-                        "       \"" + FeeModes("\"\n\"") + "\""},
+            {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
+                              "\"" + FeeModes("\"\n\"") + "\""},
             {"fee_rate", RPCArg::Type::AMOUNT, RPCArg::DefaultHint{"not set, fall back to wallet fee estimation"}, "Specify a fee rate in " + CURRENCY_ATOM + "/B."},
             {"options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED_NAMED_ARG, "",
                 Cat<std::vector<RPCArg>>(
@@ -1038,8 +1038,8 @@ RPCHelpMan sendall()
                 },
             },
             {"conf_target", RPCArg::Type::NUM, RPCArg::DefaultHint{"wallet -txconfirmtarget"}, "Confirmation target in blocks"},
-            {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, std::string() + "The fee estimate mode, must be one of (case insensitive):\n"
-                        "       \"" + FeeModes("\"\n\"") + "\""},
+            {"estimate_mode", RPCArg::Type::STR, RPCArg::Default{"unset"}, "The fee estimate mode, must be one of (case insensitive):\n"
+             "\"" + FeeModes("\"\n\"") + "\""},
             {"fee_rate", RPCArg::Type::AMOUNT, RPCArg::DefaultHint{"not set, fall back to wallet fee estimation"}, "Specify a fee rate in " + CURRENCY_ATOM + "/B."},
             {
                 "options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED_NAMED_ARG, "",


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD026 MD041 -->

## Issue being fixed or feature implemented

Replacement for dashpay/dash#7128.

This backports two small Bitcoin Core cleanups:

- bitcoin/bitcoin#27151: remove the duplicate `<utility>` include from `src/support/lockedpool.cpp`
- bitcoin/bitcoin#25849: remove unnecessary `std::string() +` prefixes from wallet RPC fee-estimate help strings

The original PR had stale review feedback because the #27151 cherry-pick removed Dash's only direct `<utility>` include after prior backports had already diverged, and the #25849 cherry-pick missed two Dash wallet RPC callsites. This replacement branch is rebuilt on current `develop` and folds those fixes into the corresponding backport commits.

## What was done?

- Rebuilt the branch from current `upstream/develop`.
- Kept `src/support/lockedpool.cpp` with one direct `<utility>` include while removing the duplicate.
- Completed the wallet RPC help-string cleanup for `sendtoaddress`, `sendmany`, `FundTxDoc`, `send`, and `sendall`.
- Preserved a clean two-commit backport history with no review-fix follow-up commits.

## How Has This Been Tested?

Local validation on macOS:

- `git diff --check upstream/develop...HEAD`
- `COMMIT_RANGE=upstream/develop..HEAD test/lint/lint-whitespace.py`
- `python3 test/lint/lint-includes.py`
- `./autogen.sh`
- `./configure --without-gui --disable-bench --disable-fuzz-binary --without-miniupnpc --without-natpmp`
- `make -C src support/libbitcoin_util_a-lockedpool.o wallet/rpc/libbitcoin_wallet_a-spend.o -j4`
- `make -C src dashd test/test_dash -j4`
- `src/test/test_dash --run_test=rpc_tests`
- `code-review dashpay/dash upstream/develop takeover-7128-clean-backport-27151-25849 "Replacement for dashpay/dash#7128: clean Bitcoin Core backport of #27151 and #25849 with prior review feedback resolved"`

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
