### PR TITLE
backport: Merge bitcoin#29041

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -119,7 +119,7 @@ class NetTest(DashTestFramework):
         self.log.info("Check getpeerinfo output before a version message was sent")
         no_version_peer_id = 3
         no_version_peer_conntime = self.mocktime
-        with self.nodes[0].assert_debug_log([f"Added connection peer={no_version_peer_id}"]):
+        with self.nodes[0].wait_for_new_peer():
             no_version_peer = self.nodes[0].add_p2p_connection(P2PInterface(), send_version=False, wait_for_verack=False)
         if self.options.v2transport:
             self.wait_until(lambda: self.nodes[0].getpeerinfo()[no_version_peer_id]["transport_protocol_type"] == "v2")


### PR DESCRIPTION
# backport: Merge bitcoin#29041

## Issue being fixed or feature implemented

- Replaces dashpay/dash#7190 with the independent bitcoin#29041 backport only.
- Fixes an intermittent `rpc_net.py` race where waiting for the
  `"Added connection peer="` debug log does not guarantee the new peer is
  already visible through `getpeerinfo()`.
- Intentionally does not include bitcoin#29034 from the original PR title.
  Review on #7190 noted bitcoin#29034 depends on prerequisite context,
  including bitcoin#28956, so this replacement keeps that separate instead of
  backporting an incomplete fragment.

## What was done?

- Backported bitcoin#29041:
  - `test: fix intermittent error in rpc_net.py (#29030)`
- Replaced the debug-log wait with the existing `wait_for_new_peer()` helper
  from the already-merged bitcoin#29006 backport.

## How Has This Been Tested?

- `git diff --check upstream/develop...HEAD`
- `COMMIT_RANGE=upstream/develop..HEAD test/lint/lint-whitespace.py`
- `python3 -m py_compile test/functional/rpc_net.py`
- `./autogen.sh`
- `./configure --without-gui --disable-bench --disable-fuzz-binary`
- `make -C src/dashbls -j4`
- `make -C src/secp256k1 -j4`
- `make -C src dashd -j4`
- `test/functional/rpc_net.py`
- `code-review dashpay/dash upstream/develop takeover-7190-backport-29041`

## Breaking Changes

- None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
