### PR TITLE
backport: keep PoSe score visible when hiding banned masternodes

### DIFF
--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -291,7 +291,6 @@ void MasternodeList::on_checkBoxOwned_stateChanged(int state)
 void MasternodeList::on_checkBoxHideBanned_stateChanged(int state)
 {
     const bool hide_banned{state == Qt::Checked};
-    ui->tableViewMasternodes->setColumnHidden(MasternodeModel::POSE, hide_banned);
     m_proxy_model->setHideBanned(hide_banned);
     m_proxy_model->forceInvalidateFilter();
     updateFilteredCount();


### PR DESCRIPTION
## Issue being fixed or feature implemented

The **Hide banned** checkbox on the Masternodes tab filters PoSe-banned
masternodes, but v23.1.x also hides the entire PoSe Score column. This prevents
users from seeing residual PoSe penalties on masternodes that are not yet
banned.

This was reported in dashpay/dash#7286 and fixed on `develop` by
dashpay/dash#7298. The fix has not reached the v23.1.x release branch.

## What was done?

Backport the merged one-line fix from dashpay/dash#7298. The checkbox continues
to filter banned rows through `MasternodeListSortFilterProxyModel`, while the
PoSe Score column remains visible.

## How Has This Been Tested?

- Confirmed the v23.1.x handler explicitly hides the PoSe column when the
  checkbox is selected.
- Confirmed the banned-row filter remains independently enforced by the proxy
  model after removing the column-visibility call.
- Verified the backport patch is byte-for-byte identical to the merged fix.
- `git diff --check`
- Mandatory local pre-PR review: `ship`

A full GUI build was not run locally; GitHub CI will provide the branch build
coverage.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
