### PR TITLE
fix: reject MnEHF signals outside deployment time range

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -110,8 +110,10 @@ bool CChainParams::IsValidMNActivation(int nBit, int64_t timePast) const
 {
     assert(nBit < VERSIONBITS_NUM_BITS);
 
+    bool found{false};
     for (int index = 0; index < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++index) {
         if (consensus.vDeployments[index].bit == nBit) {
+            found = true;
             auto& deployment = consensus.vDeployments[index];
             if (timePast > deployment.nTimeout || timePast < deployment.nStartTime) {
                 LogPrintf("%s: activation by bit=%d deployment='%s' is out of time range start=%lld timeout=%lld\n", __func__, nBit, VersionBitsDeploymentInfo[Consensus::DeploymentPos(index)].name, deployment.nStartTime, deployment.nTimeout);
@@ -124,6 +126,10 @@ bool CChainParams::IsValidMNActivation(int nBit, int64_t timePast) const
             LogPrintf("%s: set MnEHF for bit=%d is valid\n", __func__, nBit);
             return true;
         }
+    }
+    if (found) {
+        LogPrintf("%s: MnEHF fork bit=%d is outside all configured deployment time ranges\n", __func__, nBit);
+        return false;
     }
     LogPrintf("%s: WARNING: unknown MnEHF fork bit=%d\n", __func__, nBit);
     return true;


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CChainParams::IsValidMNActivation()` incorrectly returns `true` when a known MnEHF deployment bit is outside all its configured time ranges.

When the function finds a deployment with the requested bit but the deployment is outside its valid time range, it continues searching for another deployment using the same bit. If no eligible deployment is found, execution reaches the unknown-bit fallback:

```cpp
LogPrintf("%s: WARNING: unknown MnEHF fork bit=%d\n", __func__, nBit);
return true;
```

The bit is not actually unknown in this case. It matched a configured deployment, but that deployment was not eligible at the supplied time.

As a result, a known MnEHF signal can be signed and accepted before its deployment start time or after its timeout.

## What was done?

The function now tracks whether the requested bit matched any configured deployment.

It continues checking all matching deployments so that reuse of the same version bit remains supported.

If the bit matched at least one configured deployment, but none of those deployments is within its valid time range, the function returns `false` instead of falling through to the unknown-bit fallback.

The resulting behavior is:

```text
Known bit with an eligible EHF deployment
    -> return true

Known bit matching a non-EHF deployment
    -> return false

Known bit outside all configured deployment time ranges
    -> return false

Genuinely unknown bit
    -> preserve the existing fallback behavior
```

The existing behavior for genuinely unknown bits remains unchanged. This preserves compatibility with historical MnEHF transactions whose deployments have since been buried and removed from `vDeployments`.

## How Has This Been Tested?

The updated control flow was reviewed for the following cases:

- a known EHF bit inside its valid time range is accepted;
- a known EHF bit before its deployment start time is rejected;
- a known EHF bit after its deployment timeout is rejected;
- reuse of the same version bit by multiple deployments remains supported;
- a matching non-EHF deployment is rejected;
- a genuinely unknown historical bit retains the existing fallback behavior.

The patch was also checked with:

```bash
git diff --check
```

No whitespace errors were reported.

No automated tests were added as part of this change.

## Breaking Changes

This change modifies MnEHF validation for known deployment bits.

A known bit is now rejected when none of its configured deployment time ranges is valid. Previously, that case could fall through to the unknown-bit fallback and be accepted.

The behavior for genuinely unknown historical bits is unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone