### PR TITLE
test: make governance vote fixtures wire-valid

### DIFF
--- a/src/test/governance_inv_tests.cpp
+++ b/src/test/governance_inv_tests.cpp
@@ -155,6 +155,7 @@ CGovernanceVote MakeGovernanceVote(const uint256& parent_hash)
 {
     CGovernanceVote vote{COutPoint{uint256S("11"), 1}, parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES};
     vote.SetTime(GetTime<std::chrono::seconds>().count());
+    vote.SetSignature(std::vector<unsigned char>(CGovernanceVote::COMPACT_SIG_SIZE));
     return vote;
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The governance inventory tests merged in #7442 construct unsigned synthetic votes and round-trip them through the network parser. Develop now requires governance vote signatures to use a structurally valid 65- or 96-byte encoding, so the fixture is rejected as malformed before the authorization behavior under test is reached. This causes six unit-test failures across CI configurations.

## What was done?

Give the synthetic `VOTE_SIGNAL_FUNDING` vote a compact-signature-sized placeholder. The 65-byte encoding matches the real ECDSA voting-key form for funding votes. These tests deliberately use a missing parent object, so vote processing takes the orphan path before cryptographic signature verification; production validation is unchanged.

## How Has This Been Tested?

- Built `src/test/test_dash` in an isolated macOS arm64 worktree using the depends toolchain
- `./src/test/test_dash --run_test=governance_inv_tests`
- `./src/test/test_dash --run_test=governance_vote_wire_tests`
- `git diff --check`
- Mandatory independent pre-PR review gate: `ship` with no findings

## Breaking Changes

None. Test-only change.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone