### PR TITLE
fix: avoid int8_t truncation of -parbls before clamping

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2064,14 +2064,16 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                               /*coins_db_in_memory=*/false,
                                               /*dash_dbs_in_memory=*/false,
                                               /*bls_threads=*/[&args]() -> int8_t {
-                                                  int threads = args.GetIntArg("-parbls", llmq::DEFAULT_BLSCHECK_THREADS);
+                                                  int64_t threads = args.GetIntArg("-parbls", llmq::DEFAULT_BLSCHECK_THREADS);
                                                   if (threads <= 0) {
                                                       // -parbls=0 means autodetect (number of cores - 1 validator threads)
                                                       // -parbls=-n means "leave n cores free" (number of cores - n - 1 validator threads)
                                                       threads += GetNumCores();
                                                   }
                                                   // Subtract 1 because the main thread counts towards the par threads
-                                                  return static_cast<int8_t>(std::clamp(threads - 1, 0, int{llmq::MAX_BLSCHECK_THREADS}));
+                                                  const int64_t adjusted_threads = std::clamp<int64_t>(
+                                                      threads, 1, int64_t{llmq::MAX_BLSCHECK_THREADS} + 1) - 1;
+                                                  return static_cast<int8_t>(adjusted_threads);
                                               }(),
                                               llmq::DEFAULT_WORKER_COUNT,
                                               args.GetIntArg("-maxrecsigsage", llmq::DEFAULT_MAX_RECOVERED_SIGS_AGE),

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2064,14 +2064,14 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                               /*coins_db_in_memory=*/false,
                                               /*dash_dbs_in_memory=*/false,
                                               /*bls_threads=*/[&args]() -> int8_t {
-                                                  int8_t threads = args.GetIntArg("-parbls", llmq::DEFAULT_BLSCHECK_THREADS);
+                                                  int threads = args.GetIntArg("-parbls", llmq::DEFAULT_BLSCHECK_THREADS);
                                                   if (threads <= 0) {
                                                       // -parbls=0 means autodetect (number of cores - 1 validator threads)
                                                       // -parbls=-n means "leave n cores free" (number of cores - n - 1 validator threads)
                                                       threads += GetNumCores();
                                                   }
                                                   // Subtract 1 because the main thread counts towards the par threads
-                                                  return std::clamp<int8_t>(threads - 1, 0, llmq::MAX_BLSCHECK_THREADS);
+                                                  return static_cast<int8_t>(std::clamp(threads - 1, 0, int{llmq::MAX_BLSCHECK_THREADS}));
                                               }(),
                                               llmq::DEFAULT_WORKER_COUNT,
                                               args.GetIntArg("-maxrecsigsage", llmq::DEFAULT_MAX_RECOVERED_SIGS_AGE),


### PR DESCRIPTION
## Issue being fixed or feature implemented

`-parbls` is parsed as an `int64_t`, but it was narrowed to `int8_t` before the value was adjusted and clamped. Values above 127, such as `-parbls=200`, could therefore wrap negative and take the "leave cores free" path instead of clamping to the configured maximum.

## What was done?

Keep the BLS verification thread count in `int64_t` while applying the autodetection adjustment and clamp. Clamp the pre-subtraction value to `[1, MAX_BLSCHECK_THREADS + 1]`, then subtract one and cast to `int8_t`. This preserves the intended `[0, MAX_BLSCHECK_THREADS]` result across the full accepted `int64_t` argument range without signed underflow.

## How Has This Been Tested?

- Built `src/dashd` and `src/dash-cli` on macOS arm64.
- Started regtest nodes with `-parbls=2147483681` and `-parbls=9223372036854775807`; both reported 33 BLS verification threads, the configured maximum.
- Ran `git diff --check`.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_