### PR TITLE
ci: hand prepared macOS SDK to downstream jobs

### DIFF
--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -32,6 +32,9 @@ on:
       built-artifact:
         description: "Artifact holding freshly built depends (empty when restored from cache)"
         value: ${{ jobs.build.outputs.built-artifact }}
+      sdk-artifact:
+        description: "Artifact holding prepared SDKs (empty when restored from cache)"
+        value: ${{ jobs.check-cache.outputs.sdk-artifact }}
 
 jobs:
   check-cache:
@@ -43,6 +46,7 @@ jobs:
       cache-key-prefix: ${{ steps.setup.outputs.cache-key-prefix }}
       host: ${{ steps.setup.outputs.HOST }}
       dep-opts: ${{ steps.setup.outputs.DEP_OPTS }}
+      sdk-artifact: ${{ steps.prepare-sdks.outputs.artifact }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -95,8 +99,25 @@ jobs:
           restore-keys: depends-sdks-
 
       - name: Prepare SDKs
+        id: prepare-sdks
         if: inputs.build-target == 'mac' && steps.cache-sdk-check.outputs.cache-hit != 'true'
-        run: ./contrib/containers/guix/scripts/setup-sdk
+        env:
+          BUILD_TARGET: ${{ inputs.build-target }}
+        run: |
+          ./contrib/containers/guix/scripts/setup-sdk
+          echo "artifact=depends-sdks-${BUILD_TARGET}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload prepared SDKs
+        # This originates in check-cache so both Build depends (when needed)
+        # and Build source can use it even when a PR cannot save the cache.
+        if: steps.prepare-sdks.outputs.artifact != ''
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ steps.prepare-sdks.outputs.artifact }}
+          path: depends/SDKs
+          compression-level: 0
+          retention-days: 1
+          overwrite: true
 
   build:
     name: Build depends
@@ -122,13 +143,27 @@ jobs:
           restore-keys: depends-sources-
 
       - name: Restore SDKs cache
+        id: sdk-cache
         uses: actions/cache/restore@v5
         if: inputs.build-target == 'mac'
         with:
           path: depends/SDKs
           key: depends-sdks-${{ hashFiles('depends/hosts/darwin.mk') }}
           restore-keys: depends-sdks-
-          fail-on-cache-miss: true
+
+      - name: Download prepared SDKs
+        if: inputs.build-target == 'mac' && steps.sdk-cache.outputs.cache-hit != 'true' && needs.check-cache.outputs.sdk-artifact != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.check-cache.outputs.sdk-artifact }}
+          path: depends/SDKs
+
+      - name: Check prepared SDKs are present
+        if: inputs.build-target == 'mac' && steps.sdk-cache.outputs.cache-hit != 'true' && needs.check-cache.outputs.sdk-artifact == ''
+        run: |
+          echo "::error::SDK cache restore missed and no prepared SDK artifact was provided"
+          exit 1
+        shell: bash
 
       - name: Restore cached depends
         uses: actions/cache/restore@v5

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: ""
+      sdk-artifact:
+        description: "Artifact holding prepared SDKs, used if the cache restore misses"
+        required: false
+        type: string
+        default: ""
       runs-on:
         description: "Runner label to use (e.g., ubuntu-24.04 or ubuntu-24.04-arm)"
         required: true
@@ -66,13 +71,27 @@ jobs:
         shell: bash
 
       - name: Restore SDKs cache
+        id: sdk-cache
         uses: actions/cache/restore@v5
         if: inputs.build-target == 'mac'
         with:
           path: |
             depends/SDKs
           key: depends-sdks-${{ hashFiles('depends/hosts/darwin.mk') }}
-          fail-on-cache-miss: true
+
+      - name: Download prepared SDKs
+        if: inputs.build-target == 'mac' && steps.sdk-cache.outputs.cache-hit != 'true' && inputs.sdk-artifact != ''
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ inputs.sdk-artifact }}
+          path: depends/SDKs
+
+      - name: Check prepared SDKs are present
+        if: inputs.build-target == 'mac' && steps.sdk-cache.outputs.cache-hit != 'true' && inputs.sdk-artifact == ''
+        run: |
+          echo "::error::SDK cache restore missed and no prepared SDK artifact was provided"
+          exit 1
+        shell: bash
 
       - name: Restore depends cache
         id: depends-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,6 +316,7 @@ jobs:
       depends-host: ${{ needs.depends-mac.outputs.host }}
       depends-dep-opts: ${{ needs.depends-mac.outputs.dep-opts }}
       depends-artifact: ${{ needs.depends-mac.outputs.built-artifact }}
+      sdk-artifact: ${{ needs.depends-mac.outputs.sdk-artifact }}
       runs-on: ${{ needs.check-skip.outputs['runner-amd64'] }}
 
   src-win64:


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fork pull request workflows can restore GitHub Actions caches but cannot persist a missing macOS SDK cache entry. The trusted `build-depends` cache-check job prepares the SDK, but both the downstream depends build and macOS source build previously required a successful cache restore, so the prepared SDK was lost between jobs.

Fixes #7461.

## What was done?

- Expose a short-lived same-run SDK artifact from the macOS depends cache-check job whenever it prepares the SDK.
- Restore the persistent SDK cache first in both downstream consumers, then download the prepared artifact when the exact cache entry is unavailable.
- Fail with an explicit error if neither the cache nor the same-run artifact is available.
- Keep the existing trusted cache-warming behavior unchanged.

## How Has This Been Tested?

- `actionlint` schema and expression validation for the three changed workflows (ignoring the repository's pre-existing ShellCheck warnings)
- Ruby YAML parsing for the three changed workflows
- `test/lint/lint-whitespace.py`
- `git diff upstream/develop...HEAD --check`
- `git show --check`
- `git verify-commit HEAD`
- Independent exact-commit code review: zero findings, recommendation `ship`

The hosted cache/artifact transfer itself requires a live GitHub Actions run and will be validated by this pull request's CI.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests (workflow-only change; validated with workflow and repository linters)
- [ ] I have made corresponding changes to the documentation (not applicable)
- [ ] I have assigned this pull request to a milestone (for repository code-owners and collaborators only)
