### PR TITLE
fix: correct masternode operator key BLS scheme handling (desync + cross-scheme uniqueness)

### DIFF
--- a/doc/release-notes-7473.md
+++ b/doc/release-notes-7473.md
@@ -1,0 +1,25 @@
+Notable changes
+===============
+
+* Masternode operator key uniqueness is now enforced per key rather than per BLS
+  encoding. After the v24 hard fork activates, registering or updating to an
+  operator public key already used by another masternode is rejected regardless of
+  which BLS scheme (legacy or basic) either side is encoded under, closing a gap
+  where the same key could be claimed twice under different encodings.
+
+Updated RPCs
+------------
+
+* After the v24 hard fork activates, a legacy (LegacyBLS) masternode migrates to the
+  basic BLS scheme *in place* when its state version is raised, keeping the same
+  operator key: the stored operator public key is re-encoded from the legacy to the
+  basic scheme, with no key rotation required. `protx update_service` and
+  `protx update_registrar` build the corresponding basic-scheme migration
+  transaction for a legacy masternode, and the masternode is no longer PoSe-banned by
+  the change. The `..._legacy` RPC variants keep the masternode on the legacy scheme.
+  Previously a legacy masternode could not move to the basic scheme without
+  effectively rotating its operator key, and `update_registrar` clamped the
+  transaction version silently.
+
+These changes are gated on the v24 deployment and have no effect until it activates
+(v24 is not yet scheduled on mainnet or testnet).

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -443,6 +443,33 @@ public:
         return GetMN(p->first);
     }
 
+    /**
+     * Is this operator public key already held by a masternode other than `self`, under *either* BLS
+     * encoding?
+     *
+     * mnUniquePropertyMap is keyed by GetUniquePropertyHash(), which serializes its argument, and a
+     * BLS key serializes differently under the legacy and basic schemes. So one public key sits in
+     * one of two possible slots and a single lookup sees only one of them, which is why operator key
+     * uniqueness is otherwise enforced per encoding rather than per key. There are exactly two
+     * schemes, so probing both is O(1) rather than a scan.
+     *
+     * Both slots are probed even when one resolves to `self`: where a cross-scheme duplicate pair
+     * already exists, returning early on a self-match would miss the other member.
+     *
+     * Pass uint256() as `self` to exclude nothing.
+     */
+    [[nodiscard]] bool HasOperatorKeyUnderAnyScheme(const CBLSPublicKey& pubkey, const uint256& self) const
+    {
+        for (const bool legacy_scheme : {true, false}) {
+            CBLSLazyPublicKey wrapped;
+            wrapped.Set(pubkey, legacy_scheme);
+            if (!HasUniqueProperty(wrapped)) continue;
+            const auto holder = GetUniquePropertyMN(wrapped);
+            if (holder && holder->proTxHash != self) return true;
+        }
+        return false;
+    }
+
     // Compare two masternode lists for equality, ignoring non-deterministic members.
     // Non-deterministic members (nTotalRegisteredCount, internalId) can differ between
     // nodes due to different sync histories, but don't affect consensus validity.

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -578,7 +578,16 @@ private:
     template <typename T>
     [[nodiscard]] bool UpdateUniqueProperty(const CDeterministicMN& dmn, const T& oldValue, const T& newValue)
     {
-        if (oldValue == newValue) {
+        // A BLS operator key can keep the same point while its serialized encoding (legacy<->basic)
+        // changes on a version transition. The map is keyed by GetUniquePropertyHash(), so only that
+        // hash reveals the entry must be re-keyed to the new scheme; CBLSLazyPublicKey::operator==
+        // compares the point and ignores the scheme, so it would wrongly short-circuit. Compare the
+        // serialized hashes for BLS keys and the plain value for every other unique property.
+        if constexpr (std::is_same_v<std::decay_t<T>, CBLSLazyPublicKey>) {
+            if (GetUniquePropertyHash(oldValue) == GetUniquePropertyHash(newValue)) {
+                return true;
+            }
+        } else if (oldValue == newValue) {
             return true;
         }
         static const T nullValue{};

--- a/src/evo/dmnstate.h
+++ b/src/evo/dmnstate.h
@@ -236,6 +236,16 @@ public:
                     member.get(state) = member.get(b);
                     fields |= member.mask;
                 }
+            } else if constexpr (BaseType::mask == Field_pubKeyOperator) {
+                // CBLSLazyPublicKey::operator== compares the underlying key and ignores its BLS
+                // encoding, but a scheme migration re-encodes the same key (legacy->basic). That must
+                // be captured in the diff -- GetHash() is scheme-dependent -- or a diff-reconstructed
+                // list keeps the old encoding while an online-built list has the new one, and the two
+                // diverge (mnUniquePropertyMap included).
+                if (member.get(a).GetHash() != member.get(b).GetHash()) {
+                    member.get(state) = member.get(b);
+                    fields |= member.mask;
+                }
             } else {
                 if (member.get(a) != member.get(b)) {
                     member.get(state) = member.get(b);

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -384,6 +384,15 @@ bool CSpecialTxProcessor::RebuildListFromBlock(const CBlock& block, gsl::not_nul
             }
             dmn->pdmnState = dmnState;
 
+            // CheckProRegTx ran against pindexPrev, so transactions in this same block are invisible
+            // to each other and two of them could claim one operator key under different encodings.
+            // Re-probe the list as rebuilt so far. AddMN() reports a duplicate by throwing, which
+            // would escape block assembly, so reject cleanly here instead.
+            if (is_v24_deployed &&
+                newList.HasOperatorKeyUnderAnyScheme(dmn->pdmnState->pubKeyOperator.Get(), /*self=*/uint256())) {
+                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-key");
+            }
+
             newList.AddMN(dmn);
 
             if (debugLogs) {
@@ -502,6 +511,17 @@ bool CSpecialTxProcessor::RebuildListFromBlock(const CBlock& block, gsl::not_nul
             } else {
                 newState->scriptPayout = opt_proTx->scriptPayout;
                 newState->payouts.clear();
+            }
+
+            // As in the registration path: CheckProUpRegTx ran against pindexPrev, so a second
+            // transaction in this same block claiming the same key under the other encoding is
+            // invisible to it. Same key-change scoping as that check -- an update keeping its own key
+            // cannot create a duplicate. UpdateMN() reports duplicates by throwing, which would
+            // escape block assembly, so reject cleanly here instead.
+            if (is_v24_deployed && !(opt_proTx->pubKeyOperator == dmn->pdmnState->pubKeyOperator) &&
+                newList.HasOperatorKeyUnderAnyScheme(opt_proTx->pubKeyOperator.Get(),
+                                                     /*self=*/opt_proTx->proTxHash)) {
+                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-key");
             }
 
             newList.UpdateMN(opt_proTx->proTxHash, newState);
@@ -1126,6 +1146,15 @@ bool CheckProRegTx(const CTransaction& tx, gsl::not_null<const CBlockIndex*> pin
             return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
         }
 
+        // The check above only sees the operator key under the encoding this payload happens to use,
+        // so it misses a key an existing masternode holds under the other one. A ProRegTx never
+        // proves ownership of the operator key, so that gap lets anyone claim a masternode's key.
+        // Nothing is excluded here: a duplicate key is never allowed, even for a ProTx replacing an
+        // existing masternode.
+        if (is_v24_active && mnList.HasOperatorKeyUnderAnyScheme(opt_ptx->pubKeyOperator.Get(), /*self=*/uint256())) {
+            return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
+        }
+
         // never allow duplicate platformNodeIds for EvoNodes
         if (opt_ptx->nType == MnType::Evo) {
             if (mnList.HasUniqueProperty(opt_ptx->platformNodeID)) {
@@ -1285,6 +1314,17 @@ bool CheckProUpRegTx(const CTransaction& tx, gsl::not_null<const CBlockIndex*> p
         if (opt_ptx->proTxHash != otherDmn->proTxHash) {
             return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
         }
+    }
+
+    // As above, but for the key under its other encoding, which the check above cannot see. Only
+    // when the key is actually changing: an update that keeps its own key cannot create a new
+    // duplicate, and probing it anyway would let a cross-scheme pair formed before activation
+    // permanently block that masternode's registrar updates unless it rotated its key -- making an
+    // old squat more harmful rather than less.
+    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_V24) &&
+        !(opt_ptx->pubKeyOperator == dmn->pdmnState->pubKeyOperator) &&
+        mnList.HasOperatorKeyUnderAnyScheme(opt_ptx->pubKeyOperator.Get(), /*self=*/opt_ptx->proTxHash)) {
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
     }
 
     if (!DeploymentDIP0003Enforced(pindexPrev->nHeight, Params().GetConsensus())) {

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -41,6 +41,13 @@ static bool AddNetInfoEntries(const std::shared_ptr<NetInfoInterface>& net_info,
     return true;
 }
 
+// Raising a masternode's state version out of the legacy BLS scheme re-encodes its operator key and
+// moves it to a new scheme-dependent unique-property slot; the collision guards key off this.
+static bool IsSchemeMigration(int old_version, int new_version)
+{
+    return old_version == ProTxVersion::LegacyBLS && new_version > ProTxVersion::LegacyBLS;
+}
+
 static bool SetStateVersion(CDeterministicMNState& state_mn, uint16_t nVersion, MnType nType,
                             BlockValidationState& state)
 {
@@ -51,6 +58,19 @@ static bool SetStateVersion(CDeterministicMNState& state_mn, uint16_t nVersion, 
         state_mn.payouts = LegacyPayoutAsList(state_mn.scriptPayout);
         state_mn.scriptPayout.clear();
     }
+
+    // Keep the operator key's BLS encoding a deterministic function of nVersion, matching the SML and
+    // on-disk serialization, so the stored key and the (scheme-dependent) unique-property index use
+    // the same scheme on every node whether the list was built online or reloaded from a snapshot.
+    // Set() rather than SetLegacy(): the latter only flips the flag and leaves the cached
+    // serialization in the old encoding, so a reloaded node would decode a different key. This runs
+    // before the early return because callers pre-set nVersion, so the version may already match here
+    // while the key still needs re-encoding.
+    if (state_mn.pubKeyOperator != CBLSLazyPublicKey()) {
+        const CBLSPublicKey& pubkey{state_mn.pubKeyOperator.Get()};
+        state_mn.pubKeyOperator.Set(pubkey, nVersion == ProTxVersion::LegacyBLS);
+    }
+
     if (state_mn.nVersion == nVersion && state_mn.netInfo->CanStorePlatform() == needs_extended) {
         return true;
     }
@@ -470,6 +490,17 @@ bool CSpecialTxProcessor::RebuildListFromBlock(const CBlock& block, gsl::not_nul
                 }
             }
 
+            // Migrating a legacy masternode to the basic scheme re-encodes its stored key
+            // (SetStateVersion), moving it to the basic-scheme slot. Per-transaction checks ran
+            // against pindexPrev, so re-check against the list as rebuilt so far: if another
+            // masternode holds this key under either encoding, the re-key in UpdateMN() would throw
+            // out of block assembly.
+            if (is_v24_deployed && IsSchemeMigration(current_version, target_version) &&
+                newList.HasOperatorKeyUnderAnyScheme(dmn->pdmnState->pubKeyOperator.Get(),
+                                                     /*self=*/opt_proTx->proTxHash)) {
+                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-key");
+            }
+
             newList.UpdateMN(opt_proTx->proTxHash, newState);
             if (debugLogs) {
                 LogPrintf("%s -- MN %s updated at height %d: %s\n", __func__, opt_proTx->proTxHash.ToString(), nHeight,
@@ -490,6 +521,23 @@ bool CSpecialTxProcessor::RebuildListFromBlock(const CBlock& block, gsl::not_nul
             const bool operator_changed{newState->pubKeyOperator != opt_proTx->pubKeyOperator};
             const uint16_t target_version{is_v24_deployed ? std::max<uint16_t>(old_version, opt_proTx->nVersion)
                                                           : (operator_changed ? opt_proTx->nVersion : old_version)};
+
+            // Per-transaction checks ran against pindexPrev, so an earlier transaction in this same
+            // block is invisible to them. Re-evaluate against the list as rebuilt so far: this update
+            // moves the operator key to a new unique-property slot if it rotates the key or crosses
+            // the legacy->basic boundary (which re-encodes the key), and if that slot is held by
+            // another masternode the re-key in UpdateMN() would throw out of block assembly. Reject
+            // cleanly. Scoped to those two cases so a pre-existing cross-scheme pair's non-migrating
+            // routine update is not blocked.
+            {
+                const bool migrating{IsSchemeMigration(old_version, target_version)};
+                if (is_v24_deployed && (operator_changed || migrating) &&
+                    newList.HasOperatorKeyUnderAnyScheme(opt_proTx->pubKeyOperator.Get(),
+                                                         /*self=*/opt_proTx->proTxHash)) {
+                    return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-key");
+                }
+            }
+
             if (operator_changed) {
                 // reset all operator related fields and put MN into PoSe-banned state in case the operator key changes
                 newState->ResetOperatorFields();
@@ -497,11 +545,11 @@ bool CSpecialTxProcessor::RebuildListFromBlock(const CBlock& block, gsl::not_nul
                 newState->pubKeyOperator = opt_proTx->pubKeyOperator;
             }
             newState->keyIDVoting = opt_proTx->keyIDVoting;
+            // SetStateVersion() re-encodes the operator key to target_version's scheme, so the stored
+            // key stays consistent with its version whether it was carried in this payload (possibly
+            // under a different version's encoding) or migrated in place.
             if (!SetStateVersion(*newState, target_version, dmn->nType, state)) {
                 return false;
-            }
-            if (operator_changed) {
-                newState->pubKeyOperator.SetLegacy(target_version == ProTxVersion::LegacyBLS);
             }
             if (target_version >= ProTxVersion::ExtAddr) {
                 newState->payouts = opt_proTx->nVersion >= ProTxVersion::ExtAddr
@@ -511,17 +559,6 @@ bool CSpecialTxProcessor::RebuildListFromBlock(const CBlock& block, gsl::not_nul
             } else {
                 newState->scriptPayout = opt_proTx->scriptPayout;
                 newState->payouts.clear();
-            }
-
-            // As in the registration path: CheckProUpRegTx ran against pindexPrev, so a second
-            // transaction in this same block claiming the same key under the other encoding is
-            // invisible to it. Same key-change scoping as that check -- an update keeping its own key
-            // cannot create a duplicate. UpdateMN() reports duplicates by throwing, which would
-            // escape block assembly, so reject cleanly here instead.
-            if (is_v24_deployed && !(opt_proTx->pubKeyOperator == dmn->pdmnState->pubKeyOperator) &&
-                newList.HasOperatorKeyUnderAnyScheme(opt_proTx->pubKeyOperator.Get(),
-                                                     /*self=*/opt_proTx->proTxHash)) {
-                return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-protx-dup-key");
             }
 
             newList.UpdateMN(opt_proTx->proTxHash, newState);
@@ -1221,6 +1258,16 @@ bool CheckProUpServTx(const CTransaction& tx, gsl::not_null<const CBlockIndex*> 
         return false;
     }
 
+    // A service update carries no operator key, but raising a legacy masternode to the basic scheme
+    // re-encodes its stored key, moving it to the basic-scheme unique-property slot. If another
+    // masternode already holds that key under either encoding, the re-key in UpdateMN() would throw
+    // out of block assembly, so reject the migration cleanly here.
+    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_V24) &&
+        IsSchemeMigration(dmn->pdmnState->nVersion, opt_ptx->nVersion) &&
+        mnList.HasOperatorKeyUnderAnyScheme(dmn->pdmnState->pubKeyOperator.Get(), /*self=*/opt_ptx->proTxHash)) {
+        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
+    }
+
     // don't allow updating to addresses already used by other MNs
     for (const auto& entry : opt_ptx->netInfo->GetEntries()) {
         if (const auto service_opt{entry.GetAddrPort()}) {
@@ -1290,6 +1337,20 @@ bool CheckProUpRegTx(const CTransaction& tx, gsl::not_null<const CBlockIndex*> p
         return false;
     }
 
+    // This update moves the masternode's operator key to a new unique-property slot when it either
+    // rotates the key or crosses the legacy->basic scheme boundary (which re-encodes the key). Reject
+    // if that target slot is already held by another masternode -- under either encoding -- so the
+    // re-key in UpdateMN() cannot collide and throw out of block assembly. Scoped to those two cases
+    // so a pre-existing cross-scheme pair's non-migrating routine update is not blocked.
+    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_V24)) {
+        const bool key_changed{!(opt_ptx->pubKeyOperator == dmn->pdmnState->pubKeyOperator)};
+        const bool migrating{IsSchemeMigration(dmn->pdmnState->nVersion, opt_ptx->nVersion)};
+        if ((key_changed || migrating) &&
+            mnList.HasOperatorKeyUnderAnyScheme(opt_ptx->pubKeyOperator.Get(), /*self=*/opt_ptx->proTxHash)) {
+            return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
+        }
+    }
+
     const auto owner_payouts = GetOwnerPayouts(*opt_ptx);
     if (!IsPayoutListTriviallyValid(owner_payouts, dmn->pdmnState->keyIDOwner, opt_ptx->keyIDVoting, state)) return false;
 
@@ -1315,17 +1376,8 @@ bool CheckProUpRegTx(const CTransaction& tx, gsl::not_null<const CBlockIndex*> p
             return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
         }
     }
-
-    // As above, but for the key under its other encoding, which the check above cannot see. Only
-    // when the key is actually changing: an update that keeps its own key cannot create a new
-    // duplicate, and probing it anyway would let a cross-scheme pair formed before activation
-    // permanently block that masternode's registrar updates unless it rotated its key -- making an
-    // old squat more harmful rather than less.
-    if (DeploymentActiveAfter(pindexPrev, chainman, Consensus::DEPLOYMENT_V24) &&
-        !(opt_ptx->pubKeyOperator == dmn->pdmnState->pubKeyOperator) &&
-        mnList.HasOperatorKeyUnderAnyScheme(opt_ptx->pubKeyOperator.Get(), /*self=*/opt_ptx->proTxHash)) {
-        return state.Invalid(TxValidationResult::TX_BAD_SPECIAL, "bad-protx-dup-key");
-    }
+    // Cross-scheme duplicates for this update are rejected earlier (see the collision guard after the
+    // version-change check), which also covers the key-less migration case.
 
     if (!DeploymentDIP0003Enforced(pindexPrev->nHeight, Params().GetConsensus())) {
         if (dmn->pdmnState->keyIDOwner != opt_ptx->keyIDVoting) {

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -378,6 +378,23 @@ bool BlockAssembler::TestPackageTransactions(const CTxMemPool::setEntries& packa
             return false;
         }
 
+        // A special transaction that was valid when it entered the mempool can be invalidated by
+        // intervening state, most sharply by a fork activating a rule it violates, and nothing
+        // evicts it. Selection otherwise trusts mempool validity, so the entry would be picked into
+        // every template and TestBlockValidity would then reject the whole block, leaving an honest
+        // miner unable to produce one at all. Recheck here, at package granularity: the caller adds
+        // every member of a package that passes, so dropping one member while keeping its
+        // descendants would itself yield an invalid template. check_sigs is off because signatures
+        // were verified on entry and cannot have changed; note CheckMNHFTx() verifies its quorum
+        // signature regardless, which is cheap enough here given how rare MNHF signals are.
+        if (it->GetTx().IsSpecialTxVersion()) {
+            TxValidationState tx_state;
+            if (!m_chain_helper.special_tx->CheckSpecialTx(it->GetTx(), m_chainstate.m_chain.Tip(),
+                                                           m_chainstate.CoinsTip(), /*check_sigs=*/false, tx_state)) {
+                return false;
+            }
+        }
+
         const auto& txid = it->GetTx().GetHash();
         if (!m_isman.IsInstantSendEnabled() || m_isman.IsLocked(txid)) {
             continue;

--- a/src/node/miner.h
+++ b/src/node/miner.h
@@ -208,7 +208,7 @@ private:
       * Increments nPackagesSelected / nDescendantsUpdated with corresponding
       * statistics from the package selection (for logging statistics). */
     void addPackageTxs(const CTxMemPool& mempool, int& nPackagesSelected, int& nDescendantsUpdated,
-                       const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
+                       const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, mempool.cs);
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */
@@ -219,7 +219,7 @@ private:
       * locktime
       * These checks should always succeed, and they're here
       * only as an extra check in case of suboptimal node configuration */
-    bool TestPackageTransactions(const CTxMemPool::setEntries& package) const;
+    bool TestPackageTransactions(const CTxMemPool::setEntries& package) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     /** Sort the package in an order that is valid to appear in a block */
     void SortForBlock(const CTxMemPool::setEntries& package, std::vector<CTxMemPool::txiter>& sortedEntries);
 };

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1246,6 +1246,18 @@ static RPCHelpMan protx_update_registrar_wrapper(const bool specific_legacy_bls_
         ptx.pubKeyOperator = dmn->pdmnState->pubKeyOperator;
     }
 
+    // A legacy masternode migrates to the basic scheme via a (non-legacy) registrar update, keeping
+    // its operator key (migration) or supplying a new one (rotation). ptx.nVersion is already set from
+    // the deployment state above -- LegacyBLS for the legacy-BLS RPC variant, basic otherwise -- so
+    // only the key encoding needs fixing up here: a reused key is stored in the legacy encoding, so
+    // re-encode it to the basic scheme to keep the stored key consistent with its version (and the
+    // assertion below holding). A freshly parsed key already matches the requested scheme, and basic
+    // masternodes are untouched.
+    if (!use_legacy && ptx.pubKeyOperator != CBLSLazyPublicKey() && ptx.pubKeyOperator.IsLegacy()) {
+        const CBLSPublicKey& pubkey{ptx.pubKeyOperator.Get()};
+        ptx.pubKeyOperator.Set(pubkey, /*specificLegacyScheme=*/false);
+    }
+
     CHECK_NONFATAL(ptx.pubKeyOperator.IsLegacy() == (ptx.nVersion == ProTxVersion::LegacyBLS));
 
     if (!request.params[2].get_str().empty()) {

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -1483,17 +1483,66 @@ struct TestChainDIP3Setup : public TestChainDIP3BeforeActivationSetup {
     }
 };
 
-struct TestChainV24SignalBeforeV19Setup : public TestChainSetup {
-    TestChainV24SignalBeforeV19Setup() :
-        TestChainSetup(494, CBaseChainParams::REGTEST,
-                       {"-testactivationheight=v19@500", "-testactivationheight=v20@500",
-                        "-testactivationheight=mn_rr@511", "-vbparams=v24:0:9999999999:510:1:1:1:5:0"},
-                       /*coins_db_in_memory=*/true, /*block_tree_db_in_memory=*/true)
+struct TestMNChainSetup : public TestChainSetup {
+    TestMNChainSetup(int num_blocks, const std::vector<const char*>& extra_args) :
+        TestChainSetup(num_blocks, CBaseChainParams::REGTEST, extra_args,
+                       /*coins_db_in_memory=*/true, /*block_tree_db_in_memory=*/true),
+        chainman(*Assert(m_node.chainman)),
+        dmnman(*Assert(m_node.dmnman)),
+        utxos(BuildSimpleUtxoMap(m_coinbase_txns)),
+        coinbase_pk(GetScriptForRawPubKey(coinbaseKey.GetPubKey()))
     {
-        assert(WITH_LOCK(::cs_main, return !DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), m_node.chainman->GetConsensus(),
-                                      Consensus::DEPLOYMENT_V19)));
-        assert(WITH_LOCK(::cs_main, return !DeploymentActiveAfter(m_node.chainman->ActiveChain().Tip(), *m_node.chainman,
-                                      Consensus::DEPLOYMENT_V24)));
+    }
+
+    const CBlockIndex* Tip() const
+    {
+        return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip());
+    }
+
+    bool IsV19Active() const
+    {
+        return DeploymentActiveAfter(Tip(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19);
+    }
+
+    bool IsV24Active() const
+    {
+        return DeploymentActiveAfter(Tip(), chainman, Consensus::DEPLOYMENT_V24);
+    }
+
+    void ProcessBlock(const std::vector<CMutableTransaction>& txs = {})
+    {
+        CreateAndProcessBlock(txs, coinbase_pk);
+        dmnman.UpdatedBlockTip(Tip());
+    }
+
+    void MineToV19()
+    {
+        while (!IsV19Active()) {
+            ProcessBlock();
+        }
+    }
+
+    void MineToV24()
+    {
+        for (int i = 0; i < 2000 && !IsV24Active(); ++i) {
+            ProcessBlock();
+        }
+    }
+
+    ChainstateManager& chainman;
+    CDeterministicMNManager& dmnman;
+    SimpleUTXOMap utxos;
+    const CScript coinbase_pk;
+};
+
+struct TestChainV24SignalBeforeV19Setup : public TestMNChainSetup {
+    TestChainV24SignalBeforeV19Setup() :
+        TestMNChainSetup(494,
+                         {"-testactivationheight=v19@500", "-testactivationheight=v20@500",
+                          "-testactivationheight=mn_rr@511", "-vbparams=v24:0:9999999999:510:1:1:1:5:0"})
+    {
+        assert(!IsV19Active());
+        assert(!IsV24Active());
     }
 };
 
@@ -1504,16 +1553,12 @@ struct TestChainV24SignalBeforeV19Setup : public TestChainSetup {
 struct TestChainV24PendingSetup : public TestChainV24SignalBeforeV19Setup {
     TestChainV24PendingSetup()
     {
-        const CScript coinbase_pk = GetScriptForRawPubKey(coinbaseKey.GetPubKey());
-        auto& chainman = *Assert(m_node.chainman);
-        auto& dmnman = *Assert(m_node.dmnman);
         // Mine just enough to activate v19/v20 (height 500) while keeping v24 and mn_rr pending.
-        for (int i = 0; i < 20 && WITH_LOCK(::cs_main, return !DeploymentActiveAfter(chainman.ActiveChain().Tip(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)); ++i) {
-            CreateAndProcessBlock({}, coinbase_pk);
-            dmnman.UpdatedBlockTip(WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()));
+        for (int i = 0; i < 20 && !IsV19Active(); ++i) {
+            ProcessBlock();
         }
-        assert(WITH_LOCK(::cs_main, return DeploymentActiveAfter(chainman.ActiveChain().Tip(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)));
-        assert(WITH_LOCK(::cs_main, return !DeploymentActiveAfter(chainman.ActiveChain().Tip(), chainman, Consensus::DEPLOYMENT_V24)));
+        assert(IsV19Active());
+        assert(!IsV24Active());
         assert(!bls::bls_legacy_scheme.load());
     }
 };
@@ -1551,16 +1596,13 @@ static void CheckListRoundTrips(CDeterministicMNManager& dmnman, const std::stri
     BOOST_CHECK_MESSAGE(live.IsEqual(reloaded), what << ": live list diverges from its serialized form");
 }
 
-void FuncMigrationRejectedWhenKeySquatted(TestChainSetup& setup)
+void FuncMigrationRejectedWhenKeySquatted(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
 
     // Victim A: legacy, holding operator key K.
     CKey owner_key_a;
@@ -1568,15 +1610,11 @@ void FuncMigrationRejectedWhenKeySquatted(TestChainSetup& setup)
     auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
                                    operator_key);
     const auto proTxHashA = tx_reg_a.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_a});
 
     // Reach v19, register squatter B holding K basic-encoded (accepted pre-v24), then activate v24.
-    while (!DeploymentActiveAfter(tip_index(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(!DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV19();
+    BOOST_REQUIRE(!DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
 
     CKey owner_key_b;
     owner_key_b.MakeNewKey(true);
@@ -1599,15 +1637,11 @@ void FuncMigrationRejectedWhenKeySquatted(TestChainSetup& setup)
         SetTxPayload(tx_reg_b, pro_reg_b);
         SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
     }
-    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_b});
     BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(tx_reg_b.GetHash()));
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHashA)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
     // (a) A's service-update migration is rejected cleanly.
@@ -1657,30 +1691,23 @@ void FuncMigrationRejectedWhenKeySquatted(TestChainSetup& setup)
     }
 };
 
-void FuncProUpServTxMigratesLegacy(TestChainSetup& setup)
+void FuncProUpServTxMigratesLegacy(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
     CKey owner_key;
     CBLSSecretKey operator_key;
     auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
                                  operator_key);
     const auto proTxHash = tx_reg.GetHash();
-    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg});
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
 
     // A BasicBLS service update migrates a legacy masternode in place: it keeps the same operator
     // key (re-encoded to the basic scheme), raises the version, and is NOT PoSe-banned -- no key
@@ -1694,8 +1721,7 @@ void FuncProUpServTxMigratesLegacy(TestChainSetup& setup)
                                                val_state, /*check_sigs=*/true),
                               "migration ProUpServTx rejected: " << val_state.GetRejectReason());
     }
-    setup.CreateAndProcessBlock({tx}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx});
 
     const auto dmn = dmnman.GetListAtChainTip().GetMN(proTxHash);
     BOOST_REQUIRE(dmn);
@@ -1776,29 +1802,22 @@ BOOST_AUTO_TEST_CASE(proupserv_migrates_legacy)
 // is already BasicBLS, so the round-3 guard (which keys off old_version == LegacyBLS) does not fire,
 // and the v1-payload key is placed into a v2 state. Assert the final key's scheme matches its version
 // and the list round-trips.
-void FuncSameMnSameBlockVersionCrossingKeyRotation(TestChainSetup& setup)
+void FuncSameMnSameBlockVersionCrossingKeyRotation(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
     CKey owner_key;
     CBLSSecretKey operator_key_old;
     auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
                                  operator_key_old);
     const auto proTxHash = tx_reg.GetHash();
-    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg});
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
     CBLSSecretKey key1, key2;
@@ -1885,29 +1904,22 @@ void FuncSameMnSameBlockVersionCrossingKeyRotation(TestChainSetup& setup)
     }
 };
 
-void FuncSameMnSameBlockMigrationConsistent(TestChainSetup& setup)
+void FuncSameMnSameBlockMigrationConsistent(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
     CKey owner_key;
     CBLSSecretKey operator_key_old;
     auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
                                  operator_key_old);
     const auto proTxHash = tx_reg.GetHash();
-    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg});
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
     // Both rotate to the SAME new key, one legacy-encoded at v1, one basic-encoded at v2.
@@ -1965,31 +1977,25 @@ void FuncSameMnSameBlockMigrationConsistent(TestChainSetup& setup)
     BOOST_CHECK(reloaded.GetMN(proTxHash)->pdmnState->pubKeyOperator.Get() == operator_key_new.GetPublicKey());
 };
 
-void FuncPreV24CrossSchemePairCannotBecomeResident(TestChainSetup& setup)
+void FuncPreV24CrossSchemePairCannotBecomeResident(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
+    const auto& coinbase_pk = setup.coinbase_pk;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
 
     CKey owner_key_a;
     CBLSSecretKey operator_key_a;
     auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
                                    operator_key_a);
     const auto proTxHashA = tx_reg_a.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_a});
 
     // Reach v19 but stop short of v24: this is where the pair gets admitted.
-    while (!DeploymentActiveAfter(tip_index(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(!DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV19();
+    BOOST_REQUIRE(!DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
 
     CKey owner_key_b;
     owner_key_b.MakeNewKey(true);
@@ -2015,8 +2021,7 @@ void FuncPreV24CrossSchemePairCannotBecomeResident(TestChainSetup& setup)
         SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
     }
     const auto proTxHashB = tx_reg_b.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_b});
     BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(proTxHashB));
 
     CBLSSecretKey contested;
@@ -2042,11 +2047,8 @@ void FuncPreV24CrossSchemePairCannotBecomeResident(TestChainSetup& setup)
     }
 
     // Activate v24 with the surviving transaction still resident.
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
 
     // tx_a is the valid, non-conflicting claim: it must still be resident, not evicted at activation.
     auto& mempool = *Assert(setup.m_node.mempool.get());
@@ -2068,30 +2070,23 @@ void FuncPreV24CrossSchemePairCannotBecomeResident(TestChainSetup& setup)
     BOOST_CHECK_MESSAGE(selected_tx_a, "the valid surviving special transaction was not selected into the template");
 };
 
-void FuncSameBlockCrossSchemeKeyPairRejected(TestChainSetup& setup)
+void FuncSameBlockCrossSchemeKeyPairRejected(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
 
     CKey owner_key_a;
     CBLSSecretKey operator_key_a;
     auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
                                    operator_key_a);
     const auto proTxHashA = tx_reg_a.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_a});
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHashA)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
     CKey owner_key_b;
@@ -2118,8 +2113,7 @@ void FuncSameBlockCrossSchemeKeyPairRejected(TestChainSetup& setup)
         SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
     }
     const auto proTxHashB = tx_reg_b.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_b});
     BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(proTxHashB));
 
     CBLSSecretKey contested;
@@ -2169,16 +2163,13 @@ void FuncSameBlockCrossSchemeKeyPairRejected(TestChainSetup& setup)
     BOOST_CHECK_EQUAL(block_state.GetRejectReason(), "bad-protx-dup-key");
 };
 
-void FuncMempoolRejectsCrossSchemeKeyRace(TestChainSetup& setup)
+void FuncMempoolRejectsCrossSchemeKeyRace(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
 
     // MN-A stays legacy; MN-B is registered basic after v24. Both keep their own keys for now.
     CKey owner_key_a;
@@ -2186,14 +2177,10 @@ void FuncMempoolRejectsCrossSchemeKeyRace(TestChainSetup& setup)
     auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
                                    operator_key_a);
     const auto proTxHashA = tx_reg_a.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_a});
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHashA)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
     CKey owner_key_b;
@@ -2220,8 +2207,7 @@ void FuncMempoolRejectsCrossSchemeKeyRace(TestChainSetup& setup)
         SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
     }
     const auto proTxHashB = tx_reg_b.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_b});
     BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(proTxHashB));
 
     // The contested key: held by nobody yet, so both updates below pass their consensus checks.
@@ -2263,16 +2249,13 @@ void FuncMempoolRejectsCrossSchemeKeyRace(TestChainSetup& setup)
     }
 };
 
-void FuncProUpRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
+void FuncProUpRegTxRejectsCrossSchemeKeyReuse(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
 
     // MN-A registers pre-v19: legacy scheme, and stays legacy.
     CKey owner_key_a;
@@ -2280,14 +2263,10 @@ void FuncProUpRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
     auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
                                    operator_key_a);
     const auto proTxHashA = tx_reg_a.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_a});
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
     BOOST_REQUIRE(!bls::bls_legacy_scheme.load());
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHashA)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
@@ -2316,8 +2295,7 @@ void FuncProUpRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
         SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
     }
     const auto proTxHashB = tx_reg_b.GetHash();
-    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_b});
     BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(proTxHashB));
 
     auto build_upreg = [&](const uint256& protx_hash, const CKey& owner_key, const CBLSPublicKey& op_pubkey,
@@ -2358,22 +2336,18 @@ void FuncProUpRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
     }
 };
 
-void FuncProRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
+void FuncProRegTxRejectsCrossSchemeKeyReuse(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
     CKey owner_key_a;
     CBLSSecretKey operator_key;
     auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
                                    operator_key);
-    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg_a});
     BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(tx_reg_a.GetHash())->pdmnState->pubKeyOperator.IsLegacy());
 
     int port{20000};
@@ -2407,11 +2381,8 @@ void FuncProRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
                              chainman.ActiveChainstate().CoinsTip(), chainman, st, /*check_sigs=*/true);
     };
 
-    while (!DeploymentActiveAfter(tip_index(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(!DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV19();
+    BOOST_REQUIRE(!DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
 
     // Non-retroactivity: before v24 the squat is still accepted, exactly as on develop today.
     {
@@ -2421,11 +2392,8 @@ void FuncProRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
                                                       << st.GetRejectReason());
     }
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
 
     // The main post-v24 vector: reuse the legacy masternode's key, basic-encoded.
     {
@@ -2568,29 +2536,23 @@ void FuncPreV24BehaviourUnchanged(TestChainSetup& setup)
     CheckListRoundTrips(dmnman, "pre-v24 after same-key ProUpRegTx");
 };
 
-void FuncStaleSpecialTxDoesNotPoisonTemplate(TestChainSetup& setup)
+void FuncStaleSpecialTxDoesNotPoisonTemplate(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
+    const auto& coinbase_pk = setup.coinbase_pk;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
     CKey owner_key;
     CBLSSecretKey operator_key;
     auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
                                  operator_key);
     const auto proTxHash = tx_reg.GetHash();
-    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg});
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
     // A cross-scheme squatter ProRegTx: it reuses the legacy masternode's operator key basic-encoded.
@@ -2646,29 +2608,22 @@ void FuncStaleSpecialTxDoesNotPoisonTemplate(TestChainSetup& setup)
     }
 };
 
-void FuncProUpRegTxMigratesLegacySameKey(TestChainSetup& setup)
+void FuncProUpRegTxMigratesLegacySameKey(TestChainV24SignalBeforeV19Setup& setup)
 {
-    auto& chainman = *Assert(setup.m_node.chainman.get());
-    auto& dmnman = *Assert(setup.m_node.dmnman);
-    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
-    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
-    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+    auto& chainman = setup.chainman;
+    auto& dmnman = setup.dmnman;
 
     BOOST_REQUIRE(bls::bls_legacy_scheme.load());
-    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    auto& utxos = setup.utxos;
     CKey owner_key;
     CBLSSecretKey operator_key;
     auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
                                  operator_key);
     const auto proTxHash = tx_reg.GetHash();
-    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
-    sync_dmn_tip();
+    setup.ProcessBlock({tx_reg});
 
-    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
-        setup.CreateAndProcessBlock({}, coinbase_pk);
-        sync_dmn_tip();
-    }
-    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    setup.MineToV24();
+    BOOST_REQUIRE(DeploymentActiveAfter(setup.Tip(), chainman, Consensus::DEPLOYMENT_V24));
     BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
 
     auto build_upreg = [&](const CBLSPublicKey& op_pubkey, uint16_t version) {
@@ -2688,8 +2643,7 @@ void FuncProUpRegTxMigratesLegacySameKey(TestChainSetup& setup)
                                                   /*check_sigs=*/true),
                                   "same-key migration rejected: " << val_state.GetRejectReason());
         }
-        setup.CreateAndProcessBlock({tx}, coinbase_pk);
-        sync_dmn_tip();
+        setup.ProcessBlock({tx});
         const auto dmn = dmnman.GetListAtChainTip().GetMN(proTxHash);
         BOOST_REQUIRE(dmn);
         BOOST_CHECK_EQUAL(dmn->pdmnState->nVersion, ProTxVersion::BasicBLS);
@@ -2718,8 +2672,7 @@ void FuncProUpRegTxMigratesLegacySameKey(TestChainSetup& setup)
                                                   /*check_sigs=*/true),
                                   "new-key rotation rejected: " << val_state.GetRejectReason());
         }
-        setup.CreateAndProcessBlock({tx}, coinbase_pk);
-        sync_dmn_tip();
+        setup.ProcessBlock({tx});
         const auto dmn = dmnman.GetListAtChainTip().GetMN(proTxHash);
         BOOST_REQUIRE(dmn);
         BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.IsLegacy());

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -9,6 +9,7 @@
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <deploymentstatus.h>
+#include <evo/chainhelper.h>
 #include <evo/deterministicmns.h>
 #include <evo/providertx.h>
 #include <evo/simplifiedmns.h>
@@ -18,6 +19,7 @@
 #include <mempool_args.h>
 #include <messagesigner.h>
 #include <netbase.h>
+#include <node/miner.h>
 #include <policy/policy.h>
 #include <pow.h>
 #include <script/interpreter.h>
@@ -173,10 +175,11 @@ static CMutableTransaction CreateProRegTxExternalCollateral(const ChainstateMana
     return tx;
 }
 
-static CMutableTransaction CreateProUpServTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, const uint256& proTxHash, const CBLSSecretKey& operatorKey, int port, const CScript& scriptOperatorPayout, const CKey& coinbaseKey)
+static CMutableTransaction CreateProUpServTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, const uint256& proTxHash, const CBLSSecretKey& operatorKey, int port, const CScript& scriptOperatorPayout, const CKey& coinbaseKey,
+                                             uint16_t version = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false))
 {
     CProUpServTx proTx;
-    proTx.nVersion = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false);
+    proTx.nVersion = version;
     proTx.netInfo = NetInfoInterface::MakeNetInfo(proTx.nVersion);
     proTx.proTxHash = proTxHash;
     BOOST_CHECK_EQUAL(proTx.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, strprintf("1.1.1.1:%d", port)),
@@ -195,12 +198,13 @@ static CMutableTransaction CreateProUpServTx(const ChainstateManager& chainman, 
     return tx;
 }
 
-static CMutableTransaction CreateProUpRegTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, const uint256& proTxHash, const CKey& mnKey, const CBLSPublicKey& pubKeyOperator, const CKeyID& keyIDVoting, const CScript& scriptPayout, const CKey& coinbaseKey)
+static CMutableTransaction CreateProUpRegTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, const uint256& proTxHash, const CKey& mnKey, const CBLSPublicKey& pubKeyOperator, const CKeyID& keyIDVoting, const CScript& scriptPayout, const CKey& coinbaseKey,
+                                            uint16_t version = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false), CAmount fee = 0)
 {
     CProUpRegTx proTx;
-    proTx.nVersion = ProTxVersion::GetMax(!bls::bls_legacy_scheme, /*is_extended_addr=*/false);
+    proTx.nVersion = version;
     proTx.proTxHash = proTxHash;
-    proTx.pubKeyOperator.Set(pubKeyOperator, bls::bls_legacy_scheme.load());
+    proTx.pubKeyOperator.Set(pubKeyOperator, /*specificLegacyScheme=*/version == ProTxVersion::LegacyBLS);
     proTx.keyIDVoting = keyIDVoting;
     proTx.scriptPayout = scriptPayout;
 
@@ -208,6 +212,10 @@ static CMutableTransaction CreateProUpRegTx(const ChainstateManager& chainman, S
     tx.nVersion = 3;
     tx.nType = TRANSACTION_PROVIDER_UPDATE_REGISTRAR;
     const auto spent = FundTransaction(chainman, tx, utxos, GetScriptForDestination(PKHash(coinbaseKey.GetPubKey())), 1 * COIN);
+    // FundTransaction returns every input satoshi to the outputs, so the transaction pays no fee and the
+    // mempool would refuse it for not meeting the min relay fee. Tests going through CreateAndProcessBlock
+    // never notice, because block creation does not check relay fees.
+    tx.vout.back().nValue -= fee;
     proTx.inputsHash = CalcTxInputsHash(CTransaction(tx));
     CHashSigner::SignHash(::SerializeHash(proTx), mnKey, proTx.vchSig);
     SetTxPayload(tx, proTx);
@@ -1522,6 +1530,1301 @@ BOOST_AUTO_TEST_CASE(v19_activation_legacy)
 {
     TestChainV19BeforeActivationSetup setup;
     FuncV19Activation(setup);
+}
+
+// The invariant this whole change rests on: a stored operator key never advertises a scheme its own
+// state version contradicts, so the live list and the same list reloaded from disk agree — including
+// mnUniquePropertyMap, which IsEqual() compares directly.
+static void CheckListRoundTrips(CDeterministicMNManager& dmnman, const std::string& what)
+{
+    const auto live = dmnman.GetListAtChainTip();
+    live.ForEachMN(false, [&](const CDeterministicMN& dmn) {
+        BOOST_CHECK_MESSAGE(dmn.pdmnState->pubKeyOperator == CBLSLazyPublicKey() ||
+                            dmn.pdmnState->pubKeyOperator.IsLegacy() ==
+                                (dmn.pdmnState->nVersion == ProTxVersion::LegacyBLS),
+                            what << ": key scheme contradicts state version for " << dmn.proTxHash.ToString());
+    });
+    CDataStream ds(SER_DISK, CLIENT_VERSION);
+    ds << live;
+    CDeterministicMNList reloaded;
+    ds >> reloaded;
+    BOOST_CHECK_MESSAGE(live.IsEqual(reloaded), what << ": live list diverges from its serialized form");
+}
+
+void FuncMigrationRejectedWhenKeySquatted(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+
+    // Victim A: legacy, holding operator key K.
+    CKey owner_key_a;
+    CBLSSecretKey operator_key;
+    auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
+                                   operator_key);
+    const auto proTxHashA = tx_reg_a.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
+    sync_dmn_tip();
+
+    // Reach v19, register squatter B holding K basic-encoded (accepted pre-v24), then activate v24.
+    while (!DeploymentActiveAfter(tip_index(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(!DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+
+    CKey owner_key_b;
+    owner_key_b.MakeNewKey(true);
+    CProRegTx pro_reg_b;
+    pro_reg_b.nVersion = ProTxVersion::BasicBLS;
+    pro_reg_b.netInfo = NetInfoInterface::MakeNetInfo(pro_reg_b.nVersion);
+    pro_reg_b.collateralOutpoint.n = 0;
+    BOOST_REQUIRE_EQUAL(pro_reg_b.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, "1.1.1.2:20003"), NetInfoStatus::Success);
+    pro_reg_b.keyIDOwner = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.pubKeyOperator.Set(operator_key.GetPublicKey(), /*specificLegacyScheme=*/false);
+    pro_reg_b.keyIDVoting = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.scriptPayout = GenerateRandomAddress();
+    CMutableTransaction tx_reg_b;
+    tx_reg_b.nVersion = 3;
+    tx_reg_b.nType = TRANSACTION_PROVIDER_REGISTER;
+    {
+        const auto spent = FundTransaction(chainman, tx_reg_b, utxos, pro_reg_b.scriptPayout,
+                                           dmn_types::Regular.collat_amount);
+        pro_reg_b.inputsHash = CalcTxInputsHash(CTransaction(tx_reg_b));
+        SetTxPayload(tx_reg_b, pro_reg_b);
+        SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
+    }
+    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
+    sync_dmn_tip();
+    BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(tx_reg_b.GetHash()));
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHashA)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    // (a) A's service-update migration is rejected cleanly.
+    {
+        CProUpServTx ups;
+        ups.nVersion = ProTxVersion::BasicBLS;
+        ups.netInfo = NetInfoInterface::MakeNetInfo(ups.nVersion);
+        ups.proTxHash = proTxHashA;
+        BOOST_REQUIRE_EQUAL(ups.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, "1.1.1.1:19999"), NetInfoStatus::Success);
+        CMutableTransaction tx;
+        tx.nVersion = 3;
+        tx.nType = TRANSACTION_PROVIDER_UPDATE_SERVICE;
+        const auto spent = FundTransaction(chainman, tx, utxos,
+                                           GetScriptForDestination(PKHash(setup.coinbaseKey.GetPubKey())), 1 * COIN);
+        ups.inputsHash = CalcTxInputsHash(CTransaction(tx));
+        ups.sig = operator_key.Sign(::SerializeHash(ups), bls::bls_legacy_scheme);
+        SetTxPayload(tx, ups);
+        SignTransaction(tx, spent, setup.coinbaseKey);
+        TxValidationState st;
+        LOCK(cs_main);
+        BOOST_CHECK(!CheckProUpServTx(CTransaction(tx), chainman.ActiveChain().Tip(), dmnman, chainman, st, true));
+        BOOST_CHECK_EQUAL(st.GetRejectReason(), "bad-protx-dup-key");
+    }
+
+    // (b) A's same-key registrar migration is rejected cleanly.
+    {
+        CProUpRegTx upreg;
+        upreg.nVersion = ProTxVersion::BasicBLS;
+        upreg.proTxHash = proTxHashA;
+        upreg.pubKeyOperator.Set(operator_key.GetPublicKey(), /*specificLegacyScheme=*/false);
+        upreg.keyIDVoting = owner_key_a.GetPubKey().GetID();
+        upreg.scriptPayout = GenerateRandomAddress();
+        CMutableTransaction tx;
+        tx.nVersion = 3;
+        tx.nType = TRANSACTION_PROVIDER_UPDATE_REGISTRAR;
+        const auto spent = FundTransaction(chainman, tx, utxos,
+                                           GetScriptForDestination(PKHash(setup.coinbaseKey.GetPubKey())), 1 * COIN);
+        upreg.inputsHash = CalcTxInputsHash(CTransaction(tx));
+        CHashSigner::SignHash(::SerializeHash(upreg), owner_key_a, upreg.vchSig);
+        SetTxPayload(tx, upreg);
+        SignTransaction(tx, spent, setup.coinbaseKey);
+        TxValidationState st;
+        LOCK(cs_main);
+        BOOST_CHECK(!CheckProUpRegTx(CTransaction(tx), chainman.ActiveChain().Tip(), dmnman,
+                                     chainman.ActiveChainstate().CoinsTip(), chainman, st, true));
+        BOOST_CHECK_EQUAL(st.GetRejectReason(), "bad-protx-dup-key");
+    }
+};
+
+void FuncProUpServTxMigratesLegacy(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    CKey owner_key;
+    CBLSSecretKey operator_key;
+    auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
+                                 operator_key);
+    const auto proTxHash = tx_reg.GetHash();
+    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
+    sync_dmn_tip();
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+
+    // A BasicBLS service update migrates a legacy masternode in place: it keeps the same operator
+    // key (re-encoded to the basic scheme), raises the version, and is NOT PoSe-banned -- no key
+    // rotation is forced.
+    auto tx = CreateProUpServTx(chainman, utxos, proTxHash, operator_key, 19998, CScript(), setup.coinbaseKey,
+                                ProTxVersion::BasicBLS);
+    {
+        TxValidationState val_state;
+        LOCK(cs_main);
+        BOOST_REQUIRE_MESSAGE(CheckProUpServTx(CTransaction(tx), chainman.ActiveChain().Tip(), dmnman, chainman,
+                                               val_state, /*check_sigs=*/true),
+                              "migration ProUpServTx rejected: " << val_state.GetRejectReason());
+    }
+    setup.CreateAndProcessBlock({tx}, coinbase_pk);
+    sync_dmn_tip();
+
+    const auto dmn = dmnman.GetListAtChainTip().GetMN(proTxHash);
+    BOOST_REQUIRE(dmn);
+    BOOST_CHECK_EQUAL(dmn->pdmnState->nVersion, ProTxVersion::BasicBLS);
+    BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.IsLegacy());
+    BOOST_CHECK(!dmn->pdmnState->IsBanned());
+    // Same underlying key, and the list round-trips (key re-encoded, so a reloaded node decodes the
+    // same operator key an online node built).
+    BOOST_CHECK(dmn->pdmnState->pubKeyOperator.Get() == operator_key.GetPublicKey());
+    CheckListRoundTrips(dmnman, "after legacy->basic migration ProUpServTx");
+    {
+        const auto live = dmnman.GetListAtChainTip();
+        CDataStream ds(SER_DISK, CLIENT_VERSION);
+        ds << live;
+        CDeterministicMNList reloaded;
+        ds >> reloaded;
+        BOOST_CHECK(reloaded.GetMN(proTxHash)->pdmnState->pubKeyOperator.Get() == operator_key.GetPublicKey());
+    }
+};
+
+BOOST_AUTO_TEST_CASE(migration_rejected_when_key_squatted)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncMigrationRejectedWhenKeySquatted(setup);
+}
+
+BOOST_AUTO_TEST_CASE(proupserv_migrates_legacy)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncProUpServTxMigratesLegacy(setup);
+}
+
+// A legacy masternode migrates to the basic scheme keeping its operator key: SetStateVersion
+// re-encodes the key and UpdateMN re-keys the unique-property map, so no key rotation is forced.
+// A special transaction accepted into the mempool while it was valid is not evicted when a fork
+// activates a rule that invalidates it, and BlockAssembler otherwise trusts mempool validity. It
+// would then select the stale transaction into every template, and every one of those blocks would
+// be rejected by peers, stalling an honest miner.
+// Non-retroactivity. Every consensus rule added here is gated on v24, which is NEVER_ACTIVE on
+// mainnet and testnet, so before activation both transactions the new rules reject must still be
+// accepted exactly as they are on develop today. If this test ever fails, a rule has leaked past its
+// gate and is changing a live chain — that is the one failure mode here that reaches real users, so
+// fix the gating rather than this test.
+// The unique property map is keyed by the scheme-dependent serialization of a BLS key, so one public
+// key occupies a different slot depending on its encoding. The helper must find it under either, and
+// must exclude only the masternode asked about.
+// A ProRegTx must not be able to claim an operator key another masternode already holds, whichever
+// encoding either side uses. ProRegTx never proves ownership of the operator key, so without this a
+// masternode's key can be squatted for the price of a collateral.
+// A registrar update must not be able to claim an operator key another masternode already holds,
+// under either encoding. But the probe must only run when the key is actually CHANGING: an update
+// that keeps its own key cannot create a duplicate, and probing it anyway would let a cross-scheme
+// pair formed before activation permanently block the affected masternode's registrar updates,
+// making an old squat more harmful rather than less.
+// Two in-flight registrar updates must not be able to claim the same operator key under different
+// encodings. Each is valid against the confirmed list -- neither masternode holds the key yet, so
+// each is invisible to the other's consensus check -- and only the mempool sees both. Block assembly
+// does not revalidate special transactions, so admitting both would hand an honest miner a template
+// whose block is invalid.
+// The same-block case. Per-transaction checks run against pindexPrev, so two registrar updates in one
+// block are invisible to each other and could claim one operator key under different encodings. The
+// mempool keeps an honest miner from assembling that pair; this covers a hand-crafted block, which
+// must be rejected cleanly rather than by AddMN/UpdateMN throwing out of block assembly.
+// The activation-boundary case, closed at the root. Nothing evicts mempool entries when v24 activates,
+// and block assembly rechecks each candidate independently against the tip rather than cumulatively,
+// so a pair admitted beforehand would still be selected together afterwards and the rebuild would
+// then reject the whole block -- an honest miner unable to build one at all. The mempool probe is
+// therefore ungated policy: the pair can never become resident in the first place. This asserts that,
+// and that a template still builds afterwards.
+// The same masternode, twice in one block. Each transaction is checked against pindexPrev, where the
+// key is still the original, so both look like genuine rotations and pass. But the rebuild computes
+// operator_changed against the list as rebuilt so far, where the first transaction has already
+// stored the new key -- and operator== ignores the encoding, so the second looks like a no-op, skips
+// SetLegacy(), and yet still raises the version. That is bug A recreated from inside a single block.
+// Codex P1: the SAME masternode, two registrar updates in one block, version-crossing. tx1 rotates a
+// legacy MN to a new key at v2 (making it BasicBLS); tx2 then rotates it to another new key at v1.
+// tx2 passes CheckProUpRegTx against pindexPrev (the MN was legacy there), but in the rebuild the MN
+// is already BasicBLS, so the round-3 guard (which keys off old_version == LegacyBLS) does not fire,
+// and the v1-payload key is placed into a v2 state. Assert the final key's scheme matches its version
+// and the list round-trips.
+void FuncSameMnSameBlockVersionCrossingKeyRotation(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    CKey owner_key;
+    CBLSSecretKey operator_key_old;
+    auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
+                                 operator_key_old);
+    const auto proTxHash = tx_reg.GetHash();
+    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
+    sync_dmn_tip();
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    CBLSSecretKey key1, key2;
+    key1.MakeNewKey();
+    key2.MakeNewKey();
+    auto build_upreg = [&](const CBLSSecretKey& new_op, uint16_t version) {
+        return CreateProUpRegTx(chainman, utxos, proTxHash, owner_key, new_op.GetPublicKey(),
+                                owner_key.GetPubKey().GetID(), GenerateRandomAddress(), setup.coinbaseKey, version);
+    };
+    auto tx1 = build_upreg(key1, ProTxVersion::BasicBLS); // rotate to K1, bump to v2
+    auto tx2 = build_upreg(key2, ProTxVersion::LegacyBLS); // rotate to K2 at v1
+
+    // Both pass their own consensus check against pindexPrev (MN is still legacy there).
+    {
+        LOCK(cs_main);
+        TxValidationState s1, s2;
+        BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx1), chainman.ActiveChain().Tip(), dmnman,
+                                              chainman.ActiveChainstate().CoinsTip(), chainman, s1, true),
+                              "tx1 rejected standalone: " << s1.GetRejectReason());
+        BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx2), chainman.ActiveChain().Tip(), dmnman,
+                                              chainman.ActiveChainstate().CoinsTip(), chainman, s2, true),
+                              "tx2 rejected standalone: " << s2.GetRejectReason());
+    }
+
+    // Rebuild the list with both in one block, tx1 then tx2.
+    CBlock block;
+    block.vtx.push_back(MakeTransactionRef(CMutableTransaction{})); // vtx[0] skipped as coinbase
+    block.vtx.push_back(MakeTransactionRef(tx1));
+    block.vtx.push_back(MakeTransactionRef(tx2));
+    BlockValidationState block_state;
+    CDeterministicMNList mn_list_ret;
+    bool rebuilt{false};
+    std::string thrown;
+    {
+        LOCK(cs_main);
+        auto& chain_helper = *Assert(setup.m_node.chain_helper.get());
+        try {
+            rebuilt = chain_helper.special_tx->RebuildListFromBlock(
+                block, chainman.ActiveChain().Tip(), dmnman.GetListAtChainTip(),
+                chainman.ActiveChainstate().CoinsTip(), /*debugLogs=*/false, block_state, mn_list_ret);
+        } catch (const std::exception& e) {
+            thrown = e.what();
+        }
+    }
+    BOOST_TEST_MESSAGE("rebuilt=" << rebuilt << " reject=" << block_state.GetRejectReason() << " threw=" << thrown);
+    // A throw escaping RebuildListFromBlock is the block-assembly stall this PR must prevent, so it has
+    // to fail the test rather than silently skip the state checks below.
+    BOOST_REQUIRE_MESSAGE(thrown.empty(), "RebuildListFromBlock threw: " << thrown);
+
+    // If the block is accepted, the resulting state must be consistent (key scheme matches version,
+    // and the live list equals its serialized form). A mismatch here is the desync this PR must
+    // eliminate.
+    if (rebuilt) {
+        const auto dmn = mn_list_ret.GetMN(proTxHash);
+        BOOST_REQUIRE(dmn);
+        BOOST_CHECK_MESSAGE(dmn->pdmnState->pubKeyOperator == CBLSLazyPublicKey() ||
+                            dmn->pdmnState->pubKeyOperator.IsLegacy() ==
+                                (dmn->pdmnState->nVersion == ProTxVersion::LegacyBLS),
+                            "DESYNC: nVersion=" << dmn->pdmnState->nVersion << " but key IsLegacy()="
+                                                << dmn->pdmnState->pubKeyOperator.IsLegacy());
+        CDataStream ds(SER_DISK, CLIENT_VERSION);
+        ds << mn_list_ret;
+        CDeterministicMNList reloaded;
+        ds >> reloaded;
+        BOOST_CHECK_MESSAGE(mn_list_ret.IsEqual(reloaded), "DESYNC: live list != serialized-and-reloaded list");
+        // The stored key must still represent the point tx2 rotated to. If SetLegacy() left legacy
+        // bytes under a basic flag, Get() decodes them under the wrong scheme and yields a different
+        // point -- an operator key nobody can sign for (the MN is bricked), even if flag/version and
+        // the serialized bytes are self-consistent.
+        BOOST_CHECK_MESSAGE(dmn->pdmnState->pubKeyOperator.Get() == key2.GetPublicKey(),
+                            "CORRUPT KEY (online): stored operator key decodes to a different point than tx2 set");
+        // The decisive check: a node that reloaded this list from disk decodes the stored bytes fresh.
+        // If online (cached object) and reloaded (decoded bytes) yield different points, two honest
+        // nodes disagree on this operator key -- a reconstruction-history split, exactly the bug class
+        // this PR exists to eliminate.
+        const auto dmn_reloaded = reloaded.GetMN(proTxHash);
+        BOOST_REQUIRE(dmn_reloaded);
+        BOOST_CHECK_MESSAGE(dmn_reloaded->pdmnState->pubKeyOperator.Get() == key2.GetPublicKey(),
+                            "RECONSTRUCTION SPLIT: reloaded operator key decodes to a different point "
+                            "than the online list");
+        BOOST_CHECK_MESSAGE(dmn_reloaded->pdmnState->pubKeyOperator.Get() ==
+                                dmn->pdmnState->pubKeyOperator.Get(),
+                            "RECONSTRUCTION SPLIT: online vs reloaded operator key differ");
+    }
+};
+
+void FuncSameMnSameBlockMigrationConsistent(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    CKey owner_key;
+    CBLSSecretKey operator_key_old;
+    auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
+                                 operator_key_old);
+    const auto proTxHash = tx_reg.GetHash();
+    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
+    sync_dmn_tip();
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    // Both rotate to the SAME new key, one legacy-encoded at v1, one basic-encoded at v2.
+    CBLSSecretKey operator_key_new;
+    operator_key_new.MakeNewKey();
+    auto build_upreg = [&](uint16_t version) {
+        return CreateProUpRegTx(chainman, utxos, proTxHash, owner_key, operator_key_new.GetPublicKey(),
+                                owner_key.GetPubKey().GetID(), GenerateRandomAddress(), setup.coinbaseKey, version);
+    };
+    auto tx1 = build_upreg(ProTxVersion::LegacyBLS);
+    auto tx2 = build_upreg(ProTxVersion::BasicBLS);
+
+    // Each is a genuine rotation against pindexPrev, so both pass their own consensus check.
+    {
+        LOCK(cs_main);
+        TxValidationState s1, s2;
+        BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx1), chainman.ActiveChain().Tip(), dmnman,
+                                              chainman.ActiveChainstate().CoinsTip(), chainman, s1, true),
+                              "tx1 rejected standalone: " << s1.GetRejectReason());
+        BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx2), chainman.ActiveChain().Tip(), dmnman,
+                                              chainman.ActiveChainstate().CoinsTip(), chainman, s2, true),
+                              "tx2 rejected standalone: " << s2.GetRejectReason());
+    }
+
+    // Both rotate to the same new key -- tx1 at v1 (legacy-encoded), tx2 migrating to v2
+    // (basic-encoded). The rebuild must accept this and leave a consistent state: SetStateVersion
+    // re-encodes the key on the migration, so the second transaction does not desync the scheme.
+    CBlock block;
+    block.vtx.push_back(MakeTransactionRef(CMutableTransaction{})); // vtx[0] is skipped as the coinbase
+    block.vtx.push_back(MakeTransactionRef(tx1));
+    block.vtx.push_back(MakeTransactionRef(tx2));
+    BlockValidationState block_state;
+    CDeterministicMNList mn_list_ret;
+    bool rebuilt{false};
+    {
+        LOCK(cs_main);
+        auto& chain_helper = *Assert(setup.m_node.chain_helper.get());
+        BOOST_CHECK_NO_THROW(
+            rebuilt = chain_helper.special_tx->RebuildListFromBlock(
+                block, chainman.ActiveChain().Tip(), dmnman.GetListAtChainTip(),
+                chainman.ActiveChainstate().CoinsTip(), /*debugLogs=*/false, block_state, mn_list_ret));
+    }
+    BOOST_REQUIRE_MESSAGE(rebuilt, "same-key migration across one block was rejected: " << block_state.GetRejectReason());
+    const auto dmn = mn_list_ret.GetMN(proTxHash);
+    BOOST_REQUIRE(dmn);
+    BOOST_CHECK_EQUAL(dmn->pdmnState->nVersion, ProTxVersion::BasicBLS);
+    BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.IsLegacy());
+    // Online and reloaded decode the same operator key -- no reconstruction-history divergence.
+    BOOST_CHECK(dmn->pdmnState->pubKeyOperator.Get() == operator_key_new.GetPublicKey());
+    CDataStream ds(SER_DISK, CLIENT_VERSION);
+    ds << mn_list_ret;
+    CDeterministicMNList reloaded;
+    ds >> reloaded;
+    BOOST_CHECK(mn_list_ret.IsEqual(reloaded));
+    BOOST_CHECK(reloaded.GetMN(proTxHash)->pdmnState->pubKeyOperator.Get() == operator_key_new.GetPublicKey());
+};
+
+void FuncPreV24CrossSchemePairCannotBecomeResident(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+
+    CKey owner_key_a;
+    CBLSSecretKey operator_key_a;
+    auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
+                                   operator_key_a);
+    const auto proTxHashA = tx_reg_a.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
+    sync_dmn_tip();
+
+    // Reach v19 but stop short of v24: this is where the pair gets admitted.
+    while (!DeploymentActiveAfter(tip_index(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(!DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+
+    CKey owner_key_b;
+    owner_key_b.MakeNewKey(true);
+    CBLSSecretKey operator_key_b;
+    operator_key_b.MakeNewKey();
+    CProRegTx pro_reg_b;
+    pro_reg_b.nVersion = ProTxVersion::BasicBLS;
+    pro_reg_b.netInfo = NetInfoInterface::MakeNetInfo(pro_reg_b.nVersion);
+    pro_reg_b.collateralOutpoint.n = 0;
+    BOOST_REQUIRE_EQUAL(pro_reg_b.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, "1.1.1.2:20301"), NetInfoStatus::Success);
+    pro_reg_b.keyIDOwner = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.pubKeyOperator.Set(operator_key_b.GetPublicKey(), /*specificLegacyScheme=*/false);
+    pro_reg_b.keyIDVoting = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.scriptPayout = GenerateRandomAddress();
+    CMutableTransaction tx_reg_b;
+    tx_reg_b.nVersion = 3;
+    tx_reg_b.nType = TRANSACTION_PROVIDER_REGISTER;
+    {
+        const auto spent = FundTransaction(chainman, tx_reg_b, utxos, pro_reg_b.scriptPayout,
+                                           dmn_types::Regular.collat_amount);
+        pro_reg_b.inputsHash = CalcTxInputsHash(CTransaction(tx_reg_b));
+        SetTxPayload(tx_reg_b, pro_reg_b);
+        SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
+    }
+    const auto proTxHashB = tx_reg_b.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
+    sync_dmn_tip();
+    BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(proTxHashB));
+
+    CBLSSecretKey contested;
+    contested.MakeNewKey();
+    auto build_upreg = [&](const uint256& protx_hash, const CKey& owner_key, uint16_t version) {
+        return CreateProUpRegTx(chainman, utxos, protx_hash, owner_key, contested.GetPublicKey(),
+                                owner_key.GetPubKey().GetID(), GenerateRandomAddress(), setup.coinbaseKey, version,
+                                /*fee=*/100000);
+    };
+
+    // The first claim is admitted pre-v24; the ungated mempool policy rejects the conflicting one.
+    auto tx_a = build_upreg(proTxHashA, owner_key_a, ProTxVersion::LegacyBLS);
+    auto tx_b = build_upreg(proTxHashB, owner_key_b, ProTxVersion::BasicBLS);
+    {
+        LOCK(cs_main);
+        const auto ra = chainman.ProcessTransaction(MakeTransactionRef(tx_a));
+        BOOST_REQUIRE_MESSAGE(ra.m_result_type == MempoolAcceptResult::ResultType::VALID,
+                              "pre-v24 tx_a rejected: " << ra.m_state.GetRejectReason());
+        const auto rb = chainman.ProcessTransaction(MakeTransactionRef(tx_b));
+        BOOST_CHECK_MESSAGE(rb.m_result_type != MempoolAcceptResult::ResultType::VALID,
+                            "the cross-scheme pair was admitted and will survive activation");
+        BOOST_CHECK_EQUAL(rb.m_state.GetRejectReason(), "protx-dup");
+    }
+
+    // Activate v24 with the surviving transaction still resident.
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+
+    // tx_a is the valid, non-conflicting claim: it must still be resident, not evicted at activation.
+    auto& mempool = *Assert(setup.m_node.mempool.get());
+    BOOST_REQUIRE(WITH_LOCK(mempool.cs, return mempool.exists(tx_a.GetHash())));
+
+    // A template must still build and must actually select tx_a: proving the honest miner is not left
+    // unable to produce a block, and that this passes because the valid transaction survives rather
+    // than because every special transaction was dropped.
+    std::unique_ptr<node::CBlockTemplate> tmpl;
+    auto make_template = [&] {
+        tmpl = node::BlockAssembler{chainman.ActiveChainstate(), setup.m_node, &mempool}.CreateNewBlock(coinbase_pk);
+    };
+    BOOST_CHECK_NO_THROW(make_template());
+    BOOST_REQUIRE_MESSAGE(tmpl != nullptr, "no template could be built with a pre-v24 cross-scheme pair resident");
+    bool selected_tx_a{false};
+    for (const auto& tx : tmpl->block.vtx) {
+        selected_tx_a |= tx->GetHash() == tx_a.GetHash();
+    }
+    BOOST_CHECK_MESSAGE(selected_tx_a, "the valid surviving special transaction was not selected into the template");
+};
+
+void FuncSameBlockCrossSchemeKeyPairRejected(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+
+    CKey owner_key_a;
+    CBLSSecretKey operator_key_a;
+    auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
+                                   operator_key_a);
+    const auto proTxHashA = tx_reg_a.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
+    sync_dmn_tip();
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHashA)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    CKey owner_key_b;
+    owner_key_b.MakeNewKey(true);
+    CBLSSecretKey operator_key_b;
+    operator_key_b.MakeNewKey();
+    CProRegTx pro_reg_b;
+    pro_reg_b.nVersion = ProTxVersion::BasicBLS;
+    pro_reg_b.netInfo = NetInfoInterface::MakeNetInfo(pro_reg_b.nVersion);
+    pro_reg_b.collateralOutpoint.n = 0;
+    BOOST_REQUIRE_EQUAL(pro_reg_b.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, "1.1.1.2:20201"), NetInfoStatus::Success);
+    pro_reg_b.keyIDOwner = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.pubKeyOperator.Set(operator_key_b.GetPublicKey(), /*specificLegacyScheme=*/false);
+    pro_reg_b.keyIDVoting = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.scriptPayout = GenerateRandomAddress();
+    CMutableTransaction tx_reg_b;
+    tx_reg_b.nVersion = 3;
+    tx_reg_b.nType = TRANSACTION_PROVIDER_REGISTER;
+    {
+        const auto spent = FundTransaction(chainman, tx_reg_b, utxos, pro_reg_b.scriptPayout,
+                                           dmn_types::Regular.collat_amount);
+        pro_reg_b.inputsHash = CalcTxInputsHash(CTransaction(tx_reg_b));
+        SetTxPayload(tx_reg_b, pro_reg_b);
+        SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
+    }
+    const auto proTxHashB = tx_reg_b.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
+    sync_dmn_tip();
+    BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(proTxHashB));
+
+    CBLSSecretKey contested;
+    contested.MakeNewKey();
+    auto build_upreg = [&](const uint256& protx_hash, const CKey& owner_key, uint16_t version) {
+        return CreateProUpRegTx(chainman, utxos, protx_hash, owner_key, contested.GetPublicKey(),
+                                owner_key.GetPubKey().GetID(), GenerateRandomAddress(), setup.coinbaseKey, version);
+    };
+
+    // MN-B claims the key basic-encoded, MN-A claims the same key legacy-encoded. Each passes its own
+    // consensus check against the previous block's list.
+    auto tx1 = build_upreg(proTxHashB, owner_key_b, ProTxVersion::BasicBLS);
+    auto tx2 = build_upreg(proTxHashA, owner_key_a, ProTxVersion::LegacyBLS);
+    {
+        LOCK(cs_main);
+        TxValidationState s1, s2;
+        BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx1), chainman.ActiveChain().Tip(), dmnman,
+                                              chainman.ActiveChainstate().CoinsTip(), chainman, s1, true),
+                              "tx1 rejected standalone: " << s1.GetRejectReason());
+        BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx2), chainman.ActiveChain().Tip(), dmnman,
+                                              chainman.ActiveChainstate().CoinsTip(), chainman, s2, true),
+                              "tx2 rejected standalone: " << s2.GetRejectReason());
+    }
+
+    // Together in one block the rebuild must refuse them -- cleanly, with a reject reason, rather than
+    // by AddMN/UpdateMN throwing. The rebuild is driven directly here because the test fixture's
+    // CreateAndProcessBlock asserts rather than reporting a rebuild failure, so it cannot express a
+    // block that is meant to be rejected.
+    CBlock block;
+    // The rebuild skips vtx[0] as the coinbase, so a placeholder must occupy it or the first real
+    // transaction is silently never processed.
+    block.vtx.push_back(MakeTransactionRef(CMutableTransaction{}));
+    block.vtx.push_back(MakeTransactionRef(tx1));
+    block.vtx.push_back(MakeTransactionRef(tx2));
+    BlockValidationState block_state;
+    CDeterministicMNList mn_list_ret;
+    bool rebuilt{true};
+    {
+        LOCK(cs_main);
+        auto& chain_helper = *Assert(setup.m_node.chain_helper.get());
+        BOOST_CHECK_NO_THROW(
+            rebuilt = chain_helper.special_tx->RebuildListFromBlock(
+                block, chainman.ActiveChain().Tip(), dmnman.GetListAtChainTip(),
+                chainman.ActiveChainstate().CoinsTip(), /*debugLogs=*/false, block_state, mn_list_ret));
+    }
+    BOOST_CHECK_MESSAGE(!rebuilt, "a block claiming one operator key under two encodings was accepted");
+    BOOST_CHECK_EQUAL(block_state.GetRejectReason(), "bad-protx-dup-key");
+};
+
+void FuncMempoolRejectsCrossSchemeKeyRace(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+
+    // MN-A stays legacy; MN-B is registered basic after v24. Both keep their own keys for now.
+    CKey owner_key_a;
+    CBLSSecretKey operator_key_a;
+    auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
+                                   operator_key_a);
+    const auto proTxHashA = tx_reg_a.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
+    sync_dmn_tip();
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHashA)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    CKey owner_key_b;
+    owner_key_b.MakeNewKey(true);
+    CBLSSecretKey operator_key_b;
+    operator_key_b.MakeNewKey();
+    CProRegTx pro_reg_b;
+    pro_reg_b.nVersion = ProTxVersion::BasicBLS;
+    pro_reg_b.netInfo = NetInfoInterface::MakeNetInfo(pro_reg_b.nVersion);
+    pro_reg_b.collateralOutpoint.n = 0;
+    BOOST_REQUIRE_EQUAL(pro_reg_b.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, "1.1.1.2:20101"), NetInfoStatus::Success);
+    pro_reg_b.keyIDOwner = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.pubKeyOperator.Set(operator_key_b.GetPublicKey(), /*specificLegacyScheme=*/false);
+    pro_reg_b.keyIDVoting = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.scriptPayout = GenerateRandomAddress();
+    CMutableTransaction tx_reg_b;
+    tx_reg_b.nVersion = 3;
+    tx_reg_b.nType = TRANSACTION_PROVIDER_REGISTER;
+    {
+        const auto spent = FundTransaction(chainman, tx_reg_b, utxos, pro_reg_b.scriptPayout,
+                                           dmn_types::Regular.collat_amount);
+        pro_reg_b.inputsHash = CalcTxInputsHash(CTransaction(tx_reg_b));
+        SetTxPayload(tx_reg_b, pro_reg_b);
+        SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
+    }
+    const auto proTxHashB = tx_reg_b.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
+    sync_dmn_tip();
+    BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(proTxHashB));
+
+    // The contested key: held by nobody yet, so both updates below pass their consensus checks.
+    CBLSSecretKey contested;
+    contested.MakeNewKey();
+
+    auto build_upreg = [&](const uint256& protx_hash, const CKey& owner_key, uint16_t version) {
+        return CreateProUpRegTx(chainman, utxos, protx_hash, owner_key, contested.GetPublicKey(),
+                                owner_key.GetPubKey().GetID(), GenerateRandomAddress(), setup.coinbaseKey, version,
+                                /*fee=*/100000);
+    };
+
+    // MN-B claims it basic-encoded. Accepted: nobody holds it.
+    auto tx_first = build_upreg(proTxHashB, owner_key_b, ProTxVersion::BasicBLS);
+    {
+        LOCK(cs_main);
+        const auto res = chainman.ProcessTransaction(MakeTransactionRef(tx_first));
+        BOOST_REQUIRE_MESSAGE(res.m_result_type == MempoolAcceptResult::ResultType::VALID,
+                              "first cross-scheme claim rejected: " << res.m_state.GetRejectReason());
+    }
+
+    // MN-A claims the SAME key legacy-encoded. Its consensus check still passes -- the confirmed list
+    // does not contain the key -- so only the mempool can catch this.
+    auto tx_second = build_upreg(proTxHashA, owner_key_a, ProTxVersion::LegacyBLS);
+    {
+        TxValidationState st;
+        LOCK(cs_main);
+        BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx_second), chainman.ActiveChain().Tip(), dmnman,
+                                              chainman.ActiveChainstate().CoinsTip(), chainman, st,
+                                              /*check_sigs=*/true),
+                              "second claim should still pass its consensus check: " << st.GetRejectReason());
+    }
+    {
+        LOCK(cs_main);
+        const auto res = chainman.ProcessTransaction(MakeTransactionRef(tx_second));
+        BOOST_CHECK_MESSAGE(res.m_result_type != MempoolAcceptResult::ResultType::VALID,
+                            "second in-flight claim of the same key under the other encoding was accepted");
+        BOOST_CHECK_EQUAL(res.m_state.GetRejectReason(), "protx-dup");
+    }
+};
+
+void FuncProUpRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+
+    // MN-A registers pre-v19: legacy scheme, and stays legacy.
+    CKey owner_key_a;
+    CBLSSecretKey operator_key_a;
+    auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
+                                   operator_key_a);
+    const auto proTxHashA = tx_reg_a.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
+    sync_dmn_tip();
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE(!bls::bls_legacy_scheme.load());
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHashA)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    // MN-B registers post-v24 with its own fresh basic key.
+    CKey owner_key_b;
+    owner_key_b.MakeNewKey(true);
+    CBLSSecretKey operator_key_b;
+    operator_key_b.MakeNewKey();
+    CProRegTx pro_reg_b;
+    pro_reg_b.nVersion = ProTxVersion::BasicBLS;
+    pro_reg_b.netInfo = NetInfoInterface::MakeNetInfo(pro_reg_b.nVersion);
+    pro_reg_b.collateralOutpoint.n = 0;
+    BOOST_REQUIRE_EQUAL(pro_reg_b.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, "1.1.1.2:20001"), NetInfoStatus::Success);
+    pro_reg_b.keyIDOwner = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.pubKeyOperator.Set(operator_key_b.GetPublicKey(), /*specificLegacyScheme=*/false);
+    pro_reg_b.keyIDVoting = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.scriptPayout = GenerateRandomAddress();
+    CMutableTransaction tx_reg_b;
+    tx_reg_b.nVersion = 3;
+    tx_reg_b.nType = TRANSACTION_PROVIDER_REGISTER;
+    {
+        const auto spent = FundTransaction(chainman, tx_reg_b, utxos, pro_reg_b.scriptPayout,
+                                           dmn_types::Regular.collat_amount);
+        pro_reg_b.inputsHash = CalcTxInputsHash(CTransaction(tx_reg_b));
+        SetTxPayload(tx_reg_b, pro_reg_b);
+        SignTransaction(tx_reg_b, spent, setup.coinbaseKey);
+    }
+    const auto proTxHashB = tx_reg_b.GetHash();
+    setup.CreateAndProcessBlock({tx_reg_b}, coinbase_pk);
+    sync_dmn_tip();
+    BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(proTxHashB));
+
+    auto build_upreg = [&](const uint256& protx_hash, const CKey& owner_key, const CBLSPublicKey& op_pubkey,
+                           uint16_t version) {
+        return CreateProUpRegTx(chainman, utxos, protx_hash, owner_key, op_pubkey, owner_key.GetPubKey().GetID(),
+                                GenerateRandomAddress(), setup.coinbaseKey, version);
+    };
+    auto check_upreg = [&](const CMutableTransaction& tx, TxValidationState& st) {
+        LOCK(cs_main);
+        return CheckProUpRegTx(CTransaction(tx), chainman.ActiveChain().Tip(), dmnman,
+                               chainman.ActiveChainstate().CoinsTip(), chainman, st, /*check_sigs=*/true);
+    };
+
+    // MN-A tries to take MN-B's key under the OTHER encoding, via a v1 payload. This is the reverse
+    // direction's only route that survives post-v24, since registration cannot carry a legacy key.
+    {
+        auto tx = build_upreg(proTxHashA, owner_key_a, operator_key_b.GetPublicKey(), ProTxVersion::LegacyBLS);
+        TxValidationState st;
+        BOOST_CHECK(!check_upreg(tx, st));
+        BOOST_CHECK_EQUAL(st.GetRejectReason(), "bad-protx-dup-key");
+    }
+
+    // MN-B tries to take MN-A's key, basic-encoded (MN-A holds it legacy-encoded).
+    {
+        auto tx = build_upreg(proTxHashB, owner_key_b, operator_key_a.GetPublicKey(), ProTxVersion::BasicBLS);
+        TxValidationState st;
+        BOOST_CHECK(!check_upreg(tx, st));
+        BOOST_CHECK_EQUAL(st.GetRejectReason(), "bad-protx-dup-key");
+    }
+
+    // No false positive: MN-B re-submitting its OWN key unchanged is not a duplicate. This is the
+    // key-change scoping, and without it a masternode could never update its registrar again.
+    {
+        auto tx = build_upreg(proTxHashB, owner_key_b, operator_key_b.GetPublicKey(), ProTxVersion::BasicBLS);
+        TxValidationState st;
+        BOOST_CHECK_MESSAGE(check_upreg(tx, st), "self-key registrar update wrongly rejected: "
+                                                     << st.GetRejectReason());
+    }
+};
+
+void FuncProRegTxRejectsCrossSchemeKeyReuse(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    CKey owner_key_a;
+    CBLSSecretKey operator_key;
+    auto tx_reg_a = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key_a,
+                                   operator_key);
+    setup.CreateAndProcessBlock({tx_reg_a}, coinbase_pk);
+    sync_dmn_tip();
+    BOOST_REQUIRE(dmnman.GetListAtChainTip().GetMN(tx_reg_a.GetHash())->pdmnState->pubKeyOperator.IsLegacy());
+
+    int port{20000};
+    auto build_proreg = [&](const CBLSPublicKey& op_pubkey, uint16_t version) {
+        CKey owner_key_b;
+        owner_key_b.MakeNewKey(true);
+        CProRegTx pro_reg;
+        pro_reg.nVersion = version;
+        pro_reg.netInfo = NetInfoInterface::MakeNetInfo(pro_reg.nVersion);
+        pro_reg.collateralOutpoint.n = 0;
+        BOOST_REQUIRE_EQUAL(pro_reg.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, strprintf("1.1.1.%d:%d", port % 250 + 2, port)),
+                            NetInfoStatus::Success);
+        ++port;
+        pro_reg.keyIDOwner = owner_key_b.GetPubKey().GetID();
+        pro_reg.pubKeyOperator.Set(op_pubkey, /*specificLegacyScheme=*/version == ProTxVersion::LegacyBLS);
+        pro_reg.keyIDVoting = owner_key_b.GetPubKey().GetID();
+        pro_reg.scriptPayout = GenerateRandomAddress();
+        CMutableTransaction tx;
+        tx.nVersion = 3;
+        tx.nType = TRANSACTION_PROVIDER_REGISTER;
+        const auto spent = FundTransaction(chainman, tx, utxos, pro_reg.scriptPayout,
+                                           dmn_types::Regular.collat_amount);
+        pro_reg.inputsHash = CalcTxInputsHash(CTransaction(tx));
+        SetTxPayload(tx, pro_reg);
+        SignTransaction(tx, spent, setup.coinbaseKey);
+        return tx;
+    };
+    auto check_proreg = [&](const CMutableTransaction& tx, TxValidationState& st) {
+        LOCK(cs_main);
+        return CheckProRegTx(CTransaction(tx), chainman.ActiveChain().Tip(), dmnman,
+                             chainman.ActiveChainstate().CoinsTip(), chainman, st, /*check_sigs=*/true);
+    };
+
+    while (!DeploymentActiveAfter(tip_index(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(!DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+
+    // Non-retroactivity: before v24 the squat is still accepted, exactly as on develop today.
+    {
+        auto tx = build_proreg(operator_key.GetPublicKey(), ProTxVersion::BasicBLS);
+        TxValidationState st;
+        BOOST_CHECK_MESSAGE(check_proreg(tx, st), "pre-v24 cross-scheme registration wrongly rejected: "
+                                                      << st.GetRejectReason());
+    }
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+
+    // The main post-v24 vector: reuse the legacy masternode's key, basic-encoded.
+    {
+        auto tx = build_proreg(operator_key.GetPublicKey(), ProTxVersion::BasicBLS);
+        TxValidationState st;
+        BOOST_CHECK(!check_proreg(tx, st));
+        BOOST_CHECK_EQUAL(st.GetRejectReason(), "bad-protx-dup-key");
+    }
+
+    // The reverse direction is unreachable via registration post-v24 for an unrelated reason: a
+    // legacy-encoded payload needs nVersion=1, which registration refuses outright. Pinned so it
+    // cannot start silently passing.
+    {
+        CBLSSecretKey fresh;
+        fresh.MakeNewKey();
+        auto tx = build_proreg(fresh.GetPublicKey(), ProTxVersion::LegacyBLS);
+        TxValidationState st;
+        BOOST_CHECK(!check_proreg(tx, st));
+        BOOST_CHECK_EQUAL(st.GetRejectReason(), "bad-protx-version-disallowed");
+    }
+
+    // No false positives: a fresh key still registers.
+    {
+        CBLSSecretKey fresh;
+        fresh.MakeNewKey();
+        auto tx = build_proreg(fresh.GetPublicKey(), ProTxVersion::BasicBLS);
+        TxValidationState st;
+        BOOST_CHECK_MESSAGE(check_proreg(tx, st), "fresh-key registration wrongly rejected: "
+                                                      << st.GetRejectReason());
+    }
+};
+
+void FuncHasOperatorKeyUnderAnyScheme(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    CKey owner_key;
+    CBLSSecretKey operator_key;
+    auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
+                                 operator_key);
+    const auto proTxHash = tx_reg.GetHash();
+    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
+    dmnman.UpdatedBlockTip(WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()));
+
+    const auto list = dmnman.GetListAtChainTip();
+    const auto dmn = list.GetMN(proTxHash);
+    BOOST_REQUIRE(dmn);
+    // Stored legacy-encoded, so a plain lookup under the basic encoding misses it...
+    BOOST_REQUIRE(dmn->pdmnState->pubKeyOperator.IsLegacy());
+    CBLSLazyPublicKey basic_wrapped;
+    basic_wrapped.Set(operator_key.GetPublicKey(), /*specificLegacyScheme=*/false);
+    BOOST_REQUIRE(!list.HasUniqueProperty(basic_wrapped));
+    // ...which is exactly the gap the helper closes.
+    BOOST_CHECK(list.HasOperatorKeyUnderAnyScheme(operator_key.GetPublicKey(), uint256()));
+    // The holder itself is excluded when asked.
+    BOOST_CHECK(!list.HasOperatorKeyUnderAnyScheme(operator_key.GetPublicKey(), proTxHash));
+    // A key nobody holds is absent.
+    CBLSSecretKey other;
+    other.MakeNewKey();
+    BOOST_CHECK(!list.HasOperatorKeyUnderAnyScheme(other.GetPublicKey(), uint256()));
+};
+
+void FuncPreV24BehaviourUnchanged(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(!DeploymentActiveAfter(tip_index(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19));
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    CKey owner_key;
+    CBLSSecretKey operator_key;
+    auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
+                                 operator_key);
+    const auto proTxHash = tx_reg.GetHash();
+    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
+    sync_dmn_tip();
+
+    while (!DeploymentActiveAfter(tip_index(), chainman.GetConsensus(), Consensus::DEPLOYMENT_V19)) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    // v19 active, v24 inactive: this is mainnet's configuration today.
+    BOOST_REQUIRE(!DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE(!bls::bls_legacy_scheme.load());
+
+    // A BasicBLS service update on a legacy masternode: rejected post-v24 by Component 1.
+    auto tx_ups = CreateProUpServTx(chainman, utxos, proTxHash, operator_key, 19998, CScript(), setup.coinbaseKey);
+    {
+        TxValidationState val_state;
+        LOCK(cs_main);
+        BOOST_CHECK_MESSAGE(CheckProUpServTx(CTransaction(tx_ups), chainman.ActiveChain().Tip(), dmnman, chainman,
+                                             val_state, /*check_sigs=*/true),
+                            "pre-v24 v2 ProUpServTx wrongly rejected: " << val_state.GetRejectReason());
+    }
+    setup.CreateAndProcessBlock({tx_ups}, coinbase_pk);
+    sync_dmn_tip();
+    CheckListRoundTrips(dmnman, "pre-v24 after v2 ProUpServTx");
+
+    // A same-key BasicBLS registrar update on a legacy masternode: rejected post-v24 by Component 2.
+    CProUpRegTx pro_upreg;
+    pro_upreg.nVersion = ProTxVersion::BasicBLS;
+    pro_upreg.proTxHash = proTxHash;
+    pro_upreg.pubKeyOperator.Set(operator_key.GetPublicKey(), /*specificLegacyScheme=*/false);
+    pro_upreg.keyIDVoting = owner_key.GetPubKey().GetID();
+    pro_upreg.scriptPayout = GenerateRandomAddress();
+    CMutableTransaction tx_upreg;
+    tx_upreg.nVersion = 3;
+    tx_upreg.nType = TRANSACTION_PROVIDER_UPDATE_REGISTRAR;
+    const auto spent = FundTransaction(chainman, tx_upreg, utxos,
+                                       GetScriptForDestination(PKHash(setup.coinbaseKey.GetPubKey())), 1 * COIN);
+    pro_upreg.inputsHash = CalcTxInputsHash(CTransaction(tx_upreg));
+    CHashSigner::SignHash(::SerializeHash(pro_upreg), owner_key, pro_upreg.vchSig);
+    SetTxPayload(tx_upreg, pro_upreg);
+    SignTransaction(tx_upreg, spent, setup.coinbaseKey);
+    {
+        TxValidationState val_state;
+        LOCK(cs_main);
+        BOOST_CHECK_MESSAGE(CheckProUpRegTx(CTransaction(tx_upreg), chainman.ActiveChain().Tip(), dmnman,
+                                            chainman.ActiveChainstate().CoinsTip(), chainman, val_state,
+                                            /*check_sigs=*/true),
+                            "pre-v24 same-key ProUpRegTx wrongly rejected: " << val_state.GetRejectReason());
+    }
+    setup.CreateAndProcessBlock({tx_upreg}, coinbase_pk);
+    sync_dmn_tip();
+
+    // Pre-v24 the version does not move and the key keeps its scheme, so nothing desyncs.
+    const auto dmn = dmnman.GetListAtChainTip().GetMN(proTxHash);
+    BOOST_REQUIRE(dmn);
+    BOOST_CHECK_EQUAL(dmn->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+    BOOST_CHECK(dmn->pdmnState->pubKeyOperator.IsLegacy());
+    CheckListRoundTrips(dmnman, "pre-v24 after same-key ProUpRegTx");
+};
+
+void FuncStaleSpecialTxDoesNotPoisonTemplate(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    CKey owner_key;
+    CBLSSecretKey operator_key;
+    auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
+                                 operator_key);
+    const auto proTxHash = tx_reg.GetHash();
+    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
+    sync_dmn_tip();
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    // A cross-scheme squatter ProRegTx: it reuses the legacy masternode's operator key basic-encoded.
+    // Such a registration is valid before v24 and rejected after it (bad-protx-dup-key), which is the
+    // shape of transaction that can sit in the mempool when the fork activates. addUnchecked()
+    // reproduces that resident-but-now-invalid state directly.
+    CKey owner_key_b;
+    owner_key_b.MakeNewKey(true);
+    CProRegTx pro_reg_b;
+    pro_reg_b.nVersion = ProTxVersion::BasicBLS;
+    pro_reg_b.netInfo = NetInfoInterface::MakeNetInfo(pro_reg_b.nVersion);
+    pro_reg_b.collateralOutpoint.n = 0;
+    BOOST_REQUIRE_EQUAL(pro_reg_b.netInfo->AddEntry(NetInfoPurpose::CORE_P2P, "1.1.1.2:20002"), NetInfoStatus::Success);
+    pro_reg_b.keyIDOwner = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.pubKeyOperator.Set(operator_key.GetPublicKey(), /*specificLegacyScheme=*/false);
+    pro_reg_b.keyIDVoting = owner_key_b.GetPubKey().GetID();
+    pro_reg_b.scriptPayout = GenerateRandomAddress();
+    CMutableTransaction tx_stale;
+    tx_stale.nVersion = 3;
+    tx_stale.nType = TRANSACTION_PROVIDER_REGISTER;
+    const auto spent = FundTransaction(chainman, tx_stale, utxos, pro_reg_b.scriptPayout,
+                                       dmn_types::Regular.collat_amount);
+    pro_reg_b.inputsHash = CalcTxInputsHash(CTransaction(tx_stale));
+    SetTxPayload(tx_stale, pro_reg_b);
+    SignTransaction(tx_stale, spent, setup.coinbaseKey);
+    const auto stale_hash = tx_stale.GetHash();
+
+    // Sanity: consensus really does reject it now, so this test is about a genuinely invalid entry.
+    {
+        TxValidationState val_state;
+        LOCK(cs_main);
+        BOOST_REQUIRE(!CheckProRegTx(CTransaction(tx_stale), chainman.ActiveChain().Tip(), dmnman,
+                                     chainman.ActiveChainstate().CoinsTip(), chainman, val_state,
+                                     /*check_sigs=*/true));
+        BOOST_REQUIRE_EQUAL(val_state.GetRejectReason(), "bad-protx-dup-key");
+    }
+
+    // Make it fee-eligible so selection would genuinely pick it, then park it in the mempool.
+    auto& mempool = *Assert(setup.m_node.mempool.get());
+    TestMemPoolEntryHelper entry;
+    {
+        LOCK2(cs_main, mempool.cs);
+        mempool.addUnchecked(entry.Fee(50000).Time(Now<NodeSeconds>()).FromTx(tx_stale));
+        BOOST_REQUIRE(mempool.exists(stale_hash));
+    }
+
+    auto block_template = node::BlockAssembler{chainman.ActiveChainstate(), setup.m_node, &mempool}
+                              .CreateNewBlock(coinbase_pk);
+    BOOST_REQUIRE_MESSAGE(block_template != nullptr, "no template built while a stale special tx was resident");
+    for (const auto& tx : block_template->block.vtx) {
+        BOOST_CHECK_MESSAGE(tx->GetHash() != stale_hash,
+                            "a stale special tx was selected into the block template");
+    }
+};
+
+void FuncProUpRegTxMigratesLegacySameKey(TestChainSetup& setup)
+{
+    auto& chainman = *Assert(setup.m_node.chainman.get());
+    auto& dmnman = *Assert(setup.m_node.dmnman);
+    auto tip_index    = [&] { return WITH_LOCK(::cs_main, return chainman.ActiveChain().Tip()); };
+    auto sync_dmn_tip = [&] { dmnman.UpdatedBlockTip(tip_index()); };
+    const CScript coinbase_pk = GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey());
+
+    BOOST_REQUIRE(bls::bls_legacy_scheme.load());
+    auto utxos = BuildSimpleUtxoMap(setup.m_coinbase_txns);
+    CKey owner_key;
+    CBLSSecretKey operator_key;
+    auto tx_reg = CreateProRegTx(chainman, utxos, 19999, GenerateRandomAddress(), setup.coinbaseKey, owner_key,
+                                 operator_key);
+    const auto proTxHash = tx_reg.GetHash();
+    setup.CreateAndProcessBlock({tx_reg}, coinbase_pk);
+    sync_dmn_tip();
+
+    for (int i = 0; i < 2000 && !DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24); ++i) {
+        setup.CreateAndProcessBlock({}, coinbase_pk);
+        sync_dmn_tip();
+    }
+    BOOST_REQUIRE(DeploymentActiveAfter(tip_index(), chainman, Consensus::DEPLOYMENT_V24));
+    BOOST_REQUIRE_EQUAL(dmnman.GetListAtChainTip().GetMN(proTxHash)->pdmnState->nVersion, ProTxVersion::LegacyBLS);
+
+    auto build_upreg = [&](const CBLSPublicKey& op_pubkey, uint16_t version) {
+        return CreateProUpRegTx(chainman, utxos, proTxHash, owner_key, op_pubkey, owner_key.GetPubKey().GetID(),
+                                GenerateRandomAddress(), setup.coinbaseKey, version);
+    };
+
+    // Same key, re-encoded basic: migrates in place. Accepted, version rises, key preserved and
+    // re-encoded, NOT PoSe-banned (no rotation forced), and the list round-trips.
+    {
+        auto tx = build_upreg(operator_key.GetPublicKey(), ProTxVersion::BasicBLS);
+        TxValidationState val_state;
+        {
+            LOCK(cs_main);
+            BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx), chainman.ActiveChain().Tip(), dmnman,
+                                                  chainman.ActiveChainstate().CoinsTip(), chainman, val_state,
+                                                  /*check_sigs=*/true),
+                                  "same-key migration rejected: " << val_state.GetRejectReason());
+        }
+        setup.CreateAndProcessBlock({tx}, coinbase_pk);
+        sync_dmn_tip();
+        const auto dmn = dmnman.GetListAtChainTip().GetMN(proTxHash);
+        BOOST_REQUIRE(dmn);
+        BOOST_CHECK_EQUAL(dmn->pdmnState->nVersion, ProTxVersion::BasicBLS);
+        BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.IsLegacy());
+        BOOST_CHECK(!dmn->pdmnState->IsBanned());
+        BOOST_CHECK(dmn->pdmnState->pubKeyOperator.Get() == operator_key.GetPublicKey());
+        CheckListRoundTrips(dmnman, "after same-key legacy->basic migration");
+        const auto live = dmnman.GetListAtChainTip();
+        CDataStream ds(SER_DISK, CLIENT_VERSION);
+        ds << live;
+        CDeterministicMNList reloaded;
+        ds >> reloaded;
+        BOOST_CHECK(reloaded.GetMN(proTxHash)->pdmnState->pubKeyOperator.Get() == operator_key.GetPublicKey());
+    }
+
+    // A genuinely new key still rotates and PoSe-bans, as before.
+    {
+        CBLSSecretKey new_operator_key;
+        new_operator_key.MakeNewKey();
+        auto tx = build_upreg(new_operator_key.GetPublicKey(), ProTxVersion::BasicBLS);
+        TxValidationState val_state;
+        {
+            LOCK(cs_main);
+            BOOST_REQUIRE_MESSAGE(CheckProUpRegTx(CTransaction(tx), chainman.ActiveChain().Tip(), dmnman,
+                                                  chainman.ActiveChainstate().CoinsTip(), chainman, val_state,
+                                                  /*check_sigs=*/true),
+                                  "new-key rotation rejected: " << val_state.GetRejectReason());
+        }
+        setup.CreateAndProcessBlock({tx}, coinbase_pk);
+        sync_dmn_tip();
+        const auto dmn = dmnman.GetListAtChainTip().GetMN(proTxHash);
+        BOOST_REQUIRE(dmn);
+        BOOST_CHECK(!dmn->pdmnState->pubKeyOperator.IsLegacy());
+        BOOST_CHECK(dmn->pdmnState->IsBanned());
+        CheckListRoundTrips(dmnman, "after new-key rotation");
+    }
+};
+
+BOOST_AUTO_TEST_CASE(same_mn_same_block_version_crossing_key_rotation)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncSameMnSameBlockVersionCrossingKeyRotation(setup);
+}
+
+BOOST_AUTO_TEST_CASE(same_mn_same_block_migration_consistent)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncSameMnSameBlockMigrationConsistent(setup);
+}
+
+BOOST_AUTO_TEST_CASE(pre_v24_cross_scheme_pair_cannot_become_resident)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncPreV24CrossSchemePairCannotBecomeResident(setup);
+}
+
+BOOST_AUTO_TEST_CASE(same_block_cross_scheme_key_pair_rejected)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncSameBlockCrossSchemeKeyPairRejected(setup);
+}
+
+BOOST_AUTO_TEST_CASE(mempool_rejects_cross_scheme_key_race)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncMempoolRejectsCrossSchemeKeyRace(setup);
+}
+
+BOOST_AUTO_TEST_CASE(proupreg_rejects_cross_scheme_key_reuse)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncProUpRegTxRejectsCrossSchemeKeyReuse(setup);
+}
+
+BOOST_AUTO_TEST_CASE(proregtx_rejects_cross_scheme_key_reuse)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncProRegTxRejectsCrossSchemeKeyReuse(setup);
+}
+
+BOOST_AUTO_TEST_CASE(statediff_captures_operator_key_reencoding)
+{
+    // A same-key legacy->basic migration re-encodes the operator key (same point, different scheme).
+    // CDeterministicMNStateDiff must capture that, or the evoDB diff path reconstructs the masternode
+    // with the old encoding while an online-built list has the new one -- a reconstruction split that
+    // full-snapshot serialization (which re-derives the encoding from nVersion) would not reveal.
+    CBLSSecretKey sk;
+    sk.MakeNewKey();
+
+    CDeterministicMNState a;
+    a.nVersion = ProTxVersion::LegacyBLS;
+    a.pubKeyOperator.Set(sk.GetPublicKey(), /*specificLegacyScheme=*/true);
+    a.netInfo = NetInfoInterface::MakeNetInfo(a.nVersion);
+
+    CDeterministicMNState b{a};
+    b.nVersion = ProTxVersion::BasicBLS;
+    b.pubKeyOperator.Set(sk.GetPublicKey(), /*specificLegacyScheme=*/false); // same point, re-encoded
+
+    CDeterministicMNStateDiff diff{a, b};
+    CDataStream ds(SER_DISK, CLIENT_VERSION);
+    ds << diff;
+    CDeterministicMNStateDiff diff2;
+    ds >> diff2;
+
+    CDeterministicMNState reconstructed{a};
+    diff2.ApplyToState(reconstructed);
+
+    BOOST_CHECK_EQUAL(reconstructed.nVersion, ProTxVersion::BasicBLS);
+    BOOST_CHECK(!reconstructed.pubKeyOperator.IsLegacy());
+    BOOST_CHECK(reconstructed.pubKeyOperator.Get() == sk.GetPublicKey());
+    BOOST_CHECK(::SerializeHash(reconstructed.pubKeyOperator) == ::SerializeHash(b.pubKeyOperator));
+}
+
+BOOST_AUTO_TEST_CASE(has_operator_key_under_any_scheme)
+{
+    TestChainV19BeforeActivationSetup setup;
+    FuncHasOperatorKeyUnderAnyScheme(setup);
+}
+
+BOOST_AUTO_TEST_CASE(pre_v24_behaviour_unchanged)
+{
+    TestChainV19BeforeActivationSetup setup;
+    FuncPreV24BehaviourUnchanged(setup);
+}
+
+BOOST_AUTO_TEST_CASE(stale_special_tx_does_not_poison_template)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncStaleSpecialTxDoesNotPoisonTemplate(setup);
+}
+
+BOOST_AUTO_TEST_CASE(proupreg_migrates_legacy_same_key)
+{
+    TestChainV24SignalBeforeV19Setup setup;
+    FuncProUpRegTxMigratesLegacySameKey(setup);
 }
 
 BOOST_AUTO_TEST_CASE(proupreg_version_handling_before_v24)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1375,6 +1375,59 @@ TxMempoolInfo CTxMemPool::info(const uint256& hash) const
     return GetInfo(i);
 }
 
+bool CTxMemPool::existsProviderTxCrossSchemeConflict(const CTransaction& tx) const
+{
+    LOCK(cs);
+
+    // Probe both encodings of `pubkey` and report a conflict if any in-flight transaction other than
+    // `self_protx`'s own already claims it. mapProTxBlsPubKeyHashes maps the scheme-sensitive key
+    // hash to a transaction hash, not to a masternode, so resolving ownership means decoding the
+    // conflicting transaction's payload.
+    auto probe = [&](const CBLSLazyPublicKey& key, const uint256& self_protx) EXCLUSIVE_LOCKS_REQUIRED(cs) {
+        AssertLockHeld(cs);
+        const CBLSPublicKey& pubkey{key.Get()};
+        if (!pubkey.IsValid()) return false;
+        for (const bool legacy_scheme : {true, false}) {
+            CBLSLazyPublicKey wrapped;
+            wrapped.Set(pubkey, legacy_scheme);
+            auto it = mapProTxBlsPubKeyHashes.find(wrapped.GetHash());
+            if (it == mapProTxBlsPubKeyHashes.end()) continue;
+            auto txit = mapTx.find(it->second);
+            if (txit == mapTx.end()) continue;
+            if (txit->GetTx().GetHash() == tx.GetHash()) continue; // ourselves
+            if (!self_protx.IsNull() && txit->GetTx().nType == TRANSACTION_PROVIDER_UPDATE_REGISTRAR) {
+                // The same masternode's own in-flight registrar update is not a conflict.
+                if (const auto other = GetTxPayload<CProUpRegTx>(txit->GetTx());
+                    other && other->proTxHash == self_protx) {
+                    continue;
+                }
+            }
+            return true;
+        }
+        return false;
+    };
+
+    if (tx.nType == TRANSACTION_PROVIDER_REGISTER) {
+        const auto opt_proTx = GetTxPayload<CProRegTx>(tx);
+        if (!opt_proTx) return true; // can't decode payload == conflict, as elsewhere here
+        return probe(opt_proTx->pubKeyOperator, uint256());
+    }
+    if (tx.nType == TRANSACTION_PROVIDER_UPDATE_REGISTRAR) {
+        const auto opt_proTx = GetTxPayload<CProUpRegTx>(tx);
+        if (!opt_proTx) return true;
+        // Only probe when the operator key is actually changing, matching the consensus checks. An
+        // update keeping its own key cannot create a duplicate, and probing it anyway would let one
+        // member of an existing cross-scheme pair block the other's unrelated registrar updates.
+        auto dmnman = Assert(m_dmnman.load(std::memory_order_acquire));
+        if (auto dmn = dmnman->GetListAtChainTip().GetMN(opt_proTx->proTxHash);
+            dmn && opt_proTx->pubKeyOperator == dmn->pdmnState->pubKeyOperator) {
+            return false;
+        }
+        return probe(opt_proTx->pubKeyOperator, opt_proTx->proTxHash);
+    }
+    return false;
+}
+
 bool CTxMemPool::existsProviderTxConflict(const CTransaction &tx) const {
     auto dmnman = Assert(m_dmnman.load(std::memory_order_acquire));
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -827,6 +827,23 @@ public:
      */
     bool existsProviderTxConflict(const CTransaction &tx) const;
 
+    /**
+     * Does another in-flight transaction already claim this transaction's operator key under the
+     * *other* BLS encoding?
+     *
+     * mapProTxBlsPubKeyHashes is keyed by CBLSLazyPublicKey::GetHash(), which is scheme-sensitive,
+     * so existsProviderTxConflict() above compares operator keys per encoding rather than per key
+     * and cannot see this.
+     *
+     * This is mempool policy and is intentionally invoked unconditionally (not gated on the
+     * deployment that makes cross-scheme reuse a consensus error). Gating it would leave a pair
+     * admitted before activation resident afterwards: block assembly does not revalidate special
+     * transactions cumulatively, so both would still be selected and the resulting block rejected,
+     * stalling an honest miner. Policy may be stricter than consensus here, since a node that rejects
+     * the second transaction still accepts a block containing it.
+     */
+    bool existsProviderTxCrossSchemeConflict(const CTransaction& tx) const;
+
     size_t DynamicMemoryUsage() const;
 
     /** Adds a transaction to the unbroadcast set */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -993,6 +993,21 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         return state.Invalid(TxValidationResult::TX_CONFLICT, "protx-dup");
     }
 
+    // The check above compares operator keys per BLS encoding, so it cannot see a second in-flight
+    // transaction claiming the same key under the other one. Keeping such a pair out of the mempool
+    // matters because block assembly does not revalidate special transactions cumulatively: it checks
+    // each candidate against the tip, where neither key is yet present, so both would be selected and
+    // the whole block then rejected -- leaving an honest miner unable to produce one at all.
+    //
+    // Deliberately NOT gated on the deployment that makes such a pair a consensus error. A pair
+    // admitted before activation is never evicted by it, so a gated check would leave exactly that
+    // stall reachable across the boundary. This is mempool policy, which is allowed to be stricter
+    // than consensus: a node that rejects the second transaction still accepts a block containing it,
+    // so no chain can split over this.
+    if (m_pool.existsProviderTxCrossSchemeConflict(tx)) {
+        return state.Invalid(TxValidationResult::TX_CONFLICT, "protx-dup");
+    }
+
     return true;
 }
 

--- a/test/functional/feature_protx_version.py
+++ b/test/functional/feature_protx_version.py
@@ -54,6 +54,8 @@ class ProTxVersionTest(DashTestFramework):
         self.extra_args = [[
             '-deprecatedrpc=legacy_mn',
             '-testactivationheight=v19@200',
+            # Wide enough a window that v24 does not activate on its own during the body of this
+            # test; it is activated explicitly at the end.
             f'-vbparams=v24:{self.mocktime}:999999999999:450:10:8:6:5:0',
         ]] * 6
         self.set_dash_test_params(6, 5, evo_count=2, extra_args=self.extra_args)
@@ -78,9 +80,15 @@ class ProTxVersionTest(DashTestFramework):
         assert extra_legacy_mn is not None
 
         # A second legacy-scheme masternode kept alive (never revoked) until v24 activates, so that
-        # the update_registrar migration path (legacy state -> basic scheme) can be exercised below.
+        # the update_registrar migration path with a rotated key (legacy state -> basic scheme) can
+        # be exercised below.
         migrate_legacy_mn: MasternodeInfo = self.dynamically_add_masternode()
         assert migrate_legacy_mn is not None
+
+        # A third legacy-scheme masternode, also never revoked, used to exercise the in-place
+        # same-key migration path (update_service, no key rotation) once v24 activates.
+        surviving_legacy_mn: MasternodeInfo = self.dynamically_add_masternode()
+        assert surviving_legacy_mn is not None
 
         mn_list_before = self.nodes[0].masternodelist()
         pubkeyoperator_list_before = set([mn_list_before[e]["pubkeyoperator"] for e in mn_list_before])
@@ -144,9 +152,11 @@ class ProTxVersionTest(DashTestFramework):
 
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())
 
-        self.test_protx_v24_versioning(new_mn, migrate_legacy_mn, basic_mn, payout_mn)
+        self.test_protx_v24_versioning(new_mn, migrate_legacy_mn, surviving_legacy_mn, basic_mn, payout_mn)
 
-    def test_protx_v24_versioning(self, mn: MasternodeInfo, legacy_mn: MasternodeInfo, basic_mn: MasternodeInfo, payout_mn: MasternodeInfo):
+    def test_protx_v24_versioning(self, mn: MasternodeInfo, legacy_mn: MasternodeInfo,
+                                  surviving_legacy_mn: MasternodeInfo, basic_mn: MasternodeInfo,
+                                  payout_mn: MasternodeInfo):
         assert not softfork_active(self.nodes[0], 'v24')
         self.activate_by_name('v24', slow_mode=False)
         self.log.info("Activated v24 at height:" + str(self.nodes[0].getblockcount()))
@@ -181,7 +191,7 @@ class ProTxVersionTest(DashTestFramework):
         assert_equal(node.getrawtransaction(protx_result, 1, tip)['proUpRegTx']['version'], 3)
         assert_equal(node.protx('info', mn.proTxHash)['state']['version'], 3)
 
-        self.log.info("Migration v1 [legacy] protx masternode to v3 by update-registar")
+        self.log.info("Migration v1 [legacy] protx masternode to v3 by update-registar with a rotated key")
         assert_equal(node.protx('info', legacy_mn.proTxHash)['state']['version'], 1)
         node.sendtoaddress(legacy_mn.fundsAddr, 1)
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
@@ -219,6 +229,35 @@ class ProTxVersionTest(DashTestFramework):
         # The v3 ProUpRevTx is applied against a v2 state, so max(old, tx) keeps the version at 3, not 1
         assert_equal(node.protx('info', basic_mn.proTxHash)['state']['version'], 3)
 
+        # A legacy masternode can instead migrate to the basic scheme in place, keeping the same
+        # operator key: a v3 service update re-encodes the stored key (SetStateVersion) and re-keys
+        # the unique-property map. No key rotation is forced, so the masternode is not PoSe-banned.
+        # Run last: the key re-encoding is a key change for masternode authentication (CMNAuth) and
+        # briefly churns the migrated node's masternode connections, so keep it after the checks above
+        # to avoid destabilising them.
+        self.log.info("post-v24: update_service migrates a legacy masternode to the basic scheme in place")
+        assert_equal(node.protx('info', surviving_legacy_mn.proTxHash)['state']['version'], 1)
+        key_before = node.protx('info', surviving_legacy_mn.proTxHash)['state']['pubKeyOperator']
+        node.sendtoaddress(surviving_legacy_mn.fundsAddr, 1)
+        self.bump_mocktime(10 * 60 + 1)  # make the funding tx safe to include in a block
+        self.generate(node, 1)
+        upserv_hash = surviving_legacy_mn.update_service(node, submit=True,
+                                                         addrs_core_p2p=[f'127.0.0.1:{surviving_legacy_mn.nodePort}'])
+        self.bump_mocktime(10 * 60 + 1)
+        tip = self.generate(node, 1)[0]
+        assert_equal(node.getrawtransaction(upserv_hash, 1, tip)['proUpServTx']['version'], 3)
+        state = node.protx('info', surviving_legacy_mn.proTxHash)['state']
+        assert_equal(state['version'], 3)  # migrated in place
+        # Same operator key, re-encoded to the basic scheme (different hex, but not a rotation: the
+        # masternode is not PoSe-banned).
+        assert state['pubKeyOperator'] != key_before
+        assert_equal(state['PoSeBanHeight'], -1)
+        # The key re-encoding churns the migrated node's masternode connections, so reconnect it (as
+        # the rotation path does) before syncing, then confirm the list still reloads from disk
+        # identically after the in-place migration.
+        assert surviving_legacy_mn.nodeIdx is not None
+        self.connect_nodes(surviving_legacy_mn.nodeIdx, 0)
+        self.sync_all()
         list_before = self.nodes[1].masternodelist()
         self.restart_node(1, extra_args=self.extra_args[1])
         self.connect_nodes(0, 1)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two independent bugs in how a masternode's operator BLS key relates to its state
version. Both exist on `develop` today and are reproduced by test; neither is
introduced by this change.

> **Rebased on #7302.** This branch now sits on top of the merged #7302 (uniform
> protx versioning: v4 merged into v3, RPC version selection via
> `DeploymentToProtxVersion`, and the v1→v3 update restriction removed). The fixes
> below are unchanged in substance; the migration now lands a legacy masternode at
> **v3** directly (rather than clamping to v2) because #7302 allows v1→v3, and the
> operator-key re-encoding continues to make that safe.

**(A) Post-v24 operator-key scheme desync → consensus split.**
`CDeterministicMNState` derives its operator key's serialization from `nVersion`
(`CBLSLazyPublicKeyVersionWrapper(key, nVersion == LegacyBLS)`). But after v24 a
masternode's `nVersion` could rise out of LegacyBLS (v1) to a basic-scheme version
(v2/v3) while the stored key kept the legacy scheme flag:

- `ProUpServTx` carries no operator key, yet set `newState->nVersion` from the
  payload.
- `ProUpRegTx` re-submitting the *same* key basic-encoded left `operator_changed`
  false, because `CBLSLazyPublicKey::operator==` compares the public key and ignores
  the scheme, so the re-encode was skipped while the version still rose.

Once a state has a basic-scheme `nVersion` with a legacy-flagged key, a list rebuilt
from block diffs and the same list reloaded from disk hash that key differently, so
`mnUniquePropertyMap` diverges. Nodes then disagree on `HasUniqueProperty()` and
therefore on `bad-protx-dup-key` — a chain split determined purely by restart
history. `update_service` is the routine operation that plants this: any legacy
masternode updating its service address after v24 would trigger it, no attacker
required.

**(B) Operator-key uniqueness enforced per encoding, not per key (live today).**
`mnUniquePropertyMap` is keyed by `GetUniquePropertyHash()`, which serializes its
argument, and a BLS key serializes differently under the two schemes, so
`H(K, legacy) != H(K, basic)`. `CheckProRegTx`'s duplicate check consults that map,
so it does not see an operator key an existing masternode holds under the *other*
encoding. A `ProRegTx` never proves ownership of the operator key, so anyone can
re-register an existing masternode's operator public key for the price of a
collateral. This is exploitable on mainnet now; it is closed here for post-v24.

## What was done?

The approach is **migrate, don't force rotation** (adopting the maintainer's
preferred model from #7472), while keeping the cross-scheme uniqueness guards that
make the re-encode safe. Every new consensus rule is gated on `DEPLOYMENT_V24`.

A legacy masternode keeps the same operator private key across the migration; only
the serialized encoding of the public key changes. On a version bump,
`SetStateVersion()` re-encodes the stored key to the scheme its version implies
(`Set(Get(), …)`, not `SetLegacy()`, so the cached serialization actually changes),
and `UpdateUniqueProperty()` re-keys the scheme-dependent unique-property map when
the encoding changes (it now compares `GetUniquePropertyHash()` rather than the
scheme-blind `operator==`).

Re-encoding is only safe if the target slot is free: `UpdateMN()` reports a duplicate
by *throwing*, and that throw escapes `BlockAssembler::CreateNewBlock`, stalling block
production. Because bug B leaves the per-encoding registration hole open, a squatter
can already hold the key under the other encoding — so the migration is guarded at
every layer, and only when the key actually changes or the version crosses the
legacy→basic boundary (a grandfathered cross-scheme pair's non-migrating routine
update is not blocked).

The unique-property map is deliberately **not** made canonical. It is derived, not
serialized: `CDeterministicMNList::Unserialize` clears it and rebuilds via `AddMN`. A
canonical hash would apply retroactively to all history and, if any cross-scheme
duplicate pair already exists, make `AddMN` throw and nodes fail to sync past it.
Cross-scheme pairs created before activation are therefore tolerated (nothing
rehashes the map) and remain usable for non-migrating routine updates; a same-key
legacy→basic migration by the still-legacy member is rejected `bad-protx-dup-key`
until the conflicting key is rotated.

The change is split into two source commits, a test commit, a release-notes commit,
and a follow-up test-fixture dedup commit; each source commit builds on its own.

**Commit 1 — enforce uniqueness across schemes.** A helper
`HasOperatorKeyUnderAnyScheme` probes both encodings (two O(1) lookups, not a scan),
wired in at every point a key can be claimed:

- `CheckProRegTx` and `CheckProUpRegTx`, against the previous block's list.
- `RebuildListFromBlock`, against the list as rebuilt so far (same-block pairs).
- `AcceptToMemoryPool`. This probe is deliberately **not** v24-gated: block assembly
  does not revalidate special transactions cumulatively, so a pair admitted before
  activation is never evicted and would poison every template afterwards. Keeping the
  pair out of the mempool is what actually closes that, and mempool policy is allowed
  to be stricter than consensus (before v24 a node rejecting the second transaction
  would still accept a consensus-valid block containing the pair; after v24 consensus
  rejects the pair too, so the policy difference cannot split the chain in either regime).

The registrar probes run only when the operator key is actually changing: an update
that keeps its own key cannot create a duplicate, and probing it anyway would let a
pre-activation cross-scheme pair permanently block the affected masternode's
registrar updates.

**Commit 2 — allow legacy→basic migration without key rotation.** Handles bug A by
migrating in place rather than forcing a rotation (adopting #7472's re-encode model):

- `SetStateVersion()` re-encodes the stored operator key to the scheme its version
  implies (`Set(Get(), …)`, not `SetLegacy()`, so the cached serialization actually
  changes), keeping the invariant that a stored key's encoding always matches its
  `nVersion`; `UpdateUniqueProperty()` re-keys the scheme-dependent map on an encoding
  change (comparing `GetUniquePropertyHash()` rather than the scheme-blind
  `operator==`).
- The migration is guarded against collisions via `HasOperatorKeyUnderAnyScheme` in
  `CheckProUpServTx`, `CheckProUpRegTx` and `RebuildListFromBlock` — the last against
  the list as rebuilt so far, since per-transaction checks run against `pindexPrev`
  and are blind to an earlier transaction in the same block — so a re-encode that
  would collide with another masternode's key cannot throw out of block assembly. The
  guard fires only when the operator key changes or the version crosses the
  legacy→basic boundary (a shared `IsSchemeMigration` predicate), so a grandfathered
  cross-scheme pair's non-migrating update is not blocked.
- `CDeterministicMNStateDiff` now compares the scheme-dependent hash for the operator
  key field. Its comparison used `operator==` (scheme-blind), so a same-key migration
  produced a diff that omitted the key — a node reconstructing the list from evoDB
  diffs kept the old encoding while an online-built list had the new one, a
  reconstruction split that full-snapshot serialization does not reveal.
- RPC (`rpc/evo.cpp`): `protx update_service` / `protx update_registrar` migrate a
  legacy masternode to the basic scheme (keeping the same key, or supplying a new
  one), instead of erroring or forcing a rotation. Version selection flows through
  #7302's `DeploymentToProtxVersion`, so post-v24 the migration payload is **v3**
  (ExtAddr) — the legacy→BasicBLS clamp #7302 removed is not reintroduced; the
  stored/reused operator key is re-encoded to the basic scheme so it matches the
  target version. The legacy-BLS RPC variants keep the masternode on the legacy
  scheme.

**Commit 3 — tests.** Unit tests in `evo_deterministicmns_tests.cpp` and the
functional-test extension in `feature_protx_version.py` (renamed from
`feature_dip3_v19.py` by #7302) covering both fixes (enumerated below).

**Commit 4 — release notes.** `doc/release-notes-7473.md` documenting the post-v24
per-key uniqueness enforcement and the in-place migration behavior of
`protx update_service` / `protx update_registrar`.

**Commit 5 — test fixture dedup.** Deduplicates the v24-activation scaffolding in
`evo_deterministicmns_tests.cpp` into a shared `TestMNChainSetup` fixture; no
behavior change (test-only refactor, contributed by a reviewer).

## How Has This Been Tested?

Built with `--enable-werror`; the full unit suite (`./src/test/test_dash`, 778 cases)
and the touched functional test (`feature_protx_version.py`) both pass, and lint is
clean for the changed files. Each source commit was rebuilt independently and compiles
on its own under `--enable-werror`; the test commit adds the coverage below, and the
full `evo_dip3_activation_tests` suite passes.

Unit tests (`src/test/evo_deterministicmns_tests.cpp`) — each rejection test was
watched fail first (by flipping the v24 activation height):

- `proupserv_migrates_legacy`, `proupreg_migrates_legacy_same_key` — the happy-path
  migrations: a legacy masternode raises its version keeping the same operator key,
  the stored key re-encodes to basic, and the masternode is *not* PoSe-banned.
- `migration_rejected_when_key_squatted` — a squatter already holds the key under the
  other encoding; the migration is rejected `bad-protx-dup-key` at the per-tx layer
  rather than throwing.
- `same_mn_same_block_migration_consistent`,
  `same_mn_same_block_version_crossing_key_rotation` — same-masternode transitions
  within one block reconstruct identically.
- `same_block_cross_scheme_key_pair_rejected`, `mempool_rejects_cross_scheme_key_race`,
  `pre_v24_cross_scheme_pair_cannot_become_resident` — the same-block, mempool, and
  activation-boundary pairings that motivated the rebuild-time and ungated mempool
  probes.
- `proregtx_rejects_cross_scheme_key_reuse`, `proupreg_rejects_cross_scheme_key_reuse`
  — bug B at the registration and registrar paths, both directions, with fresh-key and
  self-key non-false-positive cases.
- `statediff_captures_operator_key_reencoding` — the evoDB-diff reconstruction path:
  a same-key migration must emit the re-encoded key in the diff.
- `has_operator_key_under_any_scheme` — the two-encoding lookup helper.
- `stale_special_tx_does_not_poison_template` — a resident-but-invalid special tx
  seeded via `addUnchecked`; without the package recheck `CreateNewBlock` throws.
- `pre_v24_behaviour_unchanged` — the non-retroactivity guard: asserts the new rules
  are inert before v24, so nothing on live mainnet/testnet changes.

Functional test (`test/functional/feature_protx_version.py`): extended to assert,
after v24 activation, that a legacy masternode's `update_service` migrates it to the
basic scheme in place (v3 payload, `state.version == 3`, same operator key re-encoded
to a different hex, `PoSeBanHeight == -1`), and that the list reloads from disk
identically after the migration. The same-key migration runs alongside #7302's
rotated-key `update_registrar` migration and is sequenced last (with a reconnect after
the key re-encoding, which churns the migrated node's masternode connections) so it
does not destabilise the surrounding checks.

## Breaking Changes

All consensus rules here are gated on `DEPLOYMENT_V24`, which is `NEVER_ACTIVE` on
mainnet and testnet, so there is no consensus change on any live network;
`pre_v24_behaviour_unchanged` asserts this. After v24 activates:

- Absent a cross-scheme key collision, a LegacyBLS masternode migrates to the basic
  scheme in place on its next version bump (`update_service` or `update_registrar`),
  keeping the same operator key; the stored public key is re-encoded legacy→basic. No
  forced key rotation, no PoSe ban.
- Registering or updating to an operator public key already held by another masternode
  is rejected regardless of which BLS encoding either side uses, and a migration that
  would collide with such a key is rejected `bad-protx-dup-key` rather than stalling
  block assembly.

The `AcceptToMemoryPool` cross-scheme check is mempool policy (ungated) rather than
consensus, so a node may reject a second in-flight transaction that another node's
mempool accepted; both would still accept a consensus-valid block containing it before
v24, and after v24 consensus rejects the pair, so the policy difference cannot split
the chain.

Not addressed here, and worth stating: cross-scheme duplicate pairs created *before*
activation are tolerated, not resolved; and bug B is only closed post-v24, so the
registration hole remains open on mainnet until v24 activates.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation (release notes)
- [x] I have assigned this pull request to a milestone
