### PR TITLE
ci: restore fork builds with checkout v6.1

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -41,6 +41,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Prepare variables
         id: prepare
@@ -85,6 +87,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Prepare variables
         id: prepare
@@ -128,6 +132,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -52,6 +52,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
           sparse-checkout: |
             ci/dash
             ci/test
@@ -134,6 +136,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Restore depends sources
         uses: actions/cache/restore@v5

--- a/.github/workflows/build-src.yml
+++ b/.github/workflows/build-src.yml
@@ -57,6 +57,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
           fetch-depth: 50
 
       - name: Initial setup

--- a/.github/workflows/cache-depends-sources.yml
+++ b/.github/workflows/cache-depends-sources.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Check for cached sources
         id: cache-check

--- a/.github/workflows/guix-build.yml
+++ b/.github/workflows/guix-build.yml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
           path: dash
           fetch-depth: 0
 
@@ -87,6 +89,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
           path: dash
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
           fetch-depth: 50
 
       - name: Initial setup

--- a/.github/workflows/test-src.yml
+++ b/.github/workflows/test-src.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Download build artifacts


### PR DESCRIPTION
## Issue being fixed or feature implemented

`actions/checkout@v6` moved to v6.1.0 on 2026-07-20. The new release rejects fork pull-request head checkouts from `pull_request_target` unless the workflow explicitly acknowledges them, which broke Dash Core CI in [run 29761916351](https://github.com/dashpay/dash/actions/runs/29761916351).

## What was done?

- Add `allow-unsafe-pr-checkout: true` to the 11 checkout steps that intentionally check out `github.event.pull_request.head.sha`.
- Add `persist-credentials: false` to the same steps so checkout does not leave its GitHub token in Git configuration for fork-controlled code.
- Preserve the existing GitHub-hosted/Blacksmith runner routing, cache behavior, GHCR publication, permissions, and Guix workflow structure.

GHCR is used only for CI artifacts, not production. This PR intentionally restores the existing CI design rather than introducing broader workflow hardening.

## How has this been tested?

- Verified all 11 explicit fork-head checkout steps contain both settings.
- Parsed all 15 workflow YAML files successfully.
- `git diff --check origin/develop...HEAD`.
- Rebuilt the branch as one commit at `dd537806bfe63ab76ccfe7c4bbb46dad4dec190c`; its tree exactly matches the previously reviewed `bd84229ee25e7918e17230b0fbfc748f575cd5c9` tree (`ship`, no findings).

`actionlint` was unavailable locally, so no local actionlint result is claimed.

## Breaking changes

None. This restores fork pull-request CI under checkout v6.1 while retaining the existing workflow behavior.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (not applicable; action inputs only)
- [ ] I have added or updated relevant tests (not applicable; workflow input-only change)
- [ ] I have made corresponding changes to the documentation (not applicable)
- [ ] I have assigned this pull request to a milestone

