### PR TITLE
fix: invalidate quorum commitment cache on disconnect

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -217,6 +217,7 @@ BITCOIN_CORE_H = \
   dsnotificationinterface.h \
   evo/assetlocktx.h \
   evo/cbtx.h \
+  evo/cbtx_cache.h \
   evo/chainhelper.h \
   evo/creditpool.h \
   evo/deterministicmns.h \

--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -4,6 +4,8 @@
 
 #include <evo/cbtx.h>
 
+#include <evo/cbtx_cache.h>
+
 #include <evo/specialtx.h>
 #include <llmq/blockprocessor.h>
 #include <llmq/commitment.h>
@@ -49,6 +51,35 @@ bool CheckCbTx(const CCbTx& cbTx, const CBlockIndex* pindexPrev, TxValidationSta
 using QcHashMap = std::map<Consensus::LLMQType, std::vector<uint256>>;
 using QcIndexedHashMap = std::map<Consensus::LLMQType, std::map<int16_t, uint256>>;
 
+// Process-lifetime caches for CalcCbTxMerkleRootQuorums.
+//
+// The outer whole-result cache is keyed only by the set of active quorum *base*
+// blocks. The inner LRU is keyed only by those base-block hashes. Neither key
+// includes the serialized CFinalCommitment that was actually mined for that
+// base on the active chain. Different valid branches can therefore mine
+// different commitments for the same base list, so these caches must be dropped
+// whenever mined commitment state is undone (see InvalidateCachedQcHashes).
+namespace {
+GlobalMutex g_qc_hashes_cache_mutex;
+std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> g_quorums_cached GUARDED_BY(g_qc_hashes_cache_mutex);
+std::map<Consensus::LLMQType, Uint256LruHashMap<std::pair<uint256, int>>> g_qc_hashes_lru GUARDED_BY(g_qc_hashes_cache_mutex);
+QcHashMap g_qcHashes_cached GUARDED_BY(g_qc_hashes_cache_mutex);
+QcIndexedHashMap g_qcIndexedHashes_cached GUARDED_BY(g_qc_hashes_cache_mutex);
+} // anonymous namespace
+
+void InvalidateCachedQcHashes()
+{
+    LOCK(g_qc_hashes_cache_mutex);
+    g_quorums_cached.clear();
+    g_qcHashes_cached.clear();
+    g_qcIndexedHashes_cached.clear();
+    // Clear per-type LRU contents but keep the map entries so InitQuorumsCache is
+    // not required on every post-invalidation miss.
+    for (auto& [_, cache] : g_qc_hashes_lru) {
+        cache.clear();
+    }
+}
+
 /**
  * Handles the calculation or caching of qcHashes and qcIndexedHashes
  * @param pindexPrev The const CBlockIndex* (ie a block) of a block. Both the Quorum list and quorum rotation activation status will be retrieved based on this block.
@@ -58,37 +89,32 @@ auto CachedGetQcHashesQcIndexedHashes(const CBlockIndex* pindexPrev, const llmq:
         std::optional<std::pair<QcHashMap /*qcHashes*/, QcIndexedHashMap /*qcIndexedHashes*/>> {
     auto quorums = quorum_block_processor.GetMinedAndActiveCommitmentsUntilBlock(pindexPrev);
 
-    static Mutex cs_cache;
-    static std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> quorums_cached GUARDED_BY(cs_cache);
-    static std::map<Consensus::LLMQType, Uint256LruHashMap<std::pair<uint256, int>>> qc_hashes_cached GUARDED_BY(cs_cache);
-    static QcHashMap qcHashes_cached GUARDED_BY(cs_cache);
-    static QcIndexedHashMap qcIndexedHashes_cached GUARDED_BY(cs_cache);
-
-    LOCK(cs_cache);
-    if (quorums == quorums_cached) {
-        return std::make_pair(qcHashes_cached, qcIndexedHashes_cached);
+    LOCK(g_qc_hashes_cache_mutex);
+    if (quorums == g_quorums_cached) {
+        return std::make_pair(g_qcHashes_cached, g_qcIndexedHashes_cached);
     }
 
-    // Quorums set is different, reset cached values
-    quorums_cached.clear();
-    qcHashes_cached.clear();
-    qcIndexedHashes_cached.clear();
-    if (qc_hashes_cached.empty()) {
-        llmq::utils::InitQuorumsCache(qc_hashes_cached, Params().GetConsensus());
+    // Quorums set changed: rebuild whole-result caches. Keep the per-base LRU;
+    // branch-dependent staleness is handled by InvalidateCachedQcHashes().
+    g_quorums_cached.clear();
+    g_qcHashes_cached.clear();
+    g_qcIndexedHashes_cached.clear();
+    if (g_qc_hashes_lru.empty()) {
+        llmq::utils::InitQuorumsCache(g_qc_hashes_lru, Params().GetConsensus());
     }
 
     for (const auto& [llmqType, vecBlockIndexes] : quorums) {
         const auto& llmq_params_opt = Params().GetLLMQ(llmqType);
         assert(llmq_params_opt.has_value());
         bool rotation_enabled = llmq::IsQuorumRotationEnabled(llmq_params_opt.value(), pindexPrev);
-        auto& vec_hashes = qcHashes_cached[llmqType];
+        auto& vec_hashes = g_qcHashes_cached[llmqType];
         vec_hashes.reserve(vecBlockIndexes.size());
-        auto& map_indexed_hashes = qcIndexedHashes_cached[llmqType];
+        auto& map_indexed_hashes = g_qcIndexedHashes_cached[llmqType];
         for (const auto& blockIndex : vecBlockIndexes) {
             uint256 block_hash{blockIndex->GetBlockHash()};
 
             std::pair<uint256, int> qc_hash;
-            if (!qc_hashes_cached[llmqType].get(block_hash, qc_hash)) {
+            if (!g_qc_hashes_lru[llmqType].get(block_hash, qc_hash)) {
                 auto [pqc, dummy_hash] = quorum_block_processor.GetMinedCommitment(llmqType, block_hash);
                 if (dummy_hash == uint256::ZERO) {
                     // this should never happen
@@ -96,7 +122,7 @@ auto CachedGetQcHashesQcIndexedHashes(const CBlockIndex* pindexPrev, const llmq:
                 }
                 qc_hash.first = ::SerializeHash(pqc);
                 qc_hash.second = rotation_enabled ? pqc.quorumIndex : 0;
-                qc_hashes_cached[llmqType].insert(block_hash, qc_hash);
+                g_qc_hashes_lru[llmqType].insert(block_hash, qc_hash);
             }
             if (rotation_enabled) {
                 map_indexed_hashes[qc_hash.second] = qc_hash.first;
@@ -105,8 +131,8 @@ auto CachedGetQcHashesQcIndexedHashes(const CBlockIndex* pindexPrev, const llmq:
             }
         }
     }
-    std::swap(quorums_cached, quorums);
-    return std::make_pair(qcHashes_cached, qcIndexedHashes_cached);
+    std::swap(g_quorums_cached, quorums);
+    return std::make_pair(g_qcHashes_cached, g_qcIndexedHashes_cached);
 }
 
 auto CalcHashCountFromQCHashes(const QcHashMap& qcHashes)

--- a/src/evo/cbtx_cache.h
+++ b/src/evo/cbtx_cache.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_EVO_CBTX_CACHE_H
+#define BITCOIN_EVO_CBTX_CACHE_H
+
+/**
+ * Drop process-lifetime CbTx quorum-commitment hash caches.
+ *
+ * Required when mined commitment data for a quorum base block can change without the
+ * active base-block list changing (e.g. disconnect/reorg of the block that mined a
+ * different valid CFinalCommitment for the same quorumHash).
+ */
+void InvalidateCachedQcHashes();
+
+#endif // BITCOIN_EVO_CBTX_CACHE_H

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -4,6 +4,7 @@
 
 #include <llmq/blockprocessor.h>
 
+#include <evo/cbtx_cache.h>
 #include <evo/evodb.h>
 #include <evo/specialtx.h>
 #include <llmq/commitment.h>
@@ -391,12 +392,14 @@ bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, gsl::not_null<const C
         return false;
     }
 
+    bool undone_commitment{false};
     for (auto& [_, qc2] : qcs) {
         auto& qc = qc2; // cannot capture structured binding into lambda
         if (qc.IsNull()) {
             continue;
         }
 
+        undone_commitment = true;
         m_evoDb.Erase(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(qc.llmqType, qc.quorumHash)));
 
         const auto& llmq_params_opt = Params().GetLLMQ(qc.llmqType);
@@ -412,6 +415,12 @@ bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, gsl::not_null<const C
 
         // if a reorg happened, we should allow to mine this commitment later
         AddMineableCommitment(qc);
+    }
+
+    // Drop both CbTx qc-hash cache layers: mined commitments are branch-dependent
+    // even when the active quorum base-block list is unchanged.
+    if (undone_commitment) {
+        InvalidateCachedQcHashes();
     }
 
     m_evoDb.Write(DB_BEST_BLOCK_UPGRADE, pindex->pprev->GetBlockHash());

--- a/src/test/evo_cbtx_tests.cpp
+++ b/src/test/evo_cbtx_tests.cpp
@@ -2,24 +2,42 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <test/util/llmq_tests.h>
 #include <test/util/setup_common.h>
 
 #include <bls/bls.h>
 #include <chain.h>
 #include <chainlock/chainlock.h>
 #include <chainparams.h>
+#include <compat/endian.h>
+#include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <evo/cbtx.h>
+#include <evo/cbtx_cache.h>
+#include <evo/evodb.h>
+#include <evo/specialtx.h>
 #include <evo/specialtxman.h>
+#include <hash.h>
+#include <llmq/blockprocessor.h>
+#include <llmq/commitment.h>
 #include <llmq/context.h>
-#include <llmq/quorumsman.h>
+#include <llmq/params.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
 #include <uint256.h>
 #include <validation.h>
 
 #include <cstdint>
 #include <limits>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
+
+using namespace llmq;
+using namespace llmq::testutils;
 
 BOOST_AUTO_TEST_SUITE(evo_cbtx_tests)
 
@@ -65,6 +83,206 @@ BOOST_FIXTURE_TEST_CASE(check_cbtx_best_chainlock_rejects_excessive_height_diff,
     BlockValidationState state_big;
     BOOST_CHECK(!CheckCbTxBestChainlock(cbTx, &pindex, consensus_params, chain, qman, chainlocks, state_big));
     BOOST_CHECK_EQUAL(state_big.GetRejectReason(), "bad-cbtx-cldiff");
+}
+
+namespace {
+// Mirrors private DB keys in llmq/blockprocessor.cpp so tests can install
+// mined-commitment state without a full DKG/mining path.
+static const std::string DB_MINED_COMMITMENT = "q_mc";
+static const std::string DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT = "q_mcih";
+
+std::tuple<std::string, Consensus::LLMQType, uint32_t> BuildInversedHeightKey(Consensus::LLMQType llmqType, int nMinedHeight)
+{
+    return std::make_tuple(DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT, llmqType,
+                           htobe32_internal(std::numeric_limits<uint32_t>::max() - nMinedHeight));
+}
+
+// Store a mined commitment as if it was mined at `mined_height` for the genesis
+// quorum base (quorumHeight 0). GetMinedCommitmentsUntilBlock iterates inverted-
+// height keys in [pindex->nHeight, 0), so scan height must be >= mined_height
+// and mined_height must be > 0 for the entry to be returned.
+void WriteMinedCommitment(CEvoDB& evoDb, const CFinalCommitment& qc, const uint256& mined_block_hash, int mined_height)
+{
+    assert(mined_height > 0);
+    evoDb.Write(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(qc.llmqType, qc.quorumHash)),
+                std::make_pair(qc, mined_block_hash));
+    evoDb.Write(BuildInversedHeightKey(qc.llmqType, mined_height), /*quorumHeight=*/0);
+}
+
+CTransactionRef MakeCommitmentTx(const CFinalCommitment& qc, int height)
+{
+    CFinalCommitmentTxPayload payload;
+    payload.nHeight = height;
+    payload.commitment = qc;
+
+    CMutableTransaction tx;
+    tx.nVersion = 3;
+    tx.nType = TRANSACTION_QUORUM_COMMITMENT;
+    SetTxPayload(tx, payload);
+    return MakeTransactionRef(std::move(tx));
+}
+
+uint256 CalcQuorumMerkleRootForCommitment(const CFinalCommitment& qc)
+{
+    std::vector<uint256> hashes{::SerializeHash(qc)};
+    bool mutated{false};
+    return ComputeMerkleRoot(hashes, &mutated);
+}
+
+CFinalCommitment MakeDistinctCommitment(const Consensus::LLMQParams& params, const uint256& quorum_hash, uint8_t salt)
+{
+    CFinalCommitment qc = CreateValidCommitment(params, quorum_hash);
+    // Force a deterministic difference even if random BLS material collides.
+    qc.quorumVvecHash = uint256{std::vector<unsigned char>(32, salt)};
+    return qc;
+}
+
+CBlock MakeEmptyBlock()
+{
+    CBlock block;
+    block.vtx.emplace_back(MakeTransactionRef(CMutableTransaction{}));
+    return block;
+}
+
+void ExpectQuorumMerkleRoot(const CBlock& block, const CBlockIndex* pindex, const CQuorumBlockProcessor& qblockman,
+                            const CFinalCommitment& qc)
+{
+    uint256 merkle_root;
+    BlockValidationState state;
+    BOOST_REQUIRE(CalcCbTxMerkleRootQuorums(block, pindex, qblockman, merkle_root, state));
+    BOOST_CHECK_EQUAL(merkle_root.ToString(), CalcQuorumMerkleRootForCommitment(qc).ToString());
+}
+
+const CBlockIndex* GenesisIndex(const node::NodeContext& node)
+{
+    LOCK(cs_main);
+    return node.chainman->ActiveChain()[0];
+}
+
+struct QcHashCacheCleanupGuard {
+    ~QcHashCacheCleanupGuard() { InvalidateCachedQcHashes(); }
+};
+} // anonymous namespace
+
+// Outer cache keys on active quorum base blocks; inner LRU keys on base hashes.
+// Neither includes the mined CFinalCommitment, so without InvalidateCachedQcHashes
+// a stale hash survives an evoDb commitment swap for the same base list.
+BOOST_FIXTURE_TEST_CASE(qc_hash_cache_invalidated_on_commitment_branch_change, RegTestingSetup)
+{
+    InvalidateCachedQcHashes();
+    const QcHashCacheCleanupGuard cache_cleanup;
+
+    auto& evoDb = *Assert(m_node.evodb);
+    auto& qblockman = *Assert(m_node.llmq_ctx)->quorum_block_processor;
+    const auto& params = GetLLMQParams(Consensus::LLMQType::LLMQ_TEST);
+
+    const CBlockIndex* pindex_genesis = GenesisIndex(m_node);
+    BOOST_REQUIRE(pindex_genesis != nullptr);
+    const uint256 quorum_hash = pindex_genesis->GetBlockHash();
+
+    const CFinalCommitment qc_a = MakeDistinctCommitment(params, quorum_hash, /*salt=*/0x11);
+    const CFinalCommitment qc_b = MakeDistinctCommitment(params, quorum_hash, /*salt=*/0x22);
+    BOOST_REQUIRE(::SerializeHash(qc_a) != ::SerializeHash(qc_b));
+
+    const uint256 mined_hash_a = GetTestBlockHash(1);
+    const uint256 mined_hash_b = GetTestBlockHash(2);
+    const uint256 scan_hash = GetTestBlockHash(3);
+    constexpr int mined_height = 1;
+
+    CBlockIndex pindex_scan;
+    pindex_scan.nHeight = mined_height;
+    pindex_scan.pprev = const_cast<CBlockIndex*>(pindex_genesis);
+    pindex_scan.phashBlock = &scan_hash;
+
+    {
+        auto dbTx = evoDb.BeginTransaction();
+        WriteMinedCommitment(evoDb, qc_a, mined_hash_a, mined_height);
+        dbTx->Commit();
+    }
+
+    const CBlock block = MakeEmptyBlock();
+    ExpectQuorumMerkleRoot(block, &pindex_scan, qblockman, qc_a);
+
+    // Swap evoDb to commitment B without changing the active base-block list.
+    {
+        auto dbTx = evoDb.BeginTransaction();
+        WriteMinedCommitment(evoDb, qc_b, mined_hash_b, mined_height);
+        dbTx->Commit();
+    }
+
+    // Without invalidation, both cache layers still serve commitment A.
+    {
+        uint256 merkle_root;
+        BlockValidationState state;
+        BOOST_REQUIRE(CalcCbTxMerkleRootQuorums(block, &pindex_scan, qblockman, merkle_root, state));
+        BOOST_CHECK_EQUAL(merkle_root.ToString(), CalcQuorumMerkleRootForCommitment(qc_a).ToString());
+        BOOST_CHECK(merkle_root != CalcQuorumMerkleRootForCommitment(qc_b));
+    }
+
+    InvalidateCachedQcHashes();
+    ExpectQuorumMerkleRoot(block, &pindex_scan, qblockman, qc_b);
+}
+
+// UndoBlock must invalidate the process-lifetime caches so a replacement
+// commitment is observed after disconnect.
+//
+// Activate DIP0003 immediately so GetCommitmentsFromBlock accepts the payload
+// at a low height without a long fake chain.
+struct Dip3ActiveSetup : public RegTestingSetup {
+    Dip3ActiveSetup() :
+        RegTestingSetup({"-dip3params=1:1"})
+    {
+    }
+};
+
+BOOST_FIXTURE_TEST_CASE(qc_hash_cache_invalidated_by_undoblock, Dip3ActiveSetup)
+{
+    InvalidateCachedQcHashes();
+    const QcHashCacheCleanupGuard cache_cleanup;
+
+    auto& evoDb = *Assert(m_node.evodb);
+    auto& qblockman = *Assert(m_node.llmq_ctx)->quorum_block_processor;
+    const auto& params = GetLLMQParams(Consensus::LLMQType::LLMQ_TEST);
+
+    const CBlockIndex* pindex_genesis = GenesisIndex(m_node);
+    BOOST_REQUIRE(pindex_genesis != nullptr);
+    const uint256 quorum_hash = pindex_genesis->GetBlockHash();
+
+    const CFinalCommitment qc_a = MakeDistinctCommitment(params, quorum_hash, /*salt=*/0x33);
+    const CFinalCommitment qc_b = MakeDistinctCommitment(params, quorum_hash, /*salt=*/0x44);
+    BOOST_REQUIRE(::SerializeHash(qc_a) != ::SerializeHash(qc_b));
+
+    const uint256 mined_hash_a = GetTestBlockHash(11);
+    const uint256 mined_hash_b = GetTestBlockHash(12);
+    constexpr int mined_height = 1;
+
+    {
+        auto dbTx = evoDb.BeginTransaction();
+        WriteMinedCommitment(evoDb, qc_a, mined_hash_a, mined_height);
+        dbTx->Commit();
+    }
+
+    CBlockIndex pindex_mined;
+    pindex_mined.nHeight = mined_height;
+    pindex_mined.pprev = const_cast<CBlockIndex*>(pindex_genesis);
+    pindex_mined.phashBlock = &mined_hash_a;
+
+    CBlock block_with_qc = MakeEmptyBlock();
+    block_with_qc.vtx.emplace_back(MakeCommitmentTx(qc_a, mined_height));
+    const CBlock empty_block = MakeEmptyBlock();
+
+    ExpectQuorumMerkleRoot(empty_block, &pindex_mined, qblockman, qc_a);
+
+    {
+        LOCK(cs_main);
+        auto dbTx = evoDb.BeginTransaction();
+        BOOST_REQUIRE(qblockman.UndoBlock(block_with_qc, &pindex_mined));
+        // Install the replacement while the disconnect transaction is still open.
+        WriteMinedCommitment(evoDb, qc_b, mined_hash_b, mined_height);
+        dbTx->Commit();
+    }
+
+    ExpectQuorumMerkleRoot(empty_block, &pindex_mined, qblockman, qc_b);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Issue being fixed or feature implemented
`CalcCbTxMerkleRootQuorums` memoizes quorum commitment hashes in two layers. The inner LRU is keyed only by quorum base-block hash, not by the serialized `CFinalCommitment` mined for that base. Different valid branches can mine different valid commitments for the same base, so after evoDb rolls back a disconnect, the LRU can still return the old branch's commitment hash and make validation reject a valid replacement branch with `bad-cbtx-quorummerkleroot`.

The outer whole-result cache is not itself the stale layer: it is keyed by the active quorum base-block list, and undoing the commitment removes the inversed-height entry, so that list changes and the outer cache misses. The stale value is reintroduced when that rebuild consults the surviving inner LRU.

Dash triggerability is lower than in a pure PoS setting because of PoW and ChainLocks, but the cache key remains branch-insufficient and therefore a correctness bug.

Out of scope: automatic reconsideration of a chainlocked branch already marked failed.

## What was done?

- Moved the CbTx quorum-hash caches into `CQuorumBlockProcessor`, which owns the mined-commitment evoDb state they derive from.
- Seeded the per-LLMQ LRUs from the processor's chainstate consensus parameters and made missing-type lookups fall back to uncached computation instead of default-constructing a zero-capacity LRU.
- Invalidate the cache from `CQuorumBlockProcessor::UndoBlock` whenever a non-null mined commitment is undone.
- Removed the process-global cache state and the separate `evo/cbtx_cache.h` API.
- Corrected the comments and tests to identify the inner base-hash LRU as the stale layer.
- Reworked the regression tests to assert only the desired post-invalidation result, verify `UndoBlock` performs the invalidation, and make duplicated private DB-key assumptions fail loudly through the public reader.

## How Has This Been Tested?
- Built `src/test/test_dash` in the worktree-local debug build.
- Ran `./src/test/test_dash --run_test=evo_cbtx_tests --catch_system_errors=no` (pass: 4 cases).
- Temporarily removed the `UndoBlock` invalidation and confirmed the regression test fails, then restored it and confirmed the suite passes.
- Ran `test/lint/lint-circular-dependencies.py`, `test/lint/lint-includes.py`, and `test/lint/lint-python.py` (pass).
- A broader `validation_chainstate_tests` run crashes identically at the prior PR head, so that failure is pre-existing and unrelated to this change.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation (N/A for this correctness fix)
- [x] I have assigned this pull request to a milestone *(if appropriate)*
