### PR TITLE
fix(coinjoin): push finalized DSTX directly to participants before DSCOMPLETE

### DIFF
--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -388,6 +388,14 @@ void CCoinJoinServer::CommitFinalTransaction()
 
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CommitFinalTransaction -- TRANSMITTING DSTX\n");
 
+    // Push the fully signed transaction directly to every mixing participant first:
+    // the inv-based relay below is subject to delayed trickling, so without this a
+    // participant could process DSCOMPLETE (which is sent directly) and release its
+    // inputs for reuse before ever seeing the transaction that spends them.
+    if (const auto dstx = m_dstxman.GetDSTX(hashTx); dstx) {
+        WITH_LOCK(cs_coinjoin, RelayDSTXToParticipants(dstx));
+    }
+
     CInv inv(MSG_DSTX, hashTx);
     m_peer_manager->PeerRelayInv(inv);
 
@@ -848,6 +856,25 @@ void CCoinJoinServer::RelayFinalTransaction(const CTransaction& txFinal)
             // no such node? maybe this client disconnected or our own connection went down
             RelayStatus(STATUS_REJECTED);
             break;
+        }
+    }
+}
+
+void CCoinJoinServer::RelayDSTXToParticipants(const CCoinJoinBroadcastTx& dstx)
+{
+    AssertLockHeld(cs_coinjoin);
+    // the fully signed mixing tx is pushed to mixing participants only, everyone else
+    // gets it via the regular inv-based relay
+    for (const auto& entry : vecEntries) {
+        bool fOk = connman.ForNode(entry.addr, [&dstx, this](CNode* pnode) {
+            CNetMsgMaker msgMaker(pnode->GetCommonVersion());
+            connman.PushMessage(pnode, msgMaker.Make(NetMsgType::DSTX, dstx));
+            return true;
+        });
+        if (!fOk) {
+            // best-effort only: the participant will still get the tx via regular inv relay
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::%s -- failed to push DSTX to participant %s\n", __func__,
+                     entry.addr.ToStringAddrPort());
         }
     }
 }

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -81,6 +81,7 @@ private:
 
     /// Relay mixing Messages
     void RelayFinalTransaction(const CTransaction& txFinal) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
+    void RelayDSTXToParticipants(const CCoinJoinBroadcastTx& dstx) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     void PushStatus(CNode& peer, PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID) const;
     void RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID = MSG_NOERR) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     void RelayCompletedTransaction(PoolMessage nMessageID) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);


### PR DESCRIPTION
## Issue being fixed or feature implemented

A CoinJoin participant releases its selected inputs as soon as it processes `DSCOMPLETE(MSG_SUCCESS)`. However, the coordinator announces the finalized mixing transaction only via `PeerRelayInv` (delayed inventory trickling) while `DSCOMPLETE` is pushed directly, so the completion message can overtake the `INV`/`GETDATA`/`DSTX` exchange. During that window the session inputs are neither wallet-locked nor marked spent, so with `-coinjoinmultisession=1` (where the one-block cooldown is bypassed) another session can select and sign the very same inputs, producing two valid CoinJoin transactions spending the same outpoint. One will later be rejected.

The broken invariant: after a successful session, a participant must observe the finalized transaction spending its inputs before it releases them for reuse. The old ordering allowed the release to happen first.

## What was done?

`CommitFinalTransaction` now pushes the fully signed DSTX directly to every mixing participant *before* sending `DSCOMPLETE`, so with in-order message processing participants observe the spend of their inputs (via mempool acceptance) before the success notification unlocks them. The inv-based relay to the rest of the network is unchanged. `DSTX` is an existing message, so no protocol change: old clients accept the direct push as-is (unsolicited `TX`/`DSTX` is explicitly non-punishable in `net_processing`), and the push is best-effort — a participant that misses it still gets the transaction via the regular inv relay, i.e. the previous behavior.

Note: since the fix is coordinator-side, the race is closed as masternodes upgrade; a client mixing through an un-upgraded coordinator retains the previous behavior.

## How Has This Been Tested?

- `coinjoin_tests` suite passes locally.
- Not covered: an end-to-end functional test that delays the DSTX to one participant of a real multi-party mixing session — there is currently no functional-test harness for actual mixing sessions.

## Breaking Changes

None. No wire-protocol changes (`DSTX` push uses an existing message).

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
