### PR TITLE
fix(wallet): keep mixed CoinJoin inputs locked until the finalized tx is observed

### DIFF
--- a/doc/release-notes-7480.md
+++ b/doc/release-notes-7480.md
@@ -1,0 +1,28 @@
+Updated RPCs
+------------
+
+* `getcoinjoininfo` gained a `pending_inputs` field, reporting how many
+  successfully mixed inputs are currently kept locked while waiting for the
+  finalized mixing transaction spending them to be observed.
+
+CoinJoin
+--------
+
+* After a mixing session completes successfully, the inputs a client
+  contributed to it are no longer released as soon as the `DSCOMPLETE` message
+  is processed. They stay locked until the wallet observes a transaction
+  spending them, or for at most an hour if that transaction never propagates.
+  Previously the completion message routinely overtook the trickle-relayed
+  mixing transaction, leaving a window in which another session (with
+  `-coinjoinmultisession=1`, where the one-block cooldown does not apply) could
+  select and sign the very same inputs and produce a second, conflicting
+  CoinJoin transaction.
+
+  These locks are persisted, so they survive a restart. They are tracked in a
+  new wallet database record, `cj_pending_obs`, which is written only when a
+  mixing session completes successfully. Older clients loading such a wallet
+  ignore the record, counting it as an unknown record; the accompanying
+  `lockedutxo` entries are understood by them regardless, so the inputs stay
+  locked either way. Locks the user set themselves via `lockunspent` are never
+  adopted or released by this mechanism, and unlocking a pending input manually
+  purges it from the pending set.

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -14,8 +14,10 @@
 
 #include <chain.h>
 #include <chainparams.h>
+#include <coins.h>
 #include <core_io.h>
 #include <net.h>
+#include <txmempool.h>
 #include <netmessagemaker.h>
 #include <shutdown.h>
 #include <util/check.h>
@@ -28,6 +30,7 @@
 #include <wallet/coinselection.h>
 #include <wallet/receive.h>
 #include <wallet/spend.h>
+#include <wallet/walletdb.h>
 
 #include <memory>
 #include <ranges>
@@ -577,6 +580,33 @@ void CCoinJoinClientSession::CompletedTransaction(PoolMessage nMessageID)
     if (nMessageID == MSG_SUCCESS) {
         m_clientman.UpdatedSuccessBlock();
         keyHolderStorage.KeepAll();
+        // Our inputs are now committed to the finalized mixing transaction but the
+        // DSCOMPLETE message may arrive well before the (trickle-relayed) DSTX does.
+        // Do not release those inputs yet: keep them locked until the wallet actually
+        // observes a transaction spending them, otherwise another session could pick
+        // them up in the meantime (esp. with -coinjoinmultisession) and double-spend
+        // them. Anything else we locked (e.g. collateral inputs which may never be
+        // spent) is unlocked immediately as before.
+        std::set<COutPoint> setMixingInputs;
+        {
+            LOCK(cs_coinjoin);
+            for (const auto& entry : vecEntries) {
+                for (const auto& txdsin : entry.vecTxDSIn) {
+                    setMixingInputs.emplace(txdsin.prevout);
+                }
+            }
+        }
+        std::vector<COutPoint> vecPending;
+        std::vector<COutPoint> vecUnlockNow;
+        for (const auto& outpoint : vecOutPointLocked) {
+            if (setMixingInputs.count(outpoint)) {
+                vecPending.push_back(outpoint);
+            } else {
+                vecUnlockNow.push_back(outpoint);
+            }
+        }
+        vecOutPointLocked = std::move(vecUnlockNow);
+        m_clientman.AddPendingObservation(vecPending);
         WalletCJLogPrint(m_wallet, "CompletedTransaction -- success\n");
     } else {
         WITH_LOCK(m_wallet->cs_wallet, keyHolderStorage.ReturnAll());
@@ -590,6 +620,135 @@ void CCoinJoinClientSession::CompletedTransaction(PoolMessage nMessageID)
 void CCoinJoinClientManager::UpdatedSuccessBlock()
 {
     nCachedLastSuccessBlock = nCachedBlockHeight;
+}
+
+void CCoinJoinClientManager::AddPendingObservation(const std::vector<COutPoint>& outpoints)
+{
+    AssertLockNotHeld(cs_pending_obs);
+    if (outpoints.empty()) return;
+
+    LOCK(m_wallet->cs_wallet);
+    LOCK(cs_pending_obs);
+    wallet::WalletBatch batch(m_wallet->GetDatabase());
+    LoadPendingObservations(batch);
+
+    const int64_t nNow{GetTime()};
+    bool fPersisted{true};
+    for (const auto& outpoint : outpoints) {
+        // Persist the lock so that a restart before the finalized transaction is
+        // observed cannot make the input available for selection again
+        fPersisted &= m_wallet->LockCoin(outpoint, &batch);
+        m_pending_obs.emplace(outpoint, nNow);
+        WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- %s is locked until the finalized mixing transaction is observed\n",
+                         __func__, outpoint.ToStringShort());
+    }
+    fPersisted &= batch.WriteCoinJoinPendingObs(m_pending_obs);
+    if (!fPersisted) {
+        // The in-memory lock still protects these inputs for as long as this process
+        // runs, but a restart would make them selectable again while a valid mixing
+        // transaction spending them may already be in flight. Nothing we can do about
+        // it here beyond making the failure loud - the wallet database is broken.
+        LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to persist locks for %d successfully mixed input(s), "
+                  "they will not survive a restart\n",
+                  __func__, outpoints.size());
+    }
+}
+
+void CCoinJoinClientManager::LoadPendingObservations(wallet::WalletBatch& batch)
+{
+    AssertLockHeld(cs_pending_obs);
+
+    if (m_pending_obs_loaded) return;
+    m_pending_obs_loaded = true;
+    // Missing record simply means nothing was pending when we last shut down
+    if (!batch.ReadCoinJoinPendingObs(m_pending_obs)) return;
+    WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- loaded %d pending observation(s)\n", __func__,
+                     m_pending_obs.size());
+}
+
+void CCoinJoinClientManager::CheckPendingObservations(const CTxMemPool& mempool)
+{
+    AssertLockNotHeld(cs_pending_obs);
+
+    // nothing to do in the common case, don't touch the wallet at all
+    if (WITH_LOCK(cs_pending_obs, return m_pending_obs_loaded && m_pending_obs.empty())) return;
+
+    LOCK(m_wallet->cs_wallet);
+    LOCK(cs_pending_obs);
+
+    wallet::WalletBatch batch(m_wallet->GetDatabase());
+    LoadPendingObservations(batch);
+
+    const int64_t nNow{GetTime()};
+    const bool fSynced{m_mn_sync.IsBlockchainSynced()};
+    bool fChanged{false};
+    for (auto it = m_pending_obs.begin(); it != m_pending_obs.end();) {
+        const COutPoint& outpoint = it->first;
+        if (!m_wallet->IsLockedCoin(outpoint)) {
+            // The user released the lock manually (e.g. via lockunspent), respect that
+            it = m_pending_obs.erase(it);
+            fChanged = true;
+            continue;
+        }
+        if (m_wallet->IsSpent(outpoint)) {
+            // The wallet observed a transaction spending this input, it is no longer
+            // selectable anyway, drop the protective lock
+            WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- observed spend of %s, releasing lock\n", __func__,
+                             outpoint.ToStringShort());
+            m_wallet->UnlockCoin(outpoint, &batch);
+            it = m_pending_obs.erase(it);
+            fChanged = true;
+            continue;
+        }
+        // Only ever consult chain/mempool spentness on a synced chain: while catching up
+        // the spending transaction may sit in a block we have not downloaded yet, and
+        // releasing the input on the strength of that would defeat the whole point
+        if (fSynced && nNow - it->second >= PENDING_OBSERVATION_TIMEOUT_SECONDS) {
+            // NOTE: findCoins() reports outputs which exist in the chain UTXO set or are
+            // created by a mempool transaction; it does NOT know whether a mempool
+            // transaction spends them (CCoinsViewMemPool::GetCoin never looks at
+            // mapNextTx). The finalized mixing transaction sitting unprocessed in our own
+            // mempool is exactly the case we must not misread as "never propagated", so
+            // ask the mempool about spentness explicitly as well.
+            std::map<COutPoint, Coin> coins{{outpoint, Coin{}}};
+            m_wallet->chain().findCoins(coins);
+            if (!coins.at(outpoint).IsSpent() && !mempool.isSpent(outpoint)) {
+                // Still unspent in chain and mempool long after the session completed -
+                // the finalized transaction most likely never propagated, release the
+                // input so the wallet does not lose it forever
+                LogPrintf("CCoinJoinClientManager::%s -- WARNING: never observed finalized mixing transaction for %s, "
+                          "releasing lock after %d seconds\n",
+                          __func__, outpoint.ToStringShort(), PENDING_OBSERVATION_TIMEOUT_SECONDS);
+                m_wallet->UnlockCoin(outpoint, &batch);
+                it = m_pending_obs.erase(it);
+                fChanged = true;
+                continue;
+            }
+            // Spent according to chain/mempool but the wallet has not recorded the
+            // spending transaction yet, keep waiting for it
+            it->second = nNow;
+            fChanged = true;
+        }
+        ++it;
+    }
+    if (fChanged && !batch.WriteCoinJoinPendingObs(m_pending_obs)) {
+        LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to persist %d pending observation(s)\n", __func__,
+                  m_pending_obs.size());
+    }
+}
+
+bool CCoinJoinClientManager::IsPendingObservation(const COutPoint& outpoint) const
+{
+    AssertLockNotHeld(cs_pending_obs);
+    LOCK(cs_pending_obs);
+    return m_pending_obs.count(outpoint) > 0;
+}
+
+size_t CCoinJoinClientManager::GetPendingObservationCount() const
+{
+    AssertLockNotHeld(cs_pending_obs);
+    LOCK(cs_pending_obs);
+    return m_pending_obs.size();
 }
 
 bool CCoinJoinClientManager::WaitForAnotherBlock() const
@@ -1714,9 +1873,16 @@ void CCoinJoinClientManager::UpdatedBlockTip(const CBlockIndex* pindex)
 
 void CCoinJoinClientManager::DoMaintenance(ChainstateManager& chainman, CConnman& connman, const CTxMemPool& mempool)
 {
+    if (ShutdownRequested()) return;
+
+    // Run this before the mixing gates below: inputs of already completed sessions
+    // must be able to unlock even when mixing or CoinJoin itself is disabled,
+    // otherwise their persisted locks could linger forever
+    CheckPendingObservations(mempool);
+
     if (!CCoinJoinClientOptions::IsEnabled()) return;
 
-    if (!m_mn_sync.IsBlockchainSynced() || ShutdownRequested()) return;
+    if (!m_mn_sync.IsBlockchainSynced()) return;
 
     static int nTick = 0;
     static int nDoAutoNextRun = nTick + COINJOIN_AUTO_TIMEOUT_MIN;
@@ -1751,6 +1917,7 @@ UniValue CCoinJoinClientManager::getJsonInfo() const
 {
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("running", isMixing());
+    obj.pushKV("pending_inputs", static_cast<int64_t>(GetPendingObservationCount()));
 
     UniValue arrSessions(UniValue::VARR);
     AssertLockNotHeld(cs_deqsessions);

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -638,21 +638,30 @@ void CCoinJoinClientManager::AddPendingObservation(const std::vector<COutPoint>&
         m_pending_obs.emplace(outpoint, nNow);
     }
 
-    // NOTE: the record which owns these locks has to be written BEFORE the locks
-    // themselves. These are two separate writes and a crash in between must not leave
-    // persistently locked coins behind with nothing tracking them: nothing would ever
-    // release them again. The opposite order is self-healing, CheckPendingObservations()
-    // drops a pending entry as soon as it sees its coin is not locked.
-    bool fPersisted{batch.WriteCoinJoinPendingObs(m_pending_obs)};
+    // NOTE: the record which owns the locks and the persistent locks themselves are
+    // separate writes and each write is its own implicit transaction, so commit them in
+    // one explicit database transaction: a crash in between must neither leave
+    // persistently locked coins behind with nothing tracking them (nothing would ever
+    // release them again) nor persist the record without its locks (on restart the
+    // missing lock reads as a manual unlock, the entry is dropped and the input becomes
+    // selectable again while the finalized mixing transaction may still be in flight).
+    // If no transaction can be started, don't persist anything rather than risk exactly
+    // those partial states.
+    const bool fTxn{batch.TxnBegin()};
+    bool fPersisted{fTxn && batch.WriteCoinJoinPendingObs(m_pending_obs)};
     for (const auto& outpoint : outpoints) {
         // The coins are locked in memory already (see PrepareDenominate), this only
         // persists the lock so that a restart before the finalized transaction is
-        // observed cannot make the input available for selection again. Skip persisting
-        // it if the record above could not be written though, a persistent lock with
-        // nothing left to release it strands the input.
+        // observed cannot make the input available for selection again. Stop writing
+        // once anything failed, the transaction is aborted as a whole below.
         if (!m_wallet->LockCoin(outpoint, fPersisted ? &batch : nullptr)) fPersisted = false;
         WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- %s is locked until the finalized mixing transaction is observed\n",
                          __func__, outpoint.ToStringShort());
+    }
+    if (fPersisted) {
+        fPersisted = batch.TxnCommit();
+    } else if (fTxn) {
+        batch.TxnAbort();
     }
     if (!fPersisted) {
         // The in-memory lock still protects these inputs for as long as this process

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -646,8 +646,10 @@ void CCoinJoinClientManager::AddPendingObservation(const std::vector<COutPoint>&
     // missing lock reads as a manual unlock, the entry is dropped and the input becomes
     // selectable again while the finalized mixing transaction may still be in flight).
     // If no transaction can be started, don't persist anything rather than risk exactly
-    // those partial states.
-    const bool fTxn{batch.TxnBegin()};
+    // those partial states. Likewise if the existing record could not be read
+    // (LoadPendingObservations() left m_pending_obs_loaded unset): overwriting it would
+    // permanently orphan the locks it still tracks.
+    const bool fTxn{m_pending_obs_loaded && batch.TxnBegin()};
     bool fPersisted{fTxn && batch.WriteCoinJoinPendingObs(m_pending_obs)};
     for (const auto& outpoint : outpoints) {
         // The coins are locked in memory already (see PrepareDenominate), this only
@@ -679,9 +681,26 @@ void CCoinJoinClientManager::LoadPendingObservations(wallet::WalletBatch& batch)
     AssertLockHeld(cs_pending_obs);
 
     if (m_pending_obs_loaded) return;
-    m_pending_obs_loaded = true;
     // Missing record simply means nothing was pending when we last shut down
-    if (!batch.ReadCoinJoinPendingObs(m_pending_obs)) return;
+    if (!batch.HasCoinJoinPendingObs()) {
+        m_pending_obs_loaded = true;
+        return;
+    }
+    // Read into a scratch map: a failed read of an existing record must not be mistaken
+    // for an empty one, or the persisted locks it tracks would be left with nothing to
+    // ever release them, and must not leave partially deserialized entries behind
+    // either. Not marking the state loaded retries the read on the next pass and, more
+    // importantly, keeps everything else from overwriting the record before its
+    // contents have been recovered.
+    std::map<COutPoint, int64_t> pending;
+    if (!batch.ReadCoinJoinPendingObs(pending)) {
+        LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to read the pending observation record, will retry\n",
+                  __func__);
+        return;
+    }
+    // Keep any entries added in memory while the record was unreadable
+    m_pending_obs.insert(pending.begin(), pending.end());
+    m_pending_obs_loaded = true;
     WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- loaded %d pending observation(s)\n", __func__,
                      m_pending_obs.size());
 }
@@ -771,7 +790,11 @@ void CCoinJoinClientManager::CheckPendingObservations(const CTxMemPool& mempool)
         }
         ++it;
     }
-    if (fChanged && !get_batch().WriteCoinJoinPendingObs(m_pending_obs)) {
+    // Never overwrite a record which could not be read (m_pending_obs_loaded unset),
+    // it may still track locks nothing else would ever release. An entry released
+    // above but left in such a record self-heals: once the record is readable again
+    // the entry reloads, its coin is no longer locked and it is dropped right here.
+    if (fChanged && m_pending_obs_loaded && !get_batch().WriteCoinJoinPendingObs(m_pending_obs)) {
         LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to persist %d pending observation(s)\n", __func__,
                   m_pending_obs.size());
     }

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -681,7 +681,13 @@ void CCoinJoinClientManager::LoadPendingObservations(wallet::WalletBatch& batch)
     AssertLockHeld(cs_pending_obs);
 
     if (m_pending_obs_loaded) return;
-    // Missing record simply means nothing was pending when we last shut down
+    // Missing record simply means nothing was pending when we last shut down.
+    // NOTE: this only tells a missing record apart from one which exists but cannot be
+    // deserialized, which is the realistic failure. It cannot tell a missing record apart
+    // from a database error while looking for it: both BerkeleyBatch::HasKey() and
+    // SQLiteBatch::HasKey() report anything which is not a hit as a miss, so an error
+    // there still reads as "nothing was pending". Telling those apart would need a
+    // tri-state DatabaseBatch API for both backends, which is not worth it for this.
     if (!batch.HasCoinJoinPendingObs()) {
         m_pending_obs_loaded = true;
         return;
@@ -694,15 +700,22 @@ void CCoinJoinClientManager::LoadPendingObservations(wallet::WalletBatch& batch)
     // contents have been recovered.
     std::map<COutPoint, int64_t> pending;
     if (!batch.ReadCoinJoinPendingObs(pending)) {
-        LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to read the pending observation record, will retry\n",
-                  __func__);
+        // Only complain once: a corrupt (as opposed to transiently unreadable) record
+        // never becomes readable, and the retry runs for as long as this node does.
+        if (!m_pending_obs_load_failed) {
+            m_pending_obs_load_failed = true;
+            LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to read the pending observation record, will keep " /* Continued */
+                      "retrying silently. The inputs it tracks stay locked until it can be read, `lockunspent` "
+                      "releases them manually\n",
+                      __func__);
+        }
         return;
     }
     // Keep any entries added in memory while the record was unreadable
     m_pending_obs.insert(pending.begin(), pending.end());
     m_pending_obs_loaded = true;
     WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- loaded %d pending observation(s)\n", __func__,
-                     m_pending_obs.size());
+                     pending.size());
 }
 
 void CCoinJoinClientManager::CheckPendingObservations(const CTxMemPool& mempool)

--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -17,9 +17,9 @@
 #include <coins.h>
 #include <core_io.h>
 #include <net.h>
-#include <txmempool.h>
 #include <netmessagemaker.h>
 #include <shutdown.h>
+#include <txmempool.h>
 #include <util/check.h>
 #include <util/fs_helpers.h>
 #include <util/moneystr.h>
@@ -33,6 +33,7 @@
 #include <wallet/walletdb.h>
 
 #include <memory>
+#include <optional>
 #include <ranges>
 
 #include <univalue.h>
@@ -633,22 +634,32 @@ void CCoinJoinClientManager::AddPendingObservation(const std::vector<COutPoint>&
     LoadPendingObservations(batch);
 
     const int64_t nNow{GetTime()};
-    bool fPersisted{true};
     for (const auto& outpoint : outpoints) {
-        // Persist the lock so that a restart before the finalized transaction is
-        // observed cannot make the input available for selection again
-        fPersisted &= m_wallet->LockCoin(outpoint, &batch);
         m_pending_obs.emplace(outpoint, nNow);
+    }
+
+    // NOTE: the record which owns these locks has to be written BEFORE the locks
+    // themselves. These are two separate writes and a crash in between must not leave
+    // persistently locked coins behind with nothing tracking them: nothing would ever
+    // release them again. The opposite order is self-healing, CheckPendingObservations()
+    // drops a pending entry as soon as it sees its coin is not locked.
+    bool fPersisted{batch.WriteCoinJoinPendingObs(m_pending_obs)};
+    for (const auto& outpoint : outpoints) {
+        // The coins are locked in memory already (see PrepareDenominate), this only
+        // persists the lock so that a restart before the finalized transaction is
+        // observed cannot make the input available for selection again. Skip persisting
+        // it if the record above could not be written though, a persistent lock with
+        // nothing left to release it strands the input.
+        if (!m_wallet->LockCoin(outpoint, fPersisted ? &batch : nullptr)) fPersisted = false;
         WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- %s is locked until the finalized mixing transaction is observed\n",
                          __func__, outpoint.ToStringShort());
     }
-    fPersisted &= batch.WriteCoinJoinPendingObs(m_pending_obs);
     if (!fPersisted) {
         // The in-memory lock still protects these inputs for as long as this process
         // runs, but a restart would make them selectable again while a valid mixing
         // transaction spending them may already be in flight. Nothing we can do about
         // it here beyond making the failure loud - the wallet database is broken.
-        LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to persist locks for %d successfully mixed input(s), "
+        LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to persist locks for %d successfully mixed input(s), " /* Continued */
                   "they will not survive a restart\n",
                   __func__, outpoints.size());
     }
@@ -676,8 +687,20 @@ void CCoinJoinClientManager::CheckPendingObservations(const CTxMemPool& mempool)
     LOCK(m_wallet->cs_wallet);
     LOCK(cs_pending_obs);
 
-    wallet::WalletBatch batch(m_wallet->GetDatabase());
-    LoadPendingObservations(batch);
+    if (!m_pending_obs_loaded) {
+        // Read-only, no need to checkpoint the database on the way out
+        wallet::WalletBatch batch_load(m_wallet->GetDatabase(), /*_fFlushOnClose=*/false);
+        LoadPendingObservations(batch_load);
+    }
+
+    // Constructed on the first write only: this keeps running for as long as anything is
+    // pending and every WalletBatch checkpoints the wallet database when it goes out of
+    // scope, which is far too expensive to pay for a pass which changes nothing.
+    std::optional<wallet::WalletBatch> batch;
+    const auto get_batch = [&]() -> wallet::WalletBatch& {
+        if (!batch.has_value()) batch.emplace(m_wallet->GetDatabase());
+        return batch.value();
+    };
 
     const int64_t nNow{GetTime()};
     const bool fSynced{m_mn_sync.IsBlockchainSynced()};
@@ -695,7 +718,7 @@ void CCoinJoinClientManager::CheckPendingObservations(const CTxMemPool& mempool)
             // selectable anyway, drop the protective lock
             WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- observed spend of %s, releasing lock\n", __func__,
                              outpoint.ToStringShort());
-            m_wallet->UnlockCoin(outpoint, &batch);
+            m_wallet->UnlockCoin(outpoint, &get_batch());
             it = m_pending_obs.erase(it);
             fChanged = true;
             continue;
@@ -703,7 +726,7 @@ void CCoinJoinClientManager::CheckPendingObservations(const CTxMemPool& mempool)
         // Only ever consult chain/mempool spentness on a synced chain: while catching up
         // the spending transaction may sit in a block we have not downloaded yet, and
         // releasing the input on the strength of that would defeat the whole point
-        if (fSynced && nNow - it->second >= PENDING_OBSERVATION_TIMEOUT_SECONDS) {
+        if (fSynced && nNow - it->second >= COINJOIN_PENDING_OBSERVATION_TIMEOUT) {
             // NOTE: findCoins() reports outputs which exist in the chain UTXO set or are
             // created by a mempool transaction; it does NOT know whether a mempool
             // transaction spends them (CCoinsViewMemPool::GetCoin never looks at
@@ -716,22 +739,30 @@ void CCoinJoinClientManager::CheckPendingObservations(const CTxMemPool& mempool)
                 // Still unspent in chain and mempool long after the session completed -
                 // the finalized transaction most likely never propagated, release the
                 // input so the wallet does not lose it forever
-                LogPrintf("CCoinJoinClientManager::%s -- WARNING: never observed finalized mixing transaction for %s, "
+                LogPrintf("CCoinJoinClientManager::%s -- WARNING: never observed finalized mixing transaction for %s, " /* Continued */
                           "releasing lock after %d seconds\n",
-                          __func__, outpoint.ToStringShort(), PENDING_OBSERVATION_TIMEOUT_SECONDS);
-                m_wallet->UnlockCoin(outpoint, &batch);
+                          __func__, outpoint.ToStringShort(), COINJOIN_PENDING_OBSERVATION_TIMEOUT);
+                m_wallet->UnlockCoin(outpoint, &get_batch());
                 it = m_pending_obs.erase(it);
                 fChanged = true;
                 continue;
             }
             // Spent according to chain/mempool but the wallet has not recorded the
-            // spending transaction yet, keep waiting for it
+            // spending transaction yet, keep waiting for it. Note that this can be
+            // terminal: if the wallet never learns about the spend (restored from an old
+            // backup and never rescanned, say) the entry stays for good. Releasing it
+            // would be wrong - such a coin still looks unspent to the wallet and could be
+            // selected for another session - so only refresh the timer to keep the check
+            // above from running on every pass. The refresh is deliberately not persisted,
+            // the worst a restart can do is re-run the check once.
+            WalletCJLogPrint(m_wallet, "CCoinJoinClientManager::%s -- %s is spent in chain/mempool but not according to " /* Continued */
+                                       "the wallet, keeping it locked\n",
+                             __func__, outpoint.ToStringShort());
             it->second = nNow;
-            fChanged = true;
         }
         ++it;
     }
-    if (fChanged && !batch.WriteCoinJoinPendingObs(m_pending_obs)) {
+    if (fChanged && !get_batch().WriteCoinJoinPendingObs(m_pending_obs)) {
         LogPrintf("CCoinJoinClientManager::%s -- ERROR: failed to persist %d pending observation(s)\n", __func__,
                   m_pending_obs.size());
     }
@@ -1873,16 +1904,9 @@ void CCoinJoinClientManager::UpdatedBlockTip(const CBlockIndex* pindex)
 
 void CCoinJoinClientManager::DoMaintenance(ChainstateManager& chainman, CConnman& connman, const CTxMemPool& mempool)
 {
-    if (ShutdownRequested()) return;
-
-    // Run this before the mixing gates below: inputs of already completed sessions
-    // must be able to unlock even when mixing or CoinJoin itself is disabled,
-    // otherwise their persisted locks could linger forever
-    CheckPendingObservations(mempool);
-
     if (!CCoinJoinClientOptions::IsEnabled()) return;
 
-    if (!m_mn_sync.IsBlockchainSynced()) return;
+    if (!m_mn_sync.IsBlockchainSynced() || ShutdownRequested()) return;
 
     static int nTick = 0;
     static int nDoAutoNextRun = nTick + COINJOIN_AUTO_TIMEOUT_MIN;

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -190,6 +190,9 @@ private:
     //! never confused with locks the user set themselves via `lockunspent`.
     std::map<COutPoint, int64_t> m_pending_obs GUARDED_BY(cs_pending_obs);
     bool m_pending_obs_loaded GUARDED_BY(cs_pending_obs){false};
+    //! Whether the failure to read the record has been reported already, the read is
+    //! retried for as long as this node runs and a corrupt record never becomes readable
+    bool m_pending_obs_load_failed GUARDED_BY(cs_pending_obs){false};
 
     /// Populate m_pending_obs from the wallet database, once per run
     void LoadPendingObservations(wallet::WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_pending_obs);

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -12,9 +12,14 @@
 #include <util/translation.h>
 
 #include <deque>
+#include <map>
 #include <memory>
 #include <ranges>
 #include <utility>
+
+namespace wallet {
+class WalletBatch;
+} // namespace wallet
 
 class CCoinJoinClientManager;
 class CConnman;
@@ -174,6 +179,21 @@ private:
     // how many blocks to wait for after one successful mixing tx in non-multisession mode
     static constexpr int nMinBlocksToWait{1};
 
+    mutable Mutex cs_pending_obs;
+    //! Inputs of successfully completed mixing sessions which must stay locked until
+    //! the wallet observes the finalized mixing transaction spending them. Without this
+    //! a client which processes DSCOMPLETE(MSG_SUCCESS) before the (trickle-relayed)
+    //! finalized DSTX arrives could select the very same inputs for another session
+    //! (esp. with -coinjoinmultisession) and double-spend them.
+    //! Maps outpoint to the time it was added. Mirrored to the wallet database so that
+    //! both the locks and their grace period survive a restart, and so that these are
+    //! never confused with locks the user set themselves via `lockunspent`.
+    std::map<COutPoint, int64_t> m_pending_obs GUARDED_BY(cs_pending_obs);
+    bool m_pending_obs_loaded GUARDED_BY(cs_pending_obs){false};
+
+    /// Populate m_pending_obs from the wallet database, once per run
+    void LoadPendingObservations(wallet::WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_pending_obs);
+
     // Keep track of current block height
     int nCachedBlockHeight{0};
 
@@ -211,15 +231,27 @@ public:
 
     void UpdatedSuccessBlock();
 
+    //! How long to keep waiting for the finalized mixing transaction before
+    //! double-checking chain/mempool spentness and potentially releasing the inputs
+    static constexpr int64_t PENDING_OBSERVATION_TIMEOUT_SECONDS{60 * 60};
+
+    /// Keep the given successfully mixed inputs locked (persistently) until the wallet
+    /// observes a transaction spending them
+    void AddPendingObservation(const std::vector<COutPoint>& outpoints) EXCLUSIVE_LOCKS_REQUIRED(!cs_pending_obs);
+    /// Release pending inputs whose spend has been observed by the wallet
+    void CheckPendingObservations(const CTxMemPool& mempool) EXCLUSIVE_LOCKS_REQUIRED(!cs_pending_obs);
+    bool IsPendingObservation(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(!cs_pending_obs);
+    size_t GetPendingObservationCount() const EXCLUSIVE_LOCKS_REQUIRED(!cs_pending_obs);
+
     void UpdatedBlockTip(const CBlockIndex* pindex);
 
     void DoMaintenance(ChainstateManager& chainman, CConnman& connman, const CTxMemPool& mempool)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions, !cs_pending_obs);
 
     // interfaces::CoinJoin::Client overrides
     void disableAutobackups() override { fCreateAutoBackups = false; }
     void resetPool() override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
-    UniValue getJsonInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
+    UniValue getJsonInfo() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions, !cs_pending_obs);
     std::vector<std::string> getSessionStatuses() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
     std::string getSessionDenoms() const override EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
     bool isMixing() const override;

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -231,10 +231,6 @@ public:
 
     void UpdatedSuccessBlock();
 
-    //! How long to keep waiting for the finalized mixing transaction before
-    //! double-checking chain/mempool spentness and potentially releasing the inputs
-    static constexpr int64_t PENDING_OBSERVATION_TIMEOUT_SECONDS{60 * 60};
-
     /// Keep the given successfully mixed inputs locked (persistently) until the wallet
     /// observes a transaction spending them
     void AddPendingObservation(const std::vector<COutPoint>& outpoints) EXCLUSIVE_LOCKS_REQUIRED(!cs_pending_obs);
@@ -246,7 +242,7 @@ public:
     void UpdatedBlockTip(const CBlockIndex* pindex);
 
     void DoMaintenance(ChainstateManager& chainman, CConnman& connman, const CTxMemPool& mempool)
-        EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions, !cs_pending_obs);
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
 
     // interfaces::CoinJoin::Client overrides
     void disableAutobackups() override { fCreateAutoBackups = false; }

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -47,6 +47,10 @@ static constexpr int COINJOIN_AUTO_TIMEOUT_MIN = 5;
 static constexpr int COINJOIN_AUTO_TIMEOUT_MAX = 15;
 static constexpr int COINJOIN_QUEUE_TIMEOUT = 30;
 static constexpr int COINJOIN_SIGNING_TIMEOUT = 15;
+//! How long a successfully mixed input is kept locked while waiting for the finalized
+//! mixing transaction before chain/mempool spentness is double-checked and the input is
+//! potentially released, in seconds
+static constexpr int64_t COINJOIN_PENDING_OBSERVATION_TIMEOUT = 60 * 60;
 
 static constexpr size_t COINJOIN_ENTRY_MAX_SIZE = 9;
 

--- a/src/coinjoin/walletman.cpp
+++ b/src/coinjoin/walletman.cpp
@@ -73,6 +73,7 @@ private:
     std::map<const std::string, std::unique_ptr<CCoinJoinClientManager>> m_wallet_manager_map GUARDED_BY(cs_wallet_manager_map);
 
     void DoMaintenance(CConnman& connman) EXCLUSIVE_LOCKS_REQUIRED(!cs_wallet_manager_map);
+    void CheckPendingObservations() EXCLUSIVE_LOCKS_REQUIRED(!cs_wallet_manager_map);
 
     [[nodiscard]] MessageProcessingResult ProcessDSQueue(NodeId from, CConnman& connman, std::string_view msg_type,
                                                          CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_ProcessDSQueue, !cs_wallet_manager_map);
@@ -119,7 +120,16 @@ CJWalletManagerImpl::~CJWalletManagerImpl()
 
 void CJWalletManagerImpl::Schedule(CConnman& connman, CScheduler& scheduler)
 {
-    if (!m_relay_txes) return;
+    if (!m_relay_txes) {
+        // Mixing needs transaction relay, so no CoinJoin activity is scheduled here.
+        // Inputs of a session which completed before an earlier shutdown are a different
+        // matter: their locks were persisted and are restored with the wallet, so the
+        // check which releases them once their spend is observed (or once they time out)
+        // has to keep running even in block-only mode - nothing else would ever unlock them.
+        scheduler.scheduleEvery(std::bind(&CJWalletManagerImpl::CheckPendingObservations, this),
+                                std::chrono::minutes{1});
+        return;
+    }
     scheduler.scheduleEvery(std::bind(&CJWalletManagerImpl::DoMaintenance, this, std::ref(connman)),
                             std::chrono::seconds{1});
 }
@@ -202,6 +212,15 @@ void CJWalletManagerImpl::DoMaintenance(CConnman& connman)
     LOCK(cs_wallet_manager_map);
     for (auto& [_, clientman] : m_wallet_manager_map) {
         clientman->DoMaintenance(m_chainman, connman, m_mempool);
+    }
+}
+
+void CJWalletManagerImpl::CheckPendingObservations()
+{
+    if (ShutdownRequested()) return;
+    LOCK(cs_wallet_manager_map);
+    for (auto& [_, clientman] : m_wallet_manager_map) {
+        clientman->CheckPendingObservations(m_mempool);
     }
 }
 

--- a/src/coinjoin/walletman.cpp
+++ b/src/coinjoin/walletman.cpp
@@ -120,16 +120,19 @@ CJWalletManagerImpl::~CJWalletManagerImpl()
 
 void CJWalletManagerImpl::Schedule(CConnman& connman, CScheduler& scheduler)
 {
-    if (!m_relay_txes) {
-        // Mixing needs transaction relay, so no CoinJoin activity is scheduled here.
-        // Inputs of a session which completed before an earlier shutdown are a different
-        // matter: their locks were persisted and are restored with the wallet, so the
-        // check which releases them once their spend is observed (or once they time out)
-        // has to keep running even in block-only mode - nothing else would ever unlock them.
-        scheduler.scheduleEvery(std::bind(&CJWalletManagerImpl::CheckPendingObservations, this),
-                                std::chrono::minutes{1});
-        return;
-    }
+    // Inputs of a successfully completed session stay locked until the finalized mixing
+    // transaction is observed and those locks are persisted, so they are restored with
+    // the wallet. Releasing them has to keep running independently of mixing itself:
+    // even with CoinJoin disabled, mixing stopped or transaction relay unavailable
+    // (block-only mode, where nothing below is scheduled at all) nothing else would ever
+    // unlock them. NOTE: no CJWalletManager exists on a masternode (see init.cpp), a
+    // wallet with pending observations opened there keeps its inputs locked until it is
+    // opened on a regular node again or the user unlocks them via `lockunspent`.
+    scheduler.scheduleEvery(std::bind(&CJWalletManagerImpl::CheckPendingObservations, this), std::chrono::minutes{1});
+
+    // Mixing needs transaction relay
+    if (!m_relay_txes) return;
+
     scheduler.scheduleEvery(std::bind(&CJWalletManagerImpl::DoMaintenance, this, std::ref(connman)),
                             std::chrono::seconds{1});
 }

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -429,6 +429,7 @@ static RPCHelpMan getcoinjoininfo()
                             {RPCResult::Type::NUM, "denoms_hardcap", "Maximum limit of how many inputs of each denominated amount to create"},
                             {RPCResult::Type::NUM, "queue_size", "How many queues there are currently on the network"},
                             {RPCResult::Type::BOOL, "running", "Whether mixing is currently running"},
+                            {RPCResult::Type::NUM, "pending_inputs", "The number of successfully mixed inputs kept locked until the transaction spending them is observed"},
                             {RPCResult::Type::ARR, "sessions", "",
                             {
                                 {RPCResult::Type::OBJ, "", "",

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <test/util/setup_common.h>
+#include <test/util/txmempool.h>
 
 #include <coinjoin/client.h>
 #include <coinjoin/coinjoin.h>
@@ -11,14 +12,18 @@
 #include <coinjoin/util.h>
 #include <consensus/amount.h>
 #include <interfaces/coinjoin.h>
+#include <masternode/sync.h>
 #include <node/context.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <policy/settings.h>
+#include <util/time.h>
 #include <validation.h>
+#include <txmempool.h>
 #include <wallet/context.h>
 #include <wallet/spend.h>
 #include <wallet/wallet.h>
+#include <wallet/walletdb.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -223,6 +228,120 @@ public:
         return tallyItem;
     }
 };
+
+BOOST_FIXTURE_TEST_CASE(coinjoin_pending_observation_tests, CTransactionBuilderTestSetup)
+{
+    // 0.100001 DASH, a valid CoinJoin denomination
+    constexpr CAmount nDenomAmount{10000100};
+    BOOST_REQUIRE(CoinJoin::IsDenominatedAmount(nDenomAmount));
+    CompactTallyItem tallyItem = GetTallyItem({nDenomAmount, nDenomAmount, nDenomAmount, nDenomAmount});
+    const COutPoint outpointUserLocked = tallyItem.outpoints[0];
+    const COutPoint outpointPending = tallyItem.outpoints[1];
+    const COutPoint outpointTimeout = tallyItem.outpoints[2];
+    const COutPoint outpointInMempool = tallyItem.outpoints[3];
+
+    // A denominated coin the user locked themselves, e.g. via `lockunspent`
+    WITH_LOCK(wallet->cs_wallet, wallet->LockCoin(outpointUserLocked));
+
+    BOOST_CHECK(m_node.cj_walletman->doForClient("", [&](CCoinJoinClientManager& cj_man) {
+        // A user-created lock is never adopted as a pending observation: it has no
+        // CoinJoin record backing it, so it is left strictly alone
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(!cj_man.IsPendingObservation(outpointUserLocked));
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 0);
+
+        const int64_t nStart{GetTime()};
+        SetMockTime(nStart);
+        cj_man.AddPendingObservation({outpointPending});
+        BOOST_CHECK(cj_man.IsPendingObservation(outpointPending));
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 1);
+        BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPending)));
+
+        // Pending inputs are excluded from coin selection while unrelated inputs are not
+        {
+            LOCK(wallet->cs_wallet);
+            bool fFoundPending{false};
+            bool fFoundFree{false};
+            for (const auto& out : AvailableCoinsListUnspent(*wallet).all()) {
+                fFoundPending |= out.outpoint == outpointPending;
+                fFoundFree |= out.outpoint == outpointTimeout;
+            }
+            BOOST_CHECK(!fFoundPending);
+            BOOST_CHECK(fFoundFree);
+        }
+
+        // The pending set is mirrored to the wallet database so it survives a restart
+        {
+            std::map<COutPoint, int64_t> persisted;
+            WalletBatch batch(wallet->GetDatabase());
+            BOOST_REQUIRE(batch.ReadCoinJoinPendingObs(persisted));
+            BOOST_CHECK_EQUAL(persisted.size(), 1);
+            BOOST_CHECK(persisted.count(outpointPending) > 0);
+            BOOST_CHECK_EQUAL(persisted.at(outpointPending), nStart);
+        }
+
+        // Nothing is released while the inputs remain unspent and the timeout has not passed
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 1);
+
+        // Once the wallet observes a transaction spending a pending input its lock is dropped
+        CMutableTransaction mtxSpend;
+        mtxSpend.vin.emplace_back(outpointPending);
+        mtxSpend.vout.emplace_back(nDenomAmount - 1000, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        BOOST_REQUIRE(wallet->AddToWallet(MakeTransactionRef(mtxSpend), TxStateInMempool{}));
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(!cj_man.IsPendingObservation(outpointPending));
+        BOOST_CHECK(!WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPending)));
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 0);
+
+        // An input whose spending transaction sits in the mempool but has not reached the
+        // wallet yet must NOT be released: findCoins() reports it as unspent (it only
+        // knows outputs mempool transactions create, not the ones they spend), so the
+        // mempool has to be consulted separately
+        CMutableTransaction mtxMempool;
+        mtxMempool.vin.emplace_back(outpointInMempool);
+        mtxMempool.vout.emplace_back(nDenomAmount - 1000, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        {
+            LOCK2(::cs_main, m_node.mempool->cs);
+            m_node.mempool->addUnchecked(TestMemPoolEntryHelper().FromTx(MakeTransactionRef(mtxMempool)));
+        }
+        BOOST_REQUIRE(m_node.mempool->isSpent(outpointInMempool));
+        BOOST_REQUIRE(WITH_LOCK(wallet->cs_wallet, return wallet->GetWalletTx(mtxMempool.GetHash())) == nullptr);
+
+        cj_man.AddPendingObservation({outpointTimeout, outpointInMempool});
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 2);
+        SetMockTime(nStart + CCoinJoinClientManager::PENDING_OBSERVATION_TIMEOUT_SECONDS + 1);
+
+        // The timeout never fires while the chain is still catching up: the spending
+        // transaction could be sitting in a block we have not downloaded yet
+        BOOST_REQUIRE(!m_node.mn_sync->IsBlockchainSynced());
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 2);
+        BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointTimeout)));
+
+        m_node.mn_sync->SwitchToNextAsset();
+        BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
+        cj_man.CheckPendingObservations(*m_node.mempool);
+
+        // Unspent everywhere - released (with a warning) after the terminal timeout
+        BOOST_CHECK(!cj_man.IsPendingObservation(outpointTimeout));
+        BOOST_CHECK(!WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointTimeout)));
+        // Spent by an unconfirmed transaction the wallet has not recorded - kept locked
+        BOOST_CHECK(cj_man.IsPendingObservation(outpointInMempool));
+        BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointInMempool)));
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 1);
+
+        // A manual unlock (e.g. via lockunspent) purges the pending entry
+        WITH_LOCK(wallet->cs_wallet, wallet->UnlockCoin(outpointInMempool));
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(!cj_man.IsPendingObservation(outpointInMempool));
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 0);
+
+        // The user's own lock was never touched throughout
+        BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointUserLocked)));
+        SetMockTime(0);
+    }));
+}
 
 BOOST_FIXTURE_TEST_CASE(coinjoin_manager_start_stop_tests, CTransactionBuilderTestSetup)
 {

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -21,6 +21,7 @@
 #include <validation.h>
 #include <txmempool.h>
 #include <wallet/context.h>
+#include <wallet/db.h>
 #include <wallet/spend.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
@@ -392,6 +393,82 @@ BOOST_FIXTURE_TEST_CASE(coinjoin_pending_observation_reload_tests, CTransactionB
         cj_man.CheckPendingObservations(*m_node.mempool);
         BOOST_CHECK(!cj_man.IsPendingObservation(outpointPending));
         BOOST_CHECK(!WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPending)));
+    }));
+    SetMockTime(0);
+}
+
+BOOST_FIXTURE_TEST_CASE(coinjoin_pending_observation_unreadable_tests, CTransactionBuilderTestSetup)
+{
+    // 0.100001 DASH, a valid CoinJoin denomination
+    constexpr CAmount nDenomAmount{10000100};
+    CompactTallyItem tallyItem = GetTallyItem({nDenomAmount, nDenomAmount});
+    const COutPoint outpointPersisted = tallyItem.outpoints[0];
+    const COutPoint outpointInMemory = tallyItem.outpoints[1];
+
+    const int64_t nStart{GetTime()};
+    SetMockTime(nStart);
+    BOOST_CHECK(m_node.cj_walletman->doForClient("", [&](CCoinJoinClientManager& cj_man) {
+        cj_man.AddPendingObservation({outpointPersisted});
+    }));
+    BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPersisted)));
+
+    // Corrupt the record behind the manager's back: it exists but cannot be deserialized
+    // into the pending map anymore. This must not read as "nothing was ever pending", the
+    // locks it tracks would be left with nothing to ever release them.
+    BOOST_REQUIRE(wallet->GetDatabase().MakeBatch()->Write(std::string(DBKeys::COINJOIN_PENDING_OBS),
+                                                           std::string("not a pending observation map")));
+
+    // A fresh manager for the same wallet, the way a restart would build one
+    m_node.cj_walletman->removeWallet(wallet->GetName());
+    m_node.cj_walletman->addWallet(wallet);
+
+    BOOST_CHECK(m_node.cj_walletman->doForClient("", [&](CCoinJoinClientManager& cj_man) {
+        // The read fails, so nothing is loaded and the persisted lock is left in place
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 0);
+        BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPersisted)));
+
+        // Adding a new observation while the record is unreadable must not overwrite it,
+        // that would orphan the locks it still tracks for good. The new entry is kept in
+        // memory (and its coin locked) but deliberately not persisted.
+        cj_man.AddPendingObservation({outpointInMemory});
+        BOOST_CHECK(cj_man.IsPendingObservation(outpointInMemory));
+        BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointInMemory)));
+        {
+            std::map<COutPoint, int64_t> persisted;
+            WalletBatch batch(wallet->GetDatabase());
+            BOOST_CHECK(!batch.ReadCoinJoinPendingObs(persisted));
+            BOOST_CHECK(persisted.empty());
+        }
+
+        // Same for the release path: a pass which changes the pending set must not write
+        // the record out either while its contents are still unknown
+        WITH_LOCK(wallet->cs_wallet, wallet->UnlockCoin(outpointInMemory));
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(!cj_man.IsPendingObservation(outpointInMemory));
+        BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPersisted)));
+        {
+            std::map<COutPoint, int64_t> persisted;
+            WalletBatch batch(wallet->GetDatabase());
+            BOOST_CHECK(!batch.ReadCoinJoinPendingObs(persisted));
+        }
+
+        // Once the record is readable again the entry it tracks is picked back up and the
+        // lock behind it can finally be released
+        {
+            WalletBatch batch(wallet->GetDatabase());
+            BOOST_REQUIRE(batch.WriteCoinJoinPendingObs({{outpointPersisted, nStart}}));
+        }
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(cj_man.IsPendingObservation(outpointPersisted));
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 1);
+
+        m_node.mn_sync->SwitchToNextAsset();
+        BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
+        SetMockTime(nStart + COINJOIN_PENDING_OBSERVATION_TIMEOUT + 1);
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(!cj_man.IsPendingObservation(outpointPersisted));
+        BOOST_CHECK(!WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPersisted)));
     }));
     SetMockTime(0);
 }

--- a/src/wallet/test/coinjoin_tests.cpp
+++ b/src/wallet/test/coinjoin_tests.cpp
@@ -144,6 +144,12 @@ public:
     CTransactionBuilderTestSetup() :
         wallet{std::make_unique<CWallet>(m_node.chain.get(), m_node.coinjoin_loader.get(), "", m_args, CreateMockWalletDatabase())}
     {
+        // NOTE: minRelayTxFee is a global other suites mutate without restoring the
+        // default (transaction_tests leaves it at DUST_RELAY_TX_FEE), which makes the
+        // feerate GetTallyItem() asks for lower than the minimum and fails every
+        // CreateTransaction() call below. Boost shuffles test order in CI, so pin it
+        // here for every test using this fixture instead of per test.
+        minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
         context.args = &m_args;
         context.chain = m_node.chain.get();
         context.coinjoin_loader = m_node.coinjoin_loader.get();
@@ -205,7 +211,9 @@ public:
             CTransactionRef tx;
             {
                 auto res = CreateTransaction(*wallet, {{GetScriptForDestination(tallyItem.txdest), nAmount, false}}, nChangePosRet, coinControl);
-                BOOST_REQUIRE(res);
+                // Report why it failed, a bare "critical check res has failed" says nothing
+                BOOST_REQUIRE_MESSAGE(res, strprintf("CreateTransaction(%d) failed: %s", nAmount,
+                                                     util::ErrorString(res).original));
                 tx = res->tx;
                 nChangePosRet = res->change_pos;
             }
@@ -310,7 +318,7 @@ BOOST_FIXTURE_TEST_CASE(coinjoin_pending_observation_tests, CTransactionBuilderT
 
         cj_man.AddPendingObservation({outpointTimeout, outpointInMempool});
         BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 2);
-        SetMockTime(nStart + CCoinJoinClientManager::PENDING_OBSERVATION_TIMEOUT_SECONDS + 1);
+        SetMockTime(nStart + COINJOIN_PENDING_OBSERVATION_TIMEOUT + 1);
 
         // The timeout never fires while the chain is still catching up: the spending
         // transaction could be sitting in a block we have not downloaded yet
@@ -341,6 +349,51 @@ BOOST_FIXTURE_TEST_CASE(coinjoin_pending_observation_tests, CTransactionBuilderT
         BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointUserLocked)));
         SetMockTime(0);
     }));
+}
+
+BOOST_FIXTURE_TEST_CASE(coinjoin_pending_observation_reload_tests, CTransactionBuilderTestSetup)
+{
+    // 0.100001 DASH, a valid CoinJoin denomination
+    constexpr CAmount nDenomAmount{10000100};
+    CompactTallyItem tallyItem = GetTallyItem({nDenomAmount});
+    const COutPoint outpointPending = tallyItem.outpoints[0];
+
+    const int64_t nStart{GetTime()};
+    SetMockTime(nStart);
+    BOOST_CHECK(m_node.cj_walletman->doForClient("", [&](CCoinJoinClientManager& cj_man) {
+        cj_man.AddPendingObservation({outpointPending});
+        BOOST_CHECK(cj_man.IsPendingObservation(outpointPending));
+    }));
+    BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPending)));
+
+    // Drop the client manager and create a fresh one for the same wallet: it has to pick
+    // the pending observation back up from the wallet database, the way it would after a
+    // restart, otherwise the persisted lock would be left with nothing to release it
+    m_node.cj_walletman->removeWallet(wallet->GetName());
+    m_node.cj_walletman->addWallet(wallet);
+
+    BOOST_CHECK(m_node.cj_walletman->doForClient("", [&](CCoinJoinClientManager& cj_man) {
+        // The record is read lazily, on the first check
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 0);
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(cj_man.IsPendingObservation(outpointPending));
+        BOOST_CHECK_EQUAL(cj_man.GetPendingObservationCount(), 1);
+        BOOST_CHECK(WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPending)));
+
+        m_node.mn_sync->SwitchToNextAsset();
+        BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
+
+        // The grace period was restored along with the entry rather than restarted: the
+        // terminal timeout is measured from when the session completed, not from reload
+        SetMockTime(nStart + COINJOIN_PENDING_OBSERVATION_TIMEOUT - 1);
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(cj_man.IsPendingObservation(outpointPending));
+        SetMockTime(nStart + COINJOIN_PENDING_OBSERVATION_TIMEOUT + 1);
+        cj_man.CheckPendingObservations(*m_node.mempool);
+        BOOST_CHECK(!cj_man.IsPendingObservation(outpointPending));
+        BOOST_CHECK(!WITH_LOCK(wallet->cs_wallet, return wallet->IsLockedCoin(outpointPending)));
+    }));
+    SetMockTime(0);
 }
 
 BOOST_FIXTURE_TEST_CASE(coinjoin_manager_start_stop_tests, CTransactionBuilderTestSetup)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -38,6 +38,7 @@ const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
 const std::string BESTBLOCK{"bestblock"};
 const std::string CRYPTED_KEY{"ckey"};
 const std::string CRYPTED_HDCHAIN{"chdchain"};
+const std::string COINJOIN_PENDING_OBS{"cj_pending_obs"};
 const std::string COINJOIN_SALT{"cj_salt"};
 const std::string CSCRIPT{"cscript"};
 const std::string DEFAULTKEY{"defaultkey"};
@@ -224,6 +225,16 @@ bool WalletBatch::ReadCoinJoinSalt(uint256& salt, bool fLegacy)
 bool WalletBatch::WriteCoinJoinSalt(const uint256& salt)
 {
     return WriteIC(DBKeys::COINJOIN_SALT, salt);
+}
+
+bool WalletBatch::ReadCoinJoinPendingObs(std::map<COutPoint, int64_t>& pending_obs)
+{
+    return m_batch->Read(std::string(DBKeys::COINJOIN_PENDING_OBS), pending_obs);
+}
+
+bool WalletBatch::WriteCoinJoinPendingObs(const std::map<COutPoint, int64_t>& pending_obs)
+{
+    return WriteIC(DBKeys::COINJOIN_PENDING_OBS, pending_obs);
 }
 
 bool WalletBatch::WriteGovernanceObject(const Governance::Object& obj)
@@ -778,7 +789,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                    strType != DBKeys::MINVERSION && strType != DBKeys::ACENTRY &&
                    strType != DBKeys::VERSION && strType != DBKeys::SETTINGS &&
                    strType != DBKeys::PRIVATESEND_SALT && strType != DBKeys::COINJOIN_SALT &&
-                   strType != DBKeys::FLAGS) {
+                   strType != DBKeys::COINJOIN_PENDING_OBS && strType != DBKeys::FLAGS) {
             wss.m_unknown_records++;
         }
     } catch (const std::exception& e) {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -227,6 +227,11 @@ bool WalletBatch::WriteCoinJoinSalt(const uint256& salt)
     return WriteIC(DBKeys::COINJOIN_SALT, salt);
 }
 
+bool WalletBatch::HasCoinJoinPendingObs()
+{
+    return m_batch->Exists(std::string(DBKeys::COINJOIN_PENDING_OBS));
+}
+
 bool WalletBatch::ReadCoinJoinPendingObs(std::map<COutPoint, int64_t>& pending_obs)
 {
     return m_batch->Read(std::string(DBKeys::COINJOIN_PENDING_OBS), pending_obs);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -220,7 +220,9 @@ public:
 
     /** Outpoints of successfully mixed inputs which are locked until the transaction
      *  spending them is observed, mapped to the time each was recorded. Stored as one
-     *  record because the set is small and always rewritten as a whole. */
+     *  record because the set is small and always rewritten as a whole. Has() tells a
+     *  missing record apart from one Read() could not read or deserialize. */
+    bool HasCoinJoinPendingObs();
     bool ReadCoinJoinPendingObs(std::map<COutPoint, int64_t>& pending_obs);
     bool WriteCoinJoinPendingObs(const std::map<COutPoint, int64_t>& pending_obs);
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -13,6 +13,7 @@
 #include <key.h>
 
 #include <stdint.h>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -68,6 +69,7 @@ extern const std::string BESTBLOCK;
 extern const std::string BESTBLOCK_NOMERKLE;
 extern const std::string CRYPTED_HDCHAIN;
 extern const std::string CRYPTED_KEY;
+extern const std::string COINJOIN_PENDING_OBS;
 extern const std::string COINJOIN_SALT;
 extern const std::string CSCRIPT;
 extern const std::string DEFAULTKEY;
@@ -215,6 +217,12 @@ public:
 
     bool ReadCoinJoinSalt(uint256& salt, bool fLegacy = false);
     bool WriteCoinJoinSalt(const uint256& salt);
+
+    /** Outpoints of successfully mixed inputs which are locked until the transaction
+     *  spending them is observed, mapped to the time each was recorded. Stored as one
+     *  record because the set is small and always rewritten as a whole. */
+    bool ReadCoinJoinPendingObs(std::map<COutPoint, int64_t>& pending_obs);
+    bool WriteCoinJoinPendingObs(const std::map<COutPoint, int64_t>& pending_obs);
 
     /** Write a CGovernanceObject to the database */
     bool WriteGovernanceObject(const Governance::Object& obj);

--- a/test/functional/rpc_coinjoin.py
+++ b/test/functional/rpc_coinjoin.py
@@ -84,6 +84,8 @@ class CoinJoinTest(BitcoinTestFramework):
         cj_info = node.getcoinjoininfo()
         assert_equal(cj_info['enabled'], True)
         assert_equal(cj_info['running'], True)
+        # No session has completed, so nothing is waiting to be observed
+        assert_equal(cj_info['pending_inputs'], 0)
         # Repeated start should yield error
         assert_raises_rpc_error(-32603, 'Mixing has been started already.', node.coinjoin, 'start')
         # Requesting status shouldn't complain


### PR DESCRIPTION
## Issue being fixed or feature implemented

Client-side alternative to #7478, per https://github.com/dashpay/dash/pull/7478#pullrequestreview-3547103661. #7478 fixes the wire ordering coordinator-side; this fixes the underlying invariant on the node that actually bears the risk.

A CoinJoin participant releases its selected inputs as soon as it processes `DSCOMPLETE(MSG_SUCCESS)`. The coordinator announces the finalized mixing transaction only via `PeerRelayInv` (delayed inventory trickling) while `DSCOMPLETE` is pushed directly, so the completion message routinely overtakes the `INV`/`GETDATA`/`DSTX` exchange. During that window the session inputs are neither wallet-locked nor marked spent, so with `-coinjoinmultisession=1` (where the one-block cooldown is bypassed) another session can select and sign the very same inputs, producing two valid CoinJoin transactions spending the same outpoint. Conflicting InstantSend votes then leave both transactions without an ISLock, which can stall ChainLocks.

The broken invariant: after a successful session, a participant must observe the finalized transaction spending its inputs before it releases them for reuse. The old ordering allowed the release to happen first.

Why client-side rather than coordinator-side:

- **Message ordering is not wallet ordering.** Pushing `DSTX` before `DSCOMPLETE` only guarantees the transaction reaches the mempool first. `CMainSignals::TransactionAddedToMempool` enqueues to the scheduler, so `mapTxSpends` is updated asynchronously — the participant can still process `DSCOMPLETE` and unlock while the wallet has not recorded the spend. This fix keys off actual wallet state (`CWallet::IsSpent`), so it does not depend on scheduler FIFO ordering.
- **No propagation change, so no anonymity-set leak.** A direct push moves the participants' own onward relay of the DSTX from "coordinator inbound trickle + getdata round trip" to `t0 + RTT`, making the coordinator and its N participants the earliest announcers of that round's transaction — a sybil observer could resolve the anonymity set to IPs.
- **The node bearing the risk deploys the fix**, instead of depending on masternode operators upgrading, with no opt-out for un-upgraded clients.

## What was done?

On `MSG_SUCCESS`, `CCoinJoinClientSession::CompletedTransaction` no longer unlocks the session's *mixing* inputs. They are handed to `CCoinJoinClientManager::AddPendingObservation`, which:

- persists the wallet lock via `WalletBatch`, so a restart before the finalized transaction is observed cannot make the input selectable again, and
- records the outpoint, with the time it was added, in a per-wallet pending-observation set mirrored to the wallet database under a new CoinJoin-specific record (`cj_pending_obs`). Because ownership is recorded explicitly rather than inferred, both the locks *and* their grace period survive a restart, and locks the user set themselves via `lockunspent` are never touched.

`CCoinJoinClientManager::CheckPendingObservations` runs as its own scheduler task (`CJWalletManagerImpl::Schedule`, once a minute), deliberately independent of `DoMaintenance` and its gates so pending inputs can still unlock while mixing is stopped or CoinJoin itself is disabled. It releases a lock when:

- the wallet observes a transaction spending the input (`CWallet::IsSpent`) — the normal path; or
- the input is still unspent after `PENDING_OBSERVATION_TIMEOUT_SECONDS` (1h) — the fallback, so a mixing transaction that never propagated cannot strand funds. Two guards apply here:
  - **gated on `IsBlockchainSynced()`** — while catching up, the spending transaction may sit in a block we have not downloaded yet, and releasing on the strength of that would defeat the point;
  - **chain UTXO set *and* mempool are both consulted** — `findCoins()` reports outputs that exist in the UTXO set or are *created* by a mempool transaction, but `CCoinsViewMemPool::GetCoin` never looks at `mapNextTx`, so it cannot tell that a mempool transaction *spends* a chain output. Relying on it alone would misread the finalized mixing transaction sitting unprocessed in our own mempool as "never propagated" and release the input — reopening exactly the window this PR closes. `CTxMemPool::isSpent` is queried explicitly;
- the user released the lock manually (e.g. `lockunspent`), which purges the pending entry.

This standalone scheduling also matters in block-only mode (`-blocksonly=1`), where no other CoinJoin maintenance is scheduled at all since mixing needs transaction relay: the locks are persistent and are restored with the wallet, so without the check inputs from a session that completed before an earlier shutdown would stay locked forever. No other CoinJoin activity is scheduled in that mode, as before.

Collateral inputs and every failure path keep the old immediate-unlock behavior.

`getcoinjoininfo` gains a `pending_inputs` field for observability.

## How Has This Been Tested?

- New unit test `coinjoin_pending_observation_tests` covers the full lifecycle: a user's own lock on a denominated coin is never adopted as pending, pending inputs stay locked and excluded from coin selection while unrelated inputs remain selectable, the set is mirrored to the wallet database, an observed spend releases the lock, the terminal timeout does not fire while the chain is unsynced, an input spent by a mempool transaction the wallet has not recorded yet is **kept** locked while a genuinely unspent one is released, and a manual unlock purges the pending entry.
- The mempool-spender case was verified as a real regression test: removing the `!mempool.isSpent(outpoint)` guard makes it fail (the input gets released), and restoring it makes it pass.
- `coinjoin_tests`, `wallet_tests`, `walletdb_tests` pass.
- `test/functional/rpc_coinjoin.py`, `wallet_basic.py`, `wallet_fundrawtransaction.py`, `p2p_blocksonly.py` pass.

On lock ordering: `CheckPendingObservations` holds `cs_wallet` across `chain().findCoins()`, which takes `cs_main`. That is the established direction here — `FundTransaction` ([wallet/spend.cpp:1170](src/wallet/spend.cpp:1170), straight from upstream) and the pre-existing CoinJoin signing path ([coinjoin/client.cpp:453](src/coinjoin/client.cpp:453)) both do the same. There is no `cs_main → cs_wallet` path to invert against: no wallet function asserts `cs_main`, and every validation-interface callback the wallet consumes is dispatched through the scheduler queue rather than synchronously under `cs_main`. Builds here are `-DDEBUG_LOCKORDER` and `wallet_fundrawtransaction.py` (which exercises that exact order alongside block connection and mempool activity) reports no inconsistency.

## Breaking Changes

None on the wire. Behavioral: after a successful mixing session a client's mixed inputs stay locked (and are now persistently locked) until it sees the transaction spending them, instead of becoming immediately selectable. `getcoinjoininfo` gains one field.

Wallet database: adds one new record, `cj_pending_obs`. It is written only when a mixing session completes successfully, and an older client loading such a wallet ignores it (counted as an unknown record) — the persisted `lockedutxo` entries it accompanies are understood by older clients regardless, so the inputs stay locked either way.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

