### PR TITLE
fix(net): clean recovered sig backlog after peer disconnect

### DIFF
--- a/src/llmq/net_signing.cpp
+++ b/src/llmq/net_signing.cpp
@@ -288,10 +288,23 @@ void NetSigning::WorkThreadSigning()
         constexpr auto CLEANUP_INTERVAL{5s};
         if (cleanupThrottler.TryCleanup(CLEANUP_INTERVAL)) {
             m_sig_manager.Cleanup();
-            // Drop pending recovered sigs queued by banned peers so a flood's backlog does not
-            // persist after the peer is banned (RemoveBannedNodeStates only cleans the sig-shares
-            // subsystem, not m_sig_manager's pending recovered sigs).
-            m_sig_manager.RemoveNodesIf([this](NodeId node_id) { return m_peer_manager->PeerIsBanned(node_id); });
+            // Drop pending recovered sigs queued by peers that are gone, so a flood's backlog does
+            // not persist after the peer is disconnected (RemoveBannedNodeStates only cleans the
+            // sig-shares subsystem, not m_sig_manager's pending recovered sigs).
+            //
+            // Keyed on "no longer connected" rather than "banned" deliberately. Banning is observed
+            // via Peer::m_should_discourage, a one-shot flag that MaybeDiscourageAndDisconnect
+            // clears on the very next SendMessages pass (~100ms) before disconnecting the peer,
+            // after which the Peer is finalized and the flag is unobservable. This sweep only runs
+            // every CLEANUP_INTERVAL, so a banned-peer predicate would almost never see the flag
+            // set and the backlog would survive. Disconnection is instead a durable, terminal state
+            // (node ids are never reused), so it is reliably observed on some later tick. This also
+            // reclaims the queues of peers that simply went away without misbehaving, and mirrors
+            // how CSigSharesManager::Cleanup() already prunes its per-node state.
+            //
+            // Locally reconstructed sigs use NodeId -1, which is never connected; they live in
+            // pendingReconstructedRecoveredSigs, a separate map RemoveNodesIf does not touch.
+            m_sig_manager.RemoveNodesIf([this](NodeId node_id) { return !m_peer_manager->PeerIsConnected(node_id); });
         }
 
         // TODO Wakeup when pending signing is needed?

--- a/src/llmq/net_signing.cpp
+++ b/src/llmq/net_signing.cpp
@@ -288,22 +288,7 @@ void NetSigning::WorkThreadSigning()
         constexpr auto CLEANUP_INTERVAL{5s};
         if (cleanupThrottler.TryCleanup(CLEANUP_INTERVAL)) {
             m_sig_manager.Cleanup();
-            // Drop pending recovered sigs queued by peers that are gone, so a flood's backlog does
-            // not persist after the peer is disconnected (RemoveBannedNodeStates only cleans the
-            // sig-shares subsystem, not m_sig_manager's pending recovered sigs).
-            //
-            // Keyed on "no longer connected" rather than "banned" deliberately. Banning is observed
-            // via Peer::m_should_discourage, a one-shot flag that MaybeDiscourageAndDisconnect
-            // clears on the very next SendMessages pass (~100ms) before disconnecting the peer,
-            // after which the Peer is finalized and the flag is unobservable. This sweep only runs
-            // every CLEANUP_INTERVAL, so a banned-peer predicate would almost never see the flag
-            // set and the backlog would survive. Disconnection is instead a durable, terminal state
-            // (node ids are never reused), so it is reliably observed on some later tick. This also
-            // reclaims the queues of peers that simply went away without misbehaving, and mirrors
-            // how CSigSharesManager::Cleanup() already prunes its per-node state.
-            //
-            // Locally reconstructed sigs use NodeId -1, which is never connected; they live in
-            // pendingReconstructedRecoveredSigs, a separate map RemoveNodesIf does not touch.
+            // PeerIsBanned() is transient. Finalized node ids are never reused, so disconnection remains observable.
             m_sig_manager.RemoveNodesIf([this](NodeId node_id) { return !m_peer_manager->PeerIsConnected(node_id); });
         }
 

--- a/src/llmq/signing.h
+++ b/src/llmq/signing.h
@@ -217,8 +217,7 @@ public:
         size_t maxUniqueSessions, std::unordered_map<NodeId, std::list<std::shared_ptr<const CRecoveredSig>>>& retSigShares,
         std::unordered_map<std::pair<Consensus::LLMQType, uint256>, CBLSPublicKey, StaticSaltedHasher>& ret_pubkeys)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_pending);
-    // Drop the pending (not-yet-verified) recovered sigs of any node matching the predicate, e.g.
-    // banned peers. Without this, a flooded peer's backlog would persist even after it is banned.
+    // Drop pending (not-yet-verified) recovered sigs for matching node ids.
     void RemoveNodesIf(const std::function<bool(NodeId)>& predicate) EXCLUSIVE_LOCKS_REQUIRED(!cs_pending);
     [[nodiscard]] std::vector<CRecoveredSigsListener*> GetListeners() const EXCLUSIVE_LOCKS_REQUIRED(!cs_listeners);
     // Returns true if recovered sigs should be send to listeners

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -633,6 +633,7 @@ public:
     /** Implement PeerManagerInternal */
     void PeerMisbehaving(const NodeId pnode, const int howmuch, const std::string& message = "") override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     bool PeerIsBanned(const NodeId node_id) override EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_peer_mutex);
+    bool PeerIsConnected(const NodeId node_id) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void PeerEraseObjectRequest(const NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool PeerConsumeObjectRequest(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     GetDataResponse PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
@@ -6716,6 +6717,11 @@ void PeerManagerImpl::PeerMisbehaving(const NodeId pnode, const int howmuch, con
 bool PeerManagerImpl::PeerIsBanned(const NodeId node_id)
 {
     return IsBanned(node_id);
+}
+
+bool PeerManagerImpl::PeerIsConnected(const NodeId node_id)
+{
+    return GetPeerRef(node_id) != nullptr;
 }
 
 void PeerManagerImpl::PeerEraseObjectRequest(const NodeId nodeid, const CInv& inv)

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -82,11 +82,7 @@ class PeerManagerInternal
 public:
     virtual void PeerMisbehaving(const NodeId pnode, const int howmuch, const std::string& message = "") = 0;
     virtual bool PeerIsBanned(const NodeId node_id) = 0;
-    /** Whether we still have a Peer for this node id, i.e. the peer is connected and has not been
-     *  finalized yet. Unlike PeerIsBanned(), this is a durable state rather than a one-shot flag:
-     *  it stays false for good once the peer is gone, so periodic sweeps can rely on observing it.
-     *  Node ids are never reused (CConnman::GetNewNodeId only increments), so a false result can
-     *  never later become true for the same id. */
+    /** Whether the peer exists and has not been finalized. */
     virtual bool PeerIsConnected(const NodeId node_id) = 0;
     /** Complete this peer's pending announcement of the inv, so it is not requested from them
      *  again. Announcements of the same inv by other peers are unaffected: an invalid or unusable

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -82,6 +82,12 @@ class PeerManagerInternal
 public:
     virtual void PeerMisbehaving(const NodeId pnode, const int howmuch, const std::string& message = "") = 0;
     virtual bool PeerIsBanned(const NodeId node_id) = 0;
+    /** Whether we still have a Peer for this node id, i.e. the peer is connected and has not been
+     *  finalized yet. Unlike PeerIsBanned(), this is a durable state rather than a one-shot flag:
+     *  it stays false for good once the peer is gone, so periodic sweeps can rely on observing it.
+     *  Node ids are never reused (CConnman::GetNewNodeId only increments), so a false result can
+     *  never later become true for the same id. */
+    virtual bool PeerIsConnected(const NodeId node_id) = 0;
     /** Complete this peer's pending announcement of the inv, so it is not requested from them
      *  again. Announcements of the same inv by other peers are unaffected: an invalid or unusable
      *  object must not stop us from fetching it from honest peers.

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -338,8 +338,13 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     peerLogic->InitializeNode(*nodes[0], NODE_NETWORK);
     nodes[0]->fSuccessfullyConnected = true;
     connman->AddTestNode(*nodes[0]);
+    BOOST_CHECK(peerLogic->PeerIsConnected(nodes[0]->GetId()));
     peerLogic->UnitTestMisbehaving(nodes[0]->GetId(), DISCOURAGEMENT_THRESHOLD); // Should be discouraged
+    BOOST_CHECK(WITH_LOCK(::cs_main, return peerLogic->PeerIsBanned(nodes[0]->GetId())));
+    BOOST_CHECK(peerLogic->PeerIsConnected(nodes[0]->GetId()));
     BOOST_CHECK(peerLogic->SendMessages(nodes[0]));
+    BOOST_CHECK(WITH_LOCK(::cs_main, return !peerLogic->PeerIsBanned(nodes[0]->GetId())));
+    BOOST_CHECK(peerLogic->PeerIsConnected(nodes[0]->GetId()));
     BOOST_CHECK(banman->IsDiscouraged(addr[0]));
     BOOST_CHECK(nodes[0]->fDisconnect);
     BOOST_CHECK(!banman->IsDiscouraged(other_addr)); // Different address, not discouraged
@@ -399,6 +404,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
 
     for (CNode* node : nodes) {
         peerLogic->FinalizeNode(*node);
+        BOOST_CHECK(!peerLogic->PeerIsConnected(node->GetId()));
     }
     connman->ClearTestNodes();
 }
@@ -437,74 +443,6 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     BOOST_CHECK(!banman->IsDiscouraged(addr));
 
     peerLogic->FinalizeNode(dummyNode);
-}
-
-// NetSigning's periodic sweep drops the pending (not-yet-verified) recovered sigs of peers that are
-// gone, so a flood's backlog does not outlive the peer. It runs on a 5s tick, so the state it keys
-// on must still be observable whenever that tick happens to land.
-//
-// This is a regression test for keying that sweep on PeerIsBanned(): banning is observed via
-// Peer::m_should_discourage, a one-shot flag cleared by MaybeDiscourageAndDisconnect on the very
-// next SendMessages pass, so the predicate was true only inside a ~100ms window and the 5s sweep
-// essentially never saw it. PeerIsConnected() is terminal instead, so the sweep cannot miss it.
-BOOST_AUTO_TEST_CASE(peer_gone_recovered_sig_cleanup_predicate)
-{
-    LOCK(NetEventsInterface::g_msgproc_mutex);
-
-    auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
-    auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
-    auto peerLogic = MakePeerManager(*connman, m_node, banman.get(), /*ignore_incoming_txs=*/false);
-
-    banman->ClearBanned();
-    CAddress addr{ip(0xa0b0c001), NODE_NONE};
-    // Owned by connman; ClearTestNodes() deletes it.
-    CNode* dummyNode{new CNode{/*id=*/0,
-                               /*sock=*/nullptr,
-                               addr,
-                               /*nKeyedNetGroupIn=*/0,
-                               /*nLocalHostNonceIn=*/0,
-                               CAddress(),
-                               /*addrNameIn=*/"",
-                               ConnectionType::INBOUND,
-                               /*inbound_onion=*/false}};
-    const NodeId node_id{dummyNode->GetId()};
-    dummyNode->SetCommonVersion(PROTOCOL_VERSION);
-    peerLogic->InitializeNode(*dummyNode, NODE_NETWORK);
-    dummyNode->fSuccessfullyConnected = true;
-    connman->AddTestNode(*dummyNode);
-
-    // The predicates NetSigning::WorkThreadSigning hands to CSigningManager::RemoveNodesIf. The
-    // "banned" one is what this test is a regression against; both run against the real PeerManager.
-    const auto drops_when_banned = [&] {
-        return WITH_LOCK(::cs_main, return peerLogic->PeerIsBanned(node_id));
-    };
-    const auto drops_when_gone = [&] { return !peerLogic->PeerIsConnected(node_id); };
-
-    // A connected, well-behaved peer's backlog must be left alone by both.
-    BOOST_CHECK(!drops_when_banned());
-    BOOST_CHECK(!drops_when_gone());
-
-    // Misbehave to the discouragement threshold. m_should_discourage is now set, so a sweep landing
-    // in this narrow window would see the peer as banned -- but the peer is still connected.
-    peerLogic->UnitTestMisbehaving(node_id, DISCOURAGEMENT_THRESHOLD);
-    BOOST_CHECK(drops_when_banned());
-    BOOST_CHECK(!drops_when_gone());
-
-    // One SendMessages pass (~100ms in production, long before the 5s sweep tick) consumes the
-    // one-shot flag and marks the peer for disconnection. This is the bug: the banned-keyed
-    // predicate has already gone false again while the peer's pending sigs are still queued.
-    BOOST_CHECK(peerLogic->SendMessages(dummyNode));
-    BOOST_CHECK(dummyNode->fDisconnect);
-    BOOST_CHECK(!drops_when_banned());
-
-    // Once the peer is finalized the Peer is gone for good, so the connection-keyed predicate is
-    // true on this and every later tick, whenever the sweep happens to run.
-    peerLogic->FinalizeNode(*dummyNode);
-    BOOST_CHECK(!drops_when_banned()); // still false -- the flag is now unobservable
-    BOOST_CHECK(drops_when_gone());
-    BOOST_CHECK(drops_when_gone()); // terminal: node ids are never reused
-
-    connman->ClearTestNodes();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -439,4 +439,72 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     peerLogic->FinalizeNode(dummyNode);
 }
 
+// NetSigning's periodic sweep drops the pending (not-yet-verified) recovered sigs of peers that are
+// gone, so a flood's backlog does not outlive the peer. It runs on a 5s tick, so the state it keys
+// on must still be observable whenever that tick happens to land.
+//
+// This is a regression test for keying that sweep on PeerIsBanned(): banning is observed via
+// Peer::m_should_discourage, a one-shot flag cleared by MaybeDiscourageAndDisconnect on the very
+// next SendMessages pass, so the predicate was true only inside a ~100ms window and the 5s sweep
+// essentially never saw it. PeerIsConnected() is terminal instead, so the sweep cannot miss it.
+BOOST_AUTO_TEST_CASE(peer_gone_recovered_sig_cleanup_predicate)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    auto banman = std::make_unique<BanMan>(m_args.GetDataDirBase() / "banlist", nullptr, DEFAULT_MISBEHAVING_BANTIME);
+    auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
+    auto peerLogic = MakePeerManager(*connman, m_node, banman.get(), /*ignore_incoming_txs=*/false);
+
+    banman->ClearBanned();
+    CAddress addr{ip(0xa0b0c001), NODE_NONE};
+    // Owned by connman; ClearTestNodes() deletes it.
+    CNode* dummyNode{new CNode{/*id=*/0,
+                               /*sock=*/nullptr,
+                               addr,
+                               /*nKeyedNetGroupIn=*/0,
+                               /*nLocalHostNonceIn=*/0,
+                               CAddress(),
+                               /*addrNameIn=*/"",
+                               ConnectionType::INBOUND,
+                               /*inbound_onion=*/false}};
+    const NodeId node_id{dummyNode->GetId()};
+    dummyNode->SetCommonVersion(PROTOCOL_VERSION);
+    peerLogic->InitializeNode(*dummyNode, NODE_NETWORK);
+    dummyNode->fSuccessfullyConnected = true;
+    connman->AddTestNode(*dummyNode);
+
+    // The predicates NetSigning::WorkThreadSigning hands to CSigningManager::RemoveNodesIf. The
+    // "banned" one is what this test is a regression against; both run against the real PeerManager.
+    const auto drops_when_banned = [&] {
+        return WITH_LOCK(::cs_main, return peerLogic->PeerIsBanned(node_id));
+    };
+    const auto drops_when_gone = [&] { return !peerLogic->PeerIsConnected(node_id); };
+
+    // A connected, well-behaved peer's backlog must be left alone by both.
+    BOOST_CHECK(!drops_when_banned());
+    BOOST_CHECK(!drops_when_gone());
+
+    // Misbehave to the discouragement threshold. m_should_discourage is now set, so a sweep landing
+    // in this narrow window would see the peer as banned -- but the peer is still connected.
+    peerLogic->UnitTestMisbehaving(node_id, DISCOURAGEMENT_THRESHOLD);
+    BOOST_CHECK(drops_when_banned());
+    BOOST_CHECK(!drops_when_gone());
+
+    // One SendMessages pass (~100ms in production, long before the 5s sweep tick) consumes the
+    // one-shot flag and marks the peer for disconnection. This is the bug: the banned-keyed
+    // predicate has already gone false again while the peer's pending sigs are still queued.
+    BOOST_CHECK(peerLogic->SendMessages(dummyNode));
+    BOOST_CHECK(dummyNode->fDisconnect);
+    BOOST_CHECK(!drops_when_banned());
+
+    // Once the peer is finalized the Peer is gone for good, so the connection-keyed predicate is
+    // true on this and every later tick, whenever the sweep happens to run.
+    peerLogic->FinalizeNode(*dummyNode);
+    BOOST_CHECK(!drops_when_banned()); // still false -- the flag is now unobservable
+    BOOST_CHECK(drops_when_gone());
+    BOOST_CHECK(drops_when_gone()); // terminal: node ids are never reused
+
+    connman->ClearTestNodes();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -158,4 +158,23 @@ BOOST_AUTO_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection)
     connman->ClearTestNodes();
 }
 
+BOOST_AUTO_TEST_CASE(peer_is_connected_tracks_finalize_node)
+{
+    auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
+    auto peerman = MakePeerManager(*connman, m_node, /*banman=*/nullptr, /*ignore_incoming_txs=*/false);
+    NodeId id{0};
+    std::vector<CNode*> nodes;
+
+    AddPeer(id, nodes, *peerman, *connman, ConnectionType::INBOUND);
+    CNode& node = *nodes.back();
+
+    BOOST_CHECK(peerman->PeerIsConnected(node.GetId()));
+    BOOST_CHECK(!peerman->PeerIsConnected(node.GetId() + 1));
+
+    peerman->FinalizeNode(node);
+    BOOST_CHECK(!peerman->PeerIsConnected(node.GetId()));
+
+    connman->ClearTestNodes();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/net_peer_connection_tests.cpp
+++ b/src/test/net_peer_connection_tests.cpp
@@ -158,23 +158,4 @@ BOOST_AUTO_TEST_CASE(test_addnode_getaddednodeinfo_and_connection_detection)
     connman->ClearTestNodes();
 }
 
-BOOST_AUTO_TEST_CASE(peer_is_connected_tracks_finalize_node)
-{
-    auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
-    auto peerman = MakePeerManager(*connman, m_node, /*banman=*/nullptr, /*ignore_incoming_txs=*/false);
-    NodeId id{0};
-    std::vector<CNode*> nodes;
-
-    AddPeer(id, nodes, *peerman, *connman, ConnectionType::INBOUND);
-    CNode& node = *nodes.back();
-
-    BOOST_CHECK(peerman->PeerIsConnected(node.GetId()));
-    BOOST_CHECK(!peerman->PeerIsConnected(node.GetId() + 1));
-
-    peerman->FinalizeNode(node);
-    BOOST_CHECK(!peerman->PeerIsConnected(node.GetId()));
-
-    connman->ClearTestNodes();
-}
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Issue being fixed or feature implemented

The recovered-signature cleanup added in #7402 checks `PeerIsBanned(node_id)` every five seconds. That query reads the peer's one-shot `m_should_discourage` flag, which is cleared during the next `SendMessages` pass before disconnection completes. A cleanup tick therefore usually misses the short-lived state, and once `FinalizeNode()` removes the peer, `PeerIsBanned()` returns false. Pending recovered signatures from the peer can consequently remain queued instead of being reclaimed after disconnection.

# What was done?

- Added `PeerManagerInternal::PeerIsConnected()` using the peer map as the authoritative connection-lifecycle state.
- Changed the periodic pending recovered-signature sweep to remove entries whose originating peer is no longer connected.
- Kept the rationale concise: the banned flag is transient, while finalized node IDs are not reused.
- Extended the existing peer-discouragement test to cover the transient banned state and connection lifecycle through `FinalizeNode()`.

The existing `RemoveBannedNodeStates()` path for signature shares is intentionally unchanged because it runs in the fast message-processing loop while the discourage flag is observable.

# How Has This Been Tested?

- `make -C src test/test_dash`
- `./src/test/test_dash --run_test=denialofservice_tests/peer_discouragement`
- `./src/test/test_dash --run_test=denialofservice_tests`
- `./src/test/test_dash --run_test=net_peer_connection_tests`
- `test/lint/lint-whitespace.py`
- `git diff --check`
- `clang-format-diff.py` on the PR diff

The two original standalone tests were removed after verifying that both still passed when the production cleanup predicate was reverted. The retained lifecycle assertions fail when `PeerIsConnected()` is replaced with the old transient banned-state behavior.

# Breaking Changes

None.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
