### PR TITLE
fix: drop and score P2P objects the peer was never asked for

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -135,6 +135,7 @@ BITCOIN_TESTS =\
   test/key_tests.cpp \
   test/lcg.h \
   test/limitedmap_tests.cpp \
+  test/llmq_blockprocessor_tests.cpp \
   test/llmq_dkg_tests.cpp \
   test/llmq_chainlock_tests.cpp \
   test/llmq_commitment_tests.cpp \

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -63,7 +63,8 @@ CQuorumBlockProcessor::~CQuorumBlockProcessor()
 }
 
 MessageProcessingResult CQuorumBlockProcessor::ProcessMessage(const CNode& peer, std::string_view msg_type,
-                                                              CDataStream& vRecv)
+                                                              CDataStream& vRecv,
+                                                              const ConsumeRequestFn& consume_request)
 {
     if (msg_type != NetMsgType::QFCOMMITMENT) {
         return {};
@@ -72,8 +73,20 @@ MessageProcessingResult CQuorumBlockProcessor::ProcessMessage(const CNode& peer,
     CFinalCommitment qc;
     vRecv >> qc;
 
+    // A QFCOMMITMENT is only ever sent in reply to a GETDATA (see ProcessGetData), so one we have no
+    // in-flight request for was never asked for. Drop it up front: most of the checks below reject
+    // without scoring the peer -- deliberately, since we may just be lagging behind -- so an
+    // unsolicited peer could otherwise repeat the block lookups and map probes indefinitely. A bare
+    // announcement deliberately does not qualify: it would let the peer authorise its own payload by
+    // sending INV first.
+    if (!consume_request(CInv{MSG_QUORUM_FINAL_COMMITMENT, ::SerializeHash(qc)})) {
+        LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- unrequested commitment from peer=%d\n", __func__,
+                 peer.GetId());
+        return MisbehavingError{UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE, "unrequested quorum commitment"};
+    }
+
+    // Note: no m_to_erase, the request was already consumed by the solicitation check above.
     MessageProcessingResult ret;
-    ret.m_to_erase = CInv{MSG_QUORUM_FINAL_COMMITMENT, ::SerializeHash(qc)};
 
     if (qc.IsNull()) {
         LogPrint(BCLog::LLMQ, "CQuorumBlockProcessor::%s -- null commitment from peer=%d\n", __func__, peer.GetId());

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -73,8 +73,8 @@ MessageProcessingResult CQuorumBlockProcessor::ProcessMessage(const CNode& peer,
     CFinalCommitment qc;
     vRecv >> qc;
 
-    // A QFCOMMITMENT is only ever sent in reply to a GETDATA (see ProcessGetData), so one we have no
-    // in-flight request for was never asked for. Drop it up front: most of the checks below reject
+    // A QFCOMMITMENT is only ever sent in reply to a GETDATA (see ProcessGetData), so one we never
+    // asked this peer for was pushed at us. Drop it up front: most of the checks below reject
     // without scoring the peer -- deliberately, since we may just be lagging behind -- so an
     // unsolicited peer could otherwise repeat the block lookups and map probes indefinitely. A bare
     // announcement deliberately does not qualify: it would let the peer authorise its own payload by

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -63,9 +63,12 @@ public:
                                    CQuorumSnapshotManager& qsnapman, int8_t bls_threads);
     ~CQuorumBlockProcessor();
 
-    //! Predicate answering "did we ask this peer for the inv?", consuming the pending request as a
-    //! side effect. Passed in rather than reached through PeerManagerInternal because net_processing
-    //! already depends on this header; see ProcessMessage for how it is used.
+    //! Predicate answering "do we have any record of asking this peer for the inv?", consuming that
+    //! record as a side effect. An answer that is merely late or was superseded still returns true;
+    //! false means we have nothing to show we asked, which is either because we did not or because
+    //! the answer came too long after we did (see GetDataResponse). Passed in rather than reached
+    //! through PeerManagerInternal because net_processing already depends on this header; see
+    //! ProcessMessage for how it is used.
     //!
     //! Must be invoked without ::cs_main held -- the implementation takes it. Thread-safety
     //! analysis cannot check this through the type-erased std::function, so keep any call site

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -18,6 +18,7 @@
 
 #include <gsl/pointers.h>
 
+#include <functional>
 #include <optional>
 
 class BlockValidationState;
@@ -62,7 +63,18 @@ public:
                                    CQuorumSnapshotManager& qsnapman, int8_t bls_threads);
     ~CQuorumBlockProcessor();
 
-    [[nodiscard]] MessageProcessingResult ProcessMessage(const CNode& peer, std::string_view msg_type, CDataStream& vRecv)
+    //! Predicate answering "did we ask this peer for the inv?", consuming the pending request as a
+    //! side effect. Passed in rather than reached through PeerManagerInternal because net_processing
+    //! already depends on this header; see ProcessMessage for how it is used.
+    //!
+    //! Must be invoked without ::cs_main held -- the implementation takes it. Thread-safety
+    //! analysis cannot check this through the type-erased std::function, so keep any call site
+    //! outside ProcessMessage's own LOCK(::cs_main) block.
+    using ConsumeRequestFn = std::function<bool(const CInv&)>;
+
+    [[nodiscard]] MessageProcessingResult ProcessMessage(const CNode& peer, std::string_view msg_type,
+                                                         CDataStream& vRecv,
+                                                         const ConsumeRequestFn& consume_request)
         EXCLUSIVE_LOCKS_REQUIRED(!minableCommitmentsCs);
 
     bool ProcessBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, BlockValidationState& state,

--- a/src/llmq/net_dkg.cpp
+++ b/src/llmq/net_dkg.cpp
@@ -482,6 +482,19 @@ void NetDKG::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStre
     const uint256 hash = hw.GetHash();
 
     const NodeId from = pfrom.GetId();
+
+    // DKG messages are only ever sent in reply to a GETDATA (see NetDKG::ProcessGetData), so one we
+    // have no in-flight request for was never asked for and must not reach the pending queues, where
+    // it would be retained until a worker gets around to verifying its signature. A bare
+    // announcement deliberately does not qualify: it would let the peer authorise its own payload by
+    // sending INV first.
+    const CInv inv{static_cast<uint32_t>(inv_type), hash};
+    if (!WITH_LOCK(::cs_main, return m_peer_manager->PeerConsumeGetDataResponse(from, inv))) {
+        LogPrint(BCLog::LLMQ_DKG, "NetDKG -- received unrequested %s %s, peer=%d\n", msg_type, hash.ToString(), from);
+        m_peer_manager->PeerMisbehaving(from, UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE, "unrequested DKG message");
+        return;
+    }
+
     const bool dispatched = m_qdkgsman.DoForHandler({llmqType, quorumIndex}, [&](CDKGSessionHandler& handler) {
         CDKGPendingMessages* pending = nullptr;
         switch (inv_type) {
@@ -499,7 +512,6 @@ void NetDKG::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStre
             break;
         }
         Assume(pending != nullptr);
-        WITH_LOCK(::cs_main, m_peer_manager->PeerEraseObjectRequest(from, CInv{static_cast<uint32_t>(inv_type), hash}));
         pending->PushPendingMessage(from, std::move(pm), hash);
     });
     if (!dispatched) {

--- a/src/llmq/net_dkg.cpp
+++ b/src/llmq/net_dkg.cpp
@@ -18,6 +18,7 @@
 #include <llmq/quorumsman.h>
 #include <llmq/utils.h>
 #include <masternode/meta.h>
+#include <msg_result.h>
 #include <net.h>
 #include <netmessagemaker.h>
 #include <protocol.h>
@@ -484,12 +485,17 @@ void NetDKG::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStre
     const NodeId from = pfrom.GetId();
 
     // DKG messages are only ever sent in reply to a GETDATA (see NetDKG::ProcessGetData), so one we
-    // have no in-flight request for was never asked for and must not reach the pending queues, where
-    // it would be retained until a worker gets around to verifying its signature. A bare
-    // announcement deliberately does not qualify: it would let the peer authorise its own payload by
-    // sending INV first.
+    // never asked this peer for was pushed at us and must not reach the pending queues, where it
+    // would be retained until a worker gets around to verifying its signature. A bare announcement
+    // deliberately does not qualify: it would let the peer authorise its own payload by sending INV
+    // first.
+    //
+    // This check runs last so that every pre-existing rejection above -- and the heavier penalty it
+    // carries -- is unchanged. It therefore bounds retention and signature verification, not the
+    // parsing and structural validation above, which an unsolicited sender still gets to trigger.
     const CInv inv{static_cast<uint32_t>(inv_type), hash};
-    if (!WITH_LOCK(::cs_main, return m_peer_manager->PeerConsumeGetDataResponse(from, inv))) {
+    if (WITH_LOCK(::cs_main, return m_peer_manager->PeerConsumeGetDataResponse(from, inv)) ==
+        GetDataResponse::UNREQUESTED) {
         LogPrint(BCLog::LLMQ_DKG, "NetDKG -- received unrequested %s %s, peer=%d\n", msg_type, hash.ToString(), from);
         m_peer_manager->PeerMisbehaving(from, UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE, "unrequested DKG message");
         return;

--- a/src/msg_result.h
+++ b/src/msg_result.h
@@ -15,8 +15,9 @@
 #include <vector>
 
 /** Misbehaviour score for an object message the peer was never asked for. Moderate rather than
- *  fatal: a request expires after GetObjectInterval() (5s for MSG_CLSIG), so a peer answering our
- *  GETDATA very late looks the same as one that was never asked. */
+ *  fatal: it takes a run of these to discourage a peer, which leaves room for the honest cases the
+ *  in-flight check cannot see on its own (see GetDataResponse) to be misjudged without cutting off
+ *  a useful peer. */
 static constexpr int UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE{10};
 
 struct MisbehavingError

--- a/src/msg_result.h
+++ b/src/msg_result.h
@@ -14,6 +14,11 @@
 #include <variant>
 #include <vector>
 
+/** Misbehaviour score for an object message the peer was never asked for. Moderate rather than
+ *  fatal: a request expires after GetObjectInterval() (5s for MSG_CLSIG), so a peer answering our
+ *  GETDATA very late looks the same as one that was never asked. */
+static constexpr int UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE{10};
+
 struct MisbehavingError
 {
     int score;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -26,6 +26,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <random.h>
+#include <saltedhasher.h>
 #include <scheduler.h>
 #include <streams.h>
 #include <sync.h>
@@ -34,6 +35,7 @@
 #include <txmempool.h>
 #include <txorphanage.h>
 #include <txrequest.h>
+#include <unordered_lru_cache.h>
 #include <util/check.h>
 #include <util/std23.h>
 #include <util/strencodings.h>
@@ -92,6 +94,23 @@ static constexpr auto NONPREF_PEER_TX_DELAY{2s};
 /** How long to delay requesting objects from overloaded peers (see
  *  MAX_PEER_OBJECT_REQUEST_IN_FLIGHT). */
 static constexpr auto OVERLOADED_PEER_OBJECT_DELAY{2s};
+/** How many request intervals after sending a GETDATA an answer still counts as merely late rather
+ *  than unsolicited (see CNodeState::m_recent_object_requests).
+ *
+ *  Expressed in GetObjectInterval() rather than as a wall-clock constant, because that interval is
+ *  already this node's statement of how long it is willing to wait before asking someone else: one
+ *  interval to answer, one more before the answer stops counting as an answer. A peer lagging beyond
+ *  that is not slow, it is failing to serve what it advertised, and the object has long since been
+ *  fetched elsewhere. Keeping the two in the same currency also means they stay in step if the
+ *  per-type intervals are ever changed. */
+static constexpr int RECENT_OBJECT_REQUEST_TTL_INTERVALS{2};
+/** Memory ceiling for the per-peer record of GETDATA-only requests (see
+ *  CNodeState::m_recent_object_requests). RECENT_OBJECT_REQUEST_TTL governs how long an entry is
+ *  meant to live; this only stops the record growing without bound when a peer is asked for more
+ *  objects than this within that window. Evicting early costs the late-answer grace for the oldest
+ *  requests -- degrading them to the behaviour of the gate without this record -- never correctness,
+ *  so it does not have to be proved large enough for any particular burst. */
+static constexpr size_t MAX_RECENT_OBJECT_REQUESTS{256};
 /** How long to wait before downloading a transaction from an additional peer */
 static constexpr auto GETDATA_TX_INTERVAL{60s};
 /** Limit to avoid sending big packets. Not used in processing incoming GETDATA for compatibility */
@@ -433,6 +452,18 @@ private:
 
 using PeerRef = std::shared_ptr<Peer>;
 
+/** A GETDATA we sent for a GETDATA-only object: which type we asked for, and when.
+ *
+ * The type has to be remembered rather than taken from the answer, because the type in an INV is
+ * whatever the peer said it was and is not bound to the payload until that payload arrives. A peer
+ * can announce the hash of a DKG message as MSG_CLSIG, collect our GETDATA, and then send the DKG
+ * message: the hashes match, so a record keyed on the hash alone would authorise it and would take
+ * its grace from the answer's type rather than the request's. */
+struct RequestedObject {
+    uint32_t m_inv_type{0};
+    std::chrono::microseconds m_time{0};
+};
+
 /**
  * Maintain validation-specific state about nodes, protected by cs_main, instead
  * by CNode's own locks. This simplifies asynchronous operation, where
@@ -516,6 +547,17 @@ struct CNodeState {
     //! A rolling bloom filter of all announced tx CInvs to this peer.
     CRollingBloomFilter m_recently_announced_invs = CRollingBloomFilter{INVENTORY_MAX_RECENT_RELAY, 0.000001};
 
+    //! The GETDATA-only objects (see IsGetDataOnlyObject) we have recently asked this peer for. The
+    //! tracker cannot answer "did we ever ask?" on its own: an announcement is erased once it
+    //! expires as the sole one for its hash, or once the object is accepted from anywhere.
+    //!
+    //! Only we ever add to this, so a peer cannot use it to authorise its own payload. An entry is
+    //! erased by the answer it authorises and ages out after RECENT_OBJECT_REQUEST_TTL_INTERVALS, so
+    //! one GETDATA buys exactly one accepted object, within a bounded window: a peer can neither
+    //! replay the payload it induced a request for, nor bank an unanswered request to spend later.
+    unordered_lru_cache<uint256, RequestedObject, StaticSaltedHasher, MAX_RECENT_OBJECT_REQUESTS>
+        m_recent_object_requests;
+
     CNodeState(bool is_inbound) : m_is_inbound(is_inbound) {}
 };
 
@@ -593,7 +635,7 @@ public:
     bool PeerIsBanned(const NodeId node_id) override EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_peer_mutex);
     void PeerEraseObjectRequest(const NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool PeerConsumeObjectRequest(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    GetDataResponse PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void PeerForgetObjectRequest(const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void PeerPushInventory(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void PeerRelayInv(const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
@@ -1530,6 +1572,30 @@ std::chrono::microseconds GetObjectInterval(int invType)
             return 10s;
         default:
             return GETDATA_TX_INTERVAL;
+    }
+}
+
+bool IsGetDataOnlyObject(int invType)
+{
+    // These object types only ever travel inv -> getdata -> object: the only places that send them
+    // are the GETDATA handlers (PeerManagerImpl::ProcessGetData and NetDKG::ProcessGetData), and no
+    // local producer pushes them. Receiving one we never asked for is therefore always unsolicited,
+    // which lets the handlers drop it before doing any work on the sender's behalf.
+    //
+    // Not every inv-driven type belongs here. QSIGREC (proactive relay to peers that sent
+    // QSENDRECSIGS), MSG_DSQ (SENDDSQUEUE), ISDLOCK (pushed alongside MERKLEBLOCK for BIP37 clients),
+    // SPORK (bulk push in reply to GETSPORKS) and PLATFORMBAN (injected by a Dash Platform node)
+    // all have a legitimate unsolicited-push path.
+    switch (invType) {
+        case MSG_CLSIG:
+        case MSG_QUORUM_FINAL_COMMITMENT:
+        case MSG_QUORUM_CONTRIB:
+        case MSG_QUORUM_COMPLAINT:
+        case MSG_QUORUM_JUSTIFICATION:
+        case MSG_QUORUM_PREMATURE_COMMITMENT:
+            return true;
+        default:
+            return false;
     }
 }
 
@@ -5546,7 +5612,8 @@ void PeerManagerImpl::ProcessMessage(
                                pfrom, msg_type, vRecv,
                                [this, &pfrom](const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(!::cs_main) {
                                    return WITH_LOCK(::cs_main,
-                                                    return PeerConsumeGetDataResponse(pfrom.GetId(), inv));
+                                                    return PeerConsumeGetDataResponse(pfrom.GetId(), inv)) !=
+                                          GetDataResponse::UNREQUESTED;
                                }),
                            pfrom.GetId());
         PostProcessMessage(ProcessPlatformBanMessage(pfrom.GetId(), msg_type, vRecv), pfrom.GetId());
@@ -5557,14 +5624,15 @@ void PeerManagerImpl::ProcessMessage(
                 vRecv >> clsig;
                 const CInv clsig_inv{MSG_CLSIG, ::SerializeHash(clsig)};
                 // A CLSIG is only ever sent in reply to a GETDATA (see ProcessGetData), so one we
-                // have no in-flight request for was never asked for. Drop it before
-                // ProcessNewChainLock, which exits without any penalty for a CLSIG at or below our
-                // best ChainLock -- and since every distinct signature blob hashes differently, an
-                // unsolicited peer could otherwise repeat that free work indefinitely. A bare
-                // announcement deliberately does not qualify: it would let the peer authorise its
-                // own payload by sending INV first. Consume after the spork gate so a CLSIG dropped
-                // while ChainLocks are disabled does not burn a later retransmit.
-                if (!WITH_LOCK(::cs_main, return PeerConsumeGetDataResponse(pfrom.GetId(), clsig_inv))) {
+                // never asked this peer for was pushed at us. Drop it before ProcessNewChainLock,
+                // which exits without any penalty for a CLSIG at or below our best ChainLock -- and
+                // since every distinct signature blob hashes differently, an unsolicited peer could
+                // otherwise repeat that free work indefinitely. A bare announcement deliberately
+                // does not qualify: it would let the peer authorise its own payload by sending INV
+                // first. Authorise after the spork gate so a CLSIG dropped while ChainLocks are
+                // disabled does not burn a later retransmit.
+                if (WITH_LOCK(::cs_main, return PeerConsumeGetDataResponse(pfrom.GetId(), clsig_inv)) ==
+                    GetDataResponse::UNREQUESTED) {
                     LogPrint(BCLog::CHAINLOCKS, "CLSIG -- received unrequested CLSIG %s, peer=%d\n",
                              clsig_inv.hash.ToString(), pfrom.GetId());
                     Misbehaving(*peer, UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE, "unrequested clsig");
@@ -6604,6 +6672,13 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
                     vGetData.clear();
                 }
                 m_object_request.RequestedTx(pto->GetId(), inv, current_time + GetObjectInterval(inv.type));
+                if (IsGetDataOnlyObject(inv.type)) {
+                    // Remember that we asked, so that an answer arriving after the tracker entry is
+                    // gone -- expired, or erased because the object turned up elsewhere -- is not
+                    // mistaken for an unsolicited push. See GetDataResponse.
+                    state.m_recent_object_requests.insert(inv.hash,
+                                                          RequestedObject{inv.type, current_time});
+                }
             } else {
                 // We have already seen this object, no need to download. This is for belated
                 // announcements of objects which arrived via another peer; the tracker has no
@@ -6645,9 +6720,35 @@ bool PeerManagerImpl::PeerConsumeObjectRequest(NodeId nodeid, const CInv& inv)
     return m_object_request.ReceivedResponse(nodeid, inv);
 }
 
-bool PeerManagerImpl::PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv)
+GetDataResponse PeerManagerImpl::PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv)
 {
-    return m_object_request.ReceivedRequestedResponse(nodeid, inv);
+    CNodeState* state = State(nodeid);
+    if (m_object_request.ReceivedRequestedResponse(nodeid, inv)) {
+        // Answered on time. Spend the late-answer grace too, so the GETDATA cannot also pay for a
+        // replay of the same payload.
+        if (state != nullptr) state->m_recent_object_requests.erase(inv.hash);
+        return GetDataResponse::REQUESTED;
+    }
+    // No in-flight request. Before treating this as an unsolicited push, check whether we asked this
+    // peer for it at all: the tracker entry is gone once the request expires as the sole one for its
+    // hash, or once the object is accepted from any source. Neither means the peer misbehaved.
+    if (state != nullptr) {
+        RequestedObject requested;
+        if (state->m_recent_object_requests.get(inv.hash, requested)) {
+            // Grace is one answer per GETDATA: erase it whatever the outcome, so further copies are
+            // unsolicited again and a peer cannot replay the payload it induced a request for.
+            state->m_recent_object_requests.erase(inv.hash);
+            // Both the type and the window come from what we asked for, never from the answer: the
+            // peer chose the type it announced, so letting the answer name it would let a request
+            // for one object type authorise another, with that other type's grace.
+            if (requested.m_inv_type == inv.type &&
+                GetTime<std::chrono::microseconds>() - requested.m_time <=
+                    GetObjectInterval(requested.m_inv_type) * RECENT_OBJECT_REQUEST_TTL_INTERVALS) {
+                return GetDataResponse::LATE;
+            }
+        }
+    }
+    return GetDataResponse::UNREQUESTED;
 }
 
 void PeerManagerImpl::PeerForgetObjectRequest(const CInv& inv)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5542,7 +5542,13 @@ void PeerManagerImpl::ProcessMessage(
             PostProcessMessage(m_cj_walletman->processMessage(pfrom, m_chainman.ActiveChainstate(), m_connman, m_mempool, msg_type, vRecv), pfrom.GetId());
         }
         PostProcessMessage(CMNAuth::ProcessMessage(pfrom, peer->m_their_services, m_connman, m_mn_metaman, m_nodeman, m_mn_sync, m_dmnman->GetListAtChainTip(), msg_type, vRecv), pfrom.GetId());
-        PostProcessMessage(m_llmq_ctx->quorum_block_processor->ProcessMessage(pfrom, msg_type, vRecv), pfrom.GetId());
+        PostProcessMessage(m_llmq_ctx->quorum_block_processor->ProcessMessage(
+                               pfrom, msg_type, vRecv,
+                               [this, &pfrom](const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(!::cs_main) {
+                                   return WITH_LOCK(::cs_main,
+                                                    return PeerConsumeGetDataResponse(pfrom.GetId(), inv));
+                               }),
+                           pfrom.GetId());
         PostProcessMessage(ProcessPlatformBanMessage(pfrom.GetId(), msg_type, vRecv), pfrom.GetId());
 
         if (msg_type == NetMsgType::CLSIG) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -593,6 +593,7 @@ public:
     bool PeerIsBanned(const NodeId node_id) override EXCLUSIVE_LOCKS_REQUIRED(cs_main, !m_peer_mutex);
     void PeerEraseObjectRequest(const NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool PeerConsumeObjectRequest(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    bool PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void PeerForgetObjectRequest(const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     void PeerPushInventory(NodeId nodeid, const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void PeerRelayInv(const CInv& inv) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
@@ -3660,6 +3661,10 @@ MessageProcessingResult PeerManagerImpl::ProcessPlatformBanMessage(NodeId node, 
 
     LogPrintf("PLATFORMBAN -- hash: %s protx_hash: %s height: %d peer=%d\n", hash.ToString(), ban_msg.m_protx_hash.ToString(), ban_msg.m_requested_height, node);
 
+    // NOTE: deliberately no solicitation gate here, unlike the other GETDATA-only object types.
+    // PLATFORMBAN has no local ingress (no RPC, no internal producer): the originating Dash
+    // Platform node injects the ban by pushing the message straight to a Dash Core peer, so the
+    // first hop is always unsolicited by design. See p2p_platform_ban.py.
     MessageProcessingResult ret{};
     ret.m_to_erase = CInv{MSG_PLATFORM_BAN, hash};
 
@@ -5544,9 +5549,24 @@ void PeerManagerImpl::ProcessMessage(
             if (m_chainlocks.IsEnabled()) {
                 chainlock::ChainLockSig clsig;
                 vRecv >> clsig;
-                const uint256& hash = ::SerializeHash(clsig);
-                WITH_LOCK(::cs_main, m_object_request.ReceivedResponse(pfrom.GetId(), CInv{MSG_CLSIG, hash}));
-                PostProcessMessage(m_clhandler.ProcessNewChainLock(pfrom.GetId(), clsig, *m_llmq_ctx->qman, hash), pfrom.GetId());
+                const CInv clsig_inv{MSG_CLSIG, ::SerializeHash(clsig)};
+                // A CLSIG is only ever sent in reply to a GETDATA (see ProcessGetData), so one we
+                // have no in-flight request for was never asked for. Drop it before
+                // ProcessNewChainLock, which exits without any penalty for a CLSIG at or below our
+                // best ChainLock -- and since every distinct signature blob hashes differently, an
+                // unsolicited peer could otherwise repeat that free work indefinitely. A bare
+                // announcement deliberately does not qualify: it would let the peer authorise its
+                // own payload by sending INV first. Consume after the spork gate so a CLSIG dropped
+                // while ChainLocks are disabled does not burn a later retransmit.
+                if (!WITH_LOCK(::cs_main, return PeerConsumeGetDataResponse(pfrom.GetId(), clsig_inv))) {
+                    LogPrint(BCLog::CHAINLOCKS, "CLSIG -- received unrequested CLSIG %s, peer=%d\n",
+                             clsig_inv.hash.ToString(), pfrom.GetId());
+                    Misbehaving(*peer, UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE, "unrequested clsig");
+                    return;
+                }
+                PostProcessMessage(m_clhandler.ProcessNewChainLock(pfrom.GetId(), clsig, *m_llmq_ctx->qman,
+                                                                   clsig_inv.hash),
+                                   pfrom.GetId());
             }
             return; // CLSIG
         }
@@ -6617,6 +6637,11 @@ void PeerManagerImpl::PeerEraseObjectRequest(const NodeId nodeid, const CInv& in
 bool PeerManagerImpl::PeerConsumeObjectRequest(NodeId nodeid, const CInv& inv)
 {
     return m_object_request.ReceivedResponse(nodeid, inv);
+}
+
+bool PeerManagerImpl::PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv)
+{
+    return m_object_request.ReceivedRequestedResponse(nodeid, inv);
 }
 
 void PeerManagerImpl::PeerForgetObjectRequest(const CInv& inv)

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -74,6 +74,12 @@ public:
      *  announcement, so a second call without a re-announcement in between returns false.
      *  Requires ::cs_main (see the PeerManagerImpl override). */
     virtual bool PeerConsumeObjectRequest(NodeId nodeid, const CInv& inv) = 0;
+    /** Consume this peer's in-flight GETDATA for the inv and return whether one existed. Stricter
+     *  than PeerConsumeObjectRequest: a bare announcement does not qualify, only a request we
+     *  actually sent. Use for object types that are only ever sent in reply to a GETDATA, so a peer
+     *  cannot authorise its own payload by announcing it first.
+     *  Requires ::cs_main (see the PeerManagerImpl override). */
+    virtual bool PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv) = 0;
     /** Delete all peers' announcements of the inv. Call once the object is accepted (AlreadyHave
      *  turns true), so it is not requested from anyone anymore.
      *  Requires ::cs_main (see the PeerManagerImpl override). */

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -45,6 +45,24 @@ static const int DISCOURAGEMENT_THRESHOLD{100};
 /** Maximum number of outstanding CMPCTBLOCK requests for the same block. */
 static const unsigned int MAX_CMPCTBLOCKS_INFLIGHT_PER_BLOCK = 3;
 
+/** Outcome of authorising an incoming object against what we asked a peer for.
+ *
+ * Used by object types that only ever travel inv -> getdata -> object, to tell an unsolicited push
+ * apart from an honest answer to a GETDATA of ours that no longer has a tracker entry. The latter
+ * is routine: a request expires after GetObjectInterval() and is re-pointed at another peer, and
+ * accepting the object from any source erases every announcement for it (see ForgetTxHash). */
+enum class GetDataResponse {
+    //! We had an in-flight GETDATA for this object; it has now been consumed.
+    REQUESTED,
+    //! No in-flight request, but we did send this peer a GETDATA for this object recently, so the
+    //! answer is merely late or was superseded. Process it, but do not treat it as unsolicited.
+    LATE,
+    //! We have no record of asking this peer for this object. Usually that is because we never did,
+    //! which is what makes it worth scoring -- but a record we did keep is also gone once it ages
+    //! out or is evicted, so an answer late enough is treated the same as one never asked for.
+    UNREQUESTED,
+};
+
 struct CNodeStateStats {
     int m_misbehavior_score = 0;
     int nSyncHeight = -1;
@@ -74,12 +92,14 @@ public:
      *  announcement, so a second call without a re-announcement in between returns false.
      *  Requires ::cs_main (see the PeerManagerImpl override). */
     virtual bool PeerConsumeObjectRequest(NodeId nodeid, const CInv& inv) = 0;
-    /** Consume this peer's in-flight GETDATA for the inv and return whether one existed. Stricter
-     *  than PeerConsumeObjectRequest: a bare announcement does not qualify, only a request we
-     *  actually sent. Use for object types that are only ever sent in reply to a GETDATA, so a peer
-     *  cannot authorise its own payload by announcing it first.
+    /** Consume this peer's in-flight GETDATA for the inv and report how the object was authorised.
+     *  Stricter than PeerConsumeObjectRequest: a bare announcement does not qualify, only a request
+     *  we actually sent. Use for object types that are only ever sent in reply to a GETDATA, so a
+     *  peer cannot authorise its own payload by announcing it first. Only UNREQUESTED leaves us with
+     *  nothing to show we asked; see GetDataResponse for why LATE is a normal outcome for an honest
+     *  peer, and for what else can produce UNREQUESTED besides never having asked.
      *  Requires ::cs_main (see the PeerManagerImpl override). */
-    virtual bool PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv) = 0;
+    virtual GetDataResponse PeerConsumeGetDataResponse(NodeId nodeid, const CInv& inv) = 0;
     /** Delete all peers' announcements of the inv. Call once the object is accepted (AlreadyHave
      *  turns true), so it is not requested from anyone anymore.
      *  Requires ::cs_main (see the PeerManagerImpl override). */

--- a/src/test/fuzz/txrequest.cpp
+++ b/src/test/fuzz/txrequest.cpp
@@ -247,6 +247,22 @@ public:
         assert(completed == expected_completed);
     }
 
+    void ReceivedRequestedResponse(int peer, int inv)
+    {
+        // Apply to naive structure: unlike ReceivedResponse, only a REQUESTED announcement is
+        // completed. Anything else -- including a CANDIDATE, which exists from the moment an inv is
+        // processed -- is left exactly as it was.
+        const bool expected_completed = m_announcements[inv][peer].m_state == State::REQUESTED;
+        if (expected_completed) {
+            m_announcements[inv][peer].m_state = State::COMPLETED;
+            Cleanup(inv);
+        }
+
+        // Call TxRequestTracker's implementation, and compare its return value with the naive expectation.
+        const bool completed = m_tracker.ReceivedRequestedResponse(peer, INVS[inv]);
+        assert(completed == expected_completed);
+    }
+
     void GetRequestable(int peer)
     {
         // Implement using naive structure:
@@ -324,7 +340,7 @@ FUZZ_TARGET(txrequest)
     // Decode the input as a sequence of instructions with parameters
     auto it = buffer.begin();
     while (it != buffer.end()) {
-        int cmd = *(it++) % 11;
+        int cmd = *(it++) % 12;
         int peer, invnum, delaynum;
         switch (cmd) {
         case 0: // Make time jump to the next event (m_time of CANDIDATE or REQUESTED)
@@ -371,6 +387,11 @@ FUZZ_TARGET(txrequest)
             peer = it == buffer.end() ? 0 : *(it++) % MAX_PEERS;
             invnum = it == buffer.end() ? 0 : *(it++);
             tester.ReceivedResponse(peer, invnum % MAX_INVS);
+            break;
+        case 11: // Received response to a GETDATA we actually sent
+            peer = it == buffer.end() ? 0 : *(it++) % MAX_PEERS;
+            invnum = it == buffer.end() ? 0 : *(it++);
+            tester.ReceivedRequestedResponse(peer, invnum % MAX_INVS);
             break;
         default:
             assert(false);

--- a/src/test/llmq_blockprocessor_tests.cpp
+++ b/src/test/llmq_blockprocessor_tests.cpp
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/llmq_tests.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+
+#include <chainparams.h>
+#include <consensus/params.h>
+#include <hash.h>
+#include <masternode/meta.h>
+#include <net.h>
+#include <net_processing.h>
+#include <streams.h>
+#include <util/time.h>
+#include <validation.h>
+#include <version.h>
+
+#include <llmq/blockprocessor.h>
+#include <llmq/commitment.h>
+#include <llmq/context.h>
+#include <msg_result.h>
+#include <protocol.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace llmq;
+using namespace llmq::testutils;
+
+BOOST_AUTO_TEST_SUITE(llmq_blockprocessor_tests)
+
+namespace {
+CDataStream Serialized(const CFinalCommitment& qc)
+{
+    CDataStream payload{SER_NETWORK, PROTOCOL_VERSION};
+    payload << qc;
+    return payload;
+}
+} // namespace
+
+// A QFCOMMITMENT is only ever sent in reply to a GETDATA, so one the peer was never asked for must
+// be dropped before CQuorumBlockProcessor does any lookup work on its behalf. The block processor
+// holds no PeerManagerInternal -- net_processing already includes its header, so a reference would
+// be circular -- and reaches the in-flight check through a predicate injected at the call site.
+// Everything below therefore goes through PeerManagerImpl::ProcessMessage: calling the handler
+// directly would test the gate but not the injection, which is the part that has no compiler to
+// keep it honest.
+BOOST_FIXTURE_TEST_CASE(unrequested_qfcommit_is_dropped_and_scored, TestChain100Setup)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    // INV announcements for non-spork objects are only tracked outside IBD; the 100 mined blocks
+    // of this fixture already take us out of it.
+    BOOST_REQUIRE(!m_node.chainman->ActiveChainstate().IsInitialBlockDownload());
+
+    // Every Dash-specific message is offered to CMNAuth first, which asserts a loaded metadata
+    // manager. The fixture leaves it unloaded, so initialise an empty cache here.
+    BOOST_REQUIRE(m_node.mn_metaman->LoadCache(/*load_cache=*/false));
+
+    auto& blockprocessor = *m_node.llmq_ctx->quorum_block_processor;
+    const auto& llmq_params = GetLLMQParams(Consensus::LLMQType::LLMQ_TEST_V17);
+    BOOST_REQUIRE(Params().GetLLMQ(llmq_params.type).has_value());
+
+    auto unsolicited_peer{MakeTestPeer(/*id=*/51)};
+    auto announcing_peer{MakeTestPeer(/*id=*/52)};
+    m_node.peerman->InitializeNode(*unsolicited_peer, NODE_NETWORK);
+    m_node.peerman->InitializeNode(*announcing_peer, NODE_NETWORK);
+
+    // quorumHash names no block we know of. That is the one rejection below the gate that
+    // deliberately carries no penalty -- we may simply be behind or on another chain -- so any
+    // score this payload collects can only have come from the gate, and the checks that do score
+    // cannot be mistaken for it.
+    const auto unsolicited_qc = CreateValidCommitment(llmq_params, GetTestBlockHash(51));
+    const uint256 unsolicited_hash = ::SerializeHash(unsolicited_qc);
+
+    // Sent twice on purpose: an unsolicited peer must not be able to repeat the block lookups and
+    // mineable-commitment probes for free, so both copies have to cost it.
+    for (int i = 0; i < 2; ++i) {
+        SendMessage(*m_node.peerman, *unsolicited_peer, NetMsgType::QFCOMMITMENT, Serialized(unsolicited_qc));
+    }
+    BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *unsolicited_peer),
+                      2 * UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE);
+    // Nothing below the gate ran: had the commitment been processed it could only have ended up
+    // here or been rejected, and this is the observable half of that.
+    BOOST_CHECK(!blockprocessor.HasMineableCommitment(unsolicited_hash));
+
+    // The gate also runs ahead of the null-commitment check, which scores 100. A null payload from
+    // a peer we never asked must still cost exactly the unsolicited price -- reaching the 100 would
+    // mean the gate had let it through.
+    {
+        const int score_before_null = MisbehaviorScore(*m_node.peerman, *unsolicited_peer);
+        SendMessage(*m_node.peerman, *unsolicited_peer, NetMsgType::QFCOMMITMENT, Serialized(CFinalCommitment{}));
+        BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *unsolicited_peer),
+                          score_before_null + UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE);
+    }
+
+    // Announcing the commitment is NOT enough to authorise it. An INV creates a candidate
+    // immediately, but the GETDATA only goes out later from SendMessages, so accepting on the
+    // announcement alone would let a peer authorise its own payload by racing INV and payload back
+    // to back -- which costs it nothing and defeats the gate entirely.
+    const auto announced_qc = CreateValidCommitment(llmq_params, GetTestBlockHash(52));
+    const CInv announced_inv{MSG_QUORUM_FINAL_COMMITMENT, ::SerializeHash(announced_qc)};
+
+    AnnounceInv(*m_node.peerman, *announcing_peer, announced_inv);
+    {
+        const int score_before_race = MisbehaviorScore(*m_node.peerman, *announcing_peer);
+        SendMessage(*m_node.peerman, *announcing_peer, NetMsgType::QFCOMMITMENT, Serialized(announced_qc));
+        BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *announcing_peer),
+                          score_before_race + UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE);
+    }
+
+    // Once SendMessages has actually issued the GETDATA the same payload is authorised. The
+    // rejection above must not have consumed the candidate, or no GETDATA would go out at all.
+    SetMockTime(GetTime<std::chrono::seconds>() + 61s);
+    m_node.peerman->SendMessages(announcing_peer.get());
+    const int score_before = MisbehaviorScore(*m_node.peerman, *announcing_peer);
+
+    SendMessage(*m_node.peerman, *announcing_peer, NetMsgType::QFCOMMITMENT, Serialized(announced_qc));
+
+    // Unchanged, because the unknown quorum block this commitment names is rejected without any
+    // penalty -- which is what proves the message got past the gate. Asserting the total exactly is
+    // what would catch the gate also charging a peer we did ask.
+    BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *announcing_peer), score_before);
+
+    // One GETDATA authorises exactly one answer. Both the in-flight request and the late-answer
+    // grace are spent, so a replay of the very payload we asked for is unsolicited again -- a peer
+    // must not be able to induce one request and then repeat the payload for free.
+    SendMessage(*m_node.peerman, *announcing_peer, NetMsgType::QFCOMMITMENT, Serialized(announced_qc));
+    BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *announcing_peer),
+                      score_before + UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE);
+
+    m_node.peerman->FinalizeNode(*unsolicited_peer);
+    m_node.peerman->FinalizeNode(*announcing_peer);
+    SetMockTime(0s);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/llmq_chainlock_tests.cpp
+++ b/src/test/llmq_chainlock_tests.cpp
@@ -355,8 +355,8 @@ BOOST_FIXTURE_TEST_CASE(unrequested_clsig_is_dropped_and_scored, TestChain100Set
     // would catch the gate also charging an authorised peer.
     BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *announcing_peer), score_before + 10);
     // The authorisation was consumed, so a replay of the same CLSIG is now unsolicited.
-    BOOST_CHECK(!WITH_LOCK(::cs_main,
-                           return m_node.peerman->PeerConsumeGetDataResponse(announcing_peer->GetId(), announced_inv)));
+    BOOST_CHECK(WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeGetDataResponse(
+                                         announcing_peer->GetId(), announced_inv)) == GetDataResponse::UNREQUESTED);
 
     m_node.peerman->FinalizeNode(*unsolicited_peer);
     m_node.peerman->FinalizeNode(*announcing_peer);

--- a/src/test/llmq_chainlock_tests.cpp
+++ b/src/test/llmq_chainlock_tests.cpp
@@ -354,9 +354,15 @@ BOOST_FIXTURE_TEST_CASE(unrequested_clsig_is_dropped_and_scored, TestChain100Set
     // 10 -- which is what proves the message got past the gate. Asserting the total exactly is what
     // would catch the gate also charging an authorised peer.
     BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *announcing_peer), score_before + 10);
-    // The authorisation was consumed, so a replay of the same CLSIG is now unsolicited.
-    BOOST_CHECK(WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeGetDataResponse(
-                                         announcing_peer->GetId(), announced_inv)) == GetDataResponse::UNREQUESTED);
+    // One GETDATA authorises exactly one answer. Both the in-flight request and the late-answer
+    // grace are spent, so a replay of the very payload we asked for is unsolicited again -- a peer
+    // must not be able to induce one request and then repeat the payload for free.
+    const int score_before_replay = MisbehaviorScore(*m_node.peerman, *announcing_peer);
+    CDataStream replayed_payload{SER_NETWORK, PROTOCOL_VERSION};
+    replayed_payload << announced_clsig;
+    SendMessage(*m_node.peerman, *announcing_peer, NetMsgType::CLSIG, std::move(replayed_payload));
+    BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *announcing_peer),
+                      score_before_replay + UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE);
 
     m_node.peerman->FinalizeNode(*unsolicited_peer);
     m_node.peerman->FinalizeNode(*announcing_peer);

--- a/src/test/llmq_chainlock_tests.cpp
+++ b/src/test/llmq_chainlock_tests.cpp
@@ -3,8 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <test/util/llmq_tests.h>
+#include <test/util/net.h>
 #include <test/util/setup_common.h>
-#include <test/util/validation.h>
 
 #include <hash.h>
 #include <masternode/meta.h>
@@ -247,25 +247,6 @@ namespace {
 //! Regtest spork key matching Params().SporkAddresses(), as used by the functional tests.
 constexpr const char* REGTEST_SPORK_PRIVKEY{"cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"};
 
-std::unique_ptr<CNode> MakeClsigPeer(NodeId id)
-{
-    in_addr peer_in_addr{};
-    peer_in_addr.s_addr = htonl(0x0a000001 + id);
-    auto peer{std::make_unique<CNode>(id,
-                                      /*sock=*/nullptr,
-                                      /*addrIn=*/CAddress{CService{peer_in_addr, 8333}, NODE_NETWORK},
-                                      /*nKeyedNetGroupIn=*/0,
-                                      /*nLocalHostNonceIn=*/0,
-                                      /*addrBindIn=*/CAddress{},
-                                      /*addrNameIn=*/std::string{},
-                                      /*conn_type_in=*/ConnectionType::OUTBOUND_FULL_RELAY,
-                                      /*inbound_onion=*/false)};
-    peer->nVersion = PROTOCOL_VERSION;
-    peer->SetCommonVersion(PROTOCOL_VERSION);
-    peer->fSuccessfullyConnected = true;
-    return peer;
-}
-
 void SendMessage(PeerManager& peerman, CNode& peer, const std::string& msg_type, CDataStream&& payload)
     EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex)
 {
@@ -314,8 +295,8 @@ BOOST_FIXTURE_TEST_CASE(unrequested_clsig_is_dropped_and_scored, TestChain100Set
     BOOST_REQUIRE(m_node.sporkman->UpdateSpork(SPORK_19_CHAINLOCKS_ENABLED, 0).has_value());
     BOOST_REQUIRE(m_node.chainlocks->IsEnabled());
 
-    auto unsolicited_peer{MakeClsigPeer(/*id=*/41)};
-    auto announcing_peer{MakeClsigPeer(/*id=*/42)};
+    auto unsolicited_peer{MakeTestPeer(/*id=*/41)};
+    auto announcing_peer{MakeTestPeer(/*id=*/42)};
     m_node.peerman->InitializeNode(*unsolicited_peer, NODE_NETWORK);
     m_node.peerman->InitializeNode(*announcing_peer, NODE_NETWORK);
 

--- a/src/test/llmq_chainlock_tests.cpp
+++ b/src/test/llmq_chainlock_tests.cpp
@@ -4,9 +4,18 @@
 
 #include <test/util/llmq_tests.h>
 #include <test/util/setup_common.h>
+#include <test/util/validation.h>
 
+#include <hash.h>
+#include <masternode/meta.h>
+#include <net.h>
+#include <net_processing.h>
+#include <netaddress.h>
+#include <spork.h>
 #include <streams.h>
 #include <util/strencodings.h>
+#include <validation.h>
+#include <version.h>
 
 #include <chainlock/chainlock.h>
 #include <chainlock/handler.h>
@@ -15,6 +24,8 @@
 #include <protocol.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <memory>
 
 using chainlock::ChainLockSig;
 using namespace llmq;
@@ -230,6 +241,145 @@ BOOST_FIXTURE_TEST_CASE(best_chainlock_is_already_have_after_seen_cache_eviction
     }
 
     BOOST_CHECK(m_node.clhandler->AlreadyHave(CInv{MSG_CLSIG, best_hash}));
+}
+
+namespace {
+//! Regtest spork key matching Params().SporkAddresses(), as used by the functional tests.
+constexpr const char* REGTEST_SPORK_PRIVKEY{"cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"};
+
+std::unique_ptr<CNode> MakeClsigPeer(NodeId id)
+{
+    in_addr peer_in_addr{};
+    peer_in_addr.s_addr = htonl(0x0a000001 + id);
+    auto peer{std::make_unique<CNode>(id,
+                                      /*sock=*/nullptr,
+                                      /*addrIn=*/CAddress{CService{peer_in_addr, 8333}, NODE_NETWORK},
+                                      /*nKeyedNetGroupIn=*/0,
+                                      /*nLocalHostNonceIn=*/0,
+                                      /*addrBindIn=*/CAddress{},
+                                      /*addrNameIn=*/std::string{},
+                                      /*conn_type_in=*/ConnectionType::OUTBOUND_FULL_RELAY,
+                                      /*inbound_onion=*/false)};
+    peer->nVersion = PROTOCOL_VERSION;
+    peer->SetCommonVersion(PROTOCOL_VERSION);
+    peer->fSuccessfullyConnected = true;
+    return peer;
+}
+
+void SendMessage(PeerManager& peerman, CNode& peer, const std::string& msg_type, CDataStream&& payload)
+    EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex)
+{
+    std::atomic<bool> interrupt_dummy{false};
+    peerman.ProcessMessage(peer, msg_type, payload, GetTime<std::chrono::microseconds>(), interrupt_dummy);
+}
+
+void AnnounceInv(PeerManager& peerman, CNode& peer, const CInv& inv)
+    EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex)
+{
+    CDataStream inv_stream{SER_NETWORK, PROTOCOL_VERSION};
+    inv_stream << std::vector<CInv>{inv};
+    SendMessage(peerman, peer, NetMsgType::INV, std::move(inv_stream));
+}
+
+int MisbehaviorScore(PeerManager& peerman, const CNode& peer)
+{
+    CNodeStateStats stats;
+    BOOST_REQUIRE(peerman.GetNodeStateStats(peer.GetId(), stats));
+    return stats.m_misbehavior_score;
+}
+} // namespace
+
+// A CLSIG is only ever sent in reply to a GETDATA, so one that the peer neither announced nor was
+// asked for must be dropped before ProcessNewChainLock -- which would otherwise remember its hash
+// and do that work again for every distinct signature blob, at no cost to the sender.
+BOOST_FIXTURE_TEST_CASE(unrequested_clsig_is_dropped_and_scored, TestChain100Setup)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    // INV announcements for non-spork objects are only tracked outside IBD; the 100 mined blocks
+    // of this fixture already take us out of it.
+    BOOST_REQUIRE(!m_node.chainman->ActiveChainstate().IsInitialBlockDownload());
+
+    // Every Dash-specific message is offered to CMNAuth first, which asserts a loaded metadata
+    // manager. The fixture leaves it unloaded, so initialise an empty cache here.
+    BOOST_REQUIRE(m_node.mn_metaman->LoadCache(/*load_cache=*/false));
+
+    // The CLSIG branch in net_processing is gated on spork 19. The test fixture builds a bare
+    // CSporkManager, so wire up the regtest signer before setting the spork.
+    for (const auto& address : Params().SporkAddresses()) {
+        BOOST_REQUIRE(m_node.sporkman->SetSporkAddress(address));
+    }
+    BOOST_REQUIRE(m_node.sporkman->SetMinSporkKeys(Params().MinSporkKeys()));
+    BOOST_REQUIRE(m_node.sporkman->SetPrivKey(REGTEST_SPORK_PRIVKEY));
+    BOOST_REQUIRE(m_node.sporkman->UpdateSpork(SPORK_19_CHAINLOCKS_ENABLED, 0).has_value());
+    BOOST_REQUIRE(m_node.chainlocks->IsEnabled());
+
+    auto unsolicited_peer{MakeClsigPeer(/*id=*/41)};
+    auto announcing_peer{MakeClsigPeer(/*id=*/42)};
+    m_node.peerman->InitializeNode(*unsolicited_peer, NODE_NETWORK);
+    m_node.peerman->InitializeNode(*announcing_peer, NODE_NETWORK);
+
+    const auto unsolicited_clsig = CreateChainLock(200, GetTestBlockHash(41));
+    const CInv unsolicited_inv{MSG_CLSIG, ::SerializeHash(unsolicited_clsig)};
+
+    // Sent twice on purpose. Without the gate the first copy would still be scored (this chain is
+    // too short to resolve a signing quorum for height 200) but the second would hit the seen-cache
+    // dedup and cost the peer nothing -- so only charging for both proves the gate is what rejected
+    // them, and that an unsolicited peer cannot keep repeating the work for free.
+    for (int i = 0; i < 2; ++i) {
+        CDataStream unsolicited_payload{SER_NETWORK, PROTOCOL_VERSION};
+        unsolicited_payload << unsolicited_clsig;
+        SendMessage(*m_node.peerman, *unsolicited_peer, NetMsgType::CLSIG, std::move(unsolicited_payload));
+    }
+
+    // Never reached ProcessNewChainLock: the hash was not recorded in the seen cache, so the peer
+    // could not have displaced a genuine entry, and it was scored for each attempt.
+    BOOST_CHECK(!m_node.clhandler->AlreadyHave(unsolicited_inv));
+    BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *unsolicited_peer),
+                      2 * UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE);
+
+    // Announcing the CLSIG is NOT enough to authorise it. An INV creates a candidate immediately,
+    // but the GETDATA only goes out later from SendMessages, so accepting on the announcement alone
+    // would let a peer authorise its own payload by racing INV and payload back to back -- which
+    // costs it nothing and defeats the gate entirely.
+    const auto announced_clsig = CreateChainLock(201, GetTestBlockHash(42));
+    const CInv announced_inv{MSG_CLSIG, ::SerializeHash(announced_clsig)};
+
+    AnnounceInv(*m_node.peerman, *announcing_peer, announced_inv);
+    {
+        const int score_before_race = MisbehaviorScore(*m_node.peerman, *announcing_peer);
+        CDataStream raced_payload{SER_NETWORK, PROTOCOL_VERSION};
+        raced_payload << announced_clsig;
+        SendMessage(*m_node.peerman, *announcing_peer, NetMsgType::CLSIG, std::move(raced_payload));
+
+        BOOST_CHECK(!m_node.clhandler->AlreadyHave(announced_inv));
+        BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *announcing_peer),
+                          score_before_race + UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE);
+    }
+
+    // Once SendMessages has actually issued the GETDATA the same payload is authorised. The
+    // rejection above must not have consumed the candidate, or no GETDATA would go out at all.
+    SetMockTime(GetTime<std::chrono::seconds>() + 61s);
+    m_node.peerman->SendMessages(announcing_peer.get());
+    const int score_before = MisbehaviorScore(*m_node.peerman, *announcing_peer);
+
+    CDataStream announced_payload{SER_NETWORK, PROTOCOL_VERSION};
+    announced_payload << announced_clsig;
+    SendMessage(*m_node.peerman, *announcing_peer, NetMsgType::CLSIG, std::move(announced_payload));
+
+    BOOST_CHECK(m_node.clhandler->AlreadyHave(announced_inv));
+    // Exactly the pre-existing invalid-CLSIG penalty and nothing else. This fixture's chain is 100
+    // blocks, so a CLSIG at height 201 resolves to no signing quorum and ProcessNewChainLock scores
+    // 10 -- which is what proves the message got past the gate. Asserting the total exactly is what
+    // would catch the gate also charging an authorised peer.
+    BOOST_CHECK_EQUAL(MisbehaviorScore(*m_node.peerman, *announcing_peer), score_before + 10);
+    // The authorisation was consumed, so a replay of the same CLSIG is now unsolicited.
+    BOOST_CHECK(!WITH_LOCK(::cs_main,
+                           return m_node.peerman->PeerConsumeGetDataResponse(announcing_peer->GetId(), announced_inv)));
+
+    m_node.peerman->FinalizeNode(*unsolicited_peer);
+    m_node.peerman->FinalizeNode(*announcing_peer);
+    SetMockTime(0s);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/llmq_chainlock_tests.cpp
+++ b/src/test/llmq_chainlock_tests.cpp
@@ -246,28 +246,6 @@ BOOST_FIXTURE_TEST_CASE(best_chainlock_is_already_have_after_seen_cache_eviction
 namespace {
 //! Regtest spork key matching Params().SporkAddresses(), as used by the functional tests.
 constexpr const char* REGTEST_SPORK_PRIVKEY{"cP4EKFyJsHT39LDqgdcB43Y3YXjNyjb5Fuas1GQSeAtjnZWmZEQK"};
-
-void SendMessage(PeerManager& peerman, CNode& peer, const std::string& msg_type, CDataStream&& payload)
-    EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex)
-{
-    std::atomic<bool> interrupt_dummy{false};
-    peerman.ProcessMessage(peer, msg_type, payload, GetTime<std::chrono::microseconds>(), interrupt_dummy);
-}
-
-void AnnounceInv(PeerManager& peerman, CNode& peer, const CInv& inv)
-    EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex)
-{
-    CDataStream inv_stream{SER_NETWORK, PROTOCOL_VERSION};
-    inv_stream << std::vector<CInv>{inv};
-    SendMessage(peerman, peer, NetMsgType::INV, std::move(inv_stream));
-}
-
-int MisbehaviorScore(PeerManager& peerman, const CNode& peer)
-{
-    CNodeStateStats stats;
-    BOOST_REQUIRE(peerman.GetNodeStateStats(peer.GetId(), stats));
-    return stats.m_misbehavior_score;
-}
 } // namespace
 
 // A CLSIG is only ever sent in reply to a GETDATA, so one that the peer neither announced nor was

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -39,6 +39,13 @@ using namespace std::literals;
 BOOST_FIXTURE_TEST_SUITE(net_tests, RegTestingSetup)
 
 namespace {
+//! GetObjectInterval(MSG_CLSIG), the shortest of the per-type request intervals, and the grace that
+//! follows it: RECENT_OBJECT_REQUEST_TTL_INTERVALS of them. Neither is reachable from a test, so the
+//! arithmetic is spelled out here -- if either changes, the cases pinning this boundary should be
+//! revisited rather than silently re-pointed at a different one.
+constexpr auto CLSIG_REQUEST_INTERVAL{5s};
+constexpr auto CLSIG_LATE_GRACE{2 * CLSIG_REQUEST_INTERVAL};
+
 GetDataResponse ConsumeGetDataResponse(PeerManager& peerman, const CNode& peer, const CInv& inv)
 {
     return WITH_LOCK(::cs_main, return peerman.PeerConsumeGetDataResponse(peer.GetId(), inv));
@@ -150,6 +157,148 @@ BOOST_AUTO_TEST_CASE(peer_getdata_response_requires_an_inflight_request)
     const CInv never_announced{MSG_SPORK, uint256S("05")};
     BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, never_announced) == GetDataResponse::UNREQUESTED);
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 0U);
+
+    m_node.peerman->FinalizeNode(*peer);
+    chainstate.ResetIbd();
+    SetMockTime(0s);
+}
+
+// The tracker cannot answer "did we ever ask this peer?" on its own: an announcement is erased once
+// it expires as the sole one for its hash. A peer that answers our GETDATA a little too slowly is
+// then indistinguishable from one that was never asked -- unless we remember having asked. Without
+// that memory an honest but slow peer accrues misbehaviour, and the score never decays within a
+// connection.
+BOOST_AUTO_TEST_CASE(expired_getdata_response_is_late_not_unrequested)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    TestChainState& chainstate = *static_cast<TestChainState*>(&m_node.chainman->ActiveChainstate());
+    chainstate.JumpOutOfIbd();
+
+    auto peer{MakeTestPeer(/*id=*/0)};
+    m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
+
+    // MSG_CLSIG is a GETDATA-only type, and its request interval is the shortest of them all.
+    const CInv inv{MSG_CLSIG, uint256S("06")};
+    ProcessInv(*m_node.peerman, *peer, inv);
+
+    // Nudge past the announcement's reqtime so SendMessages issues the GETDATA.
+    SetMockTime(GetTime<std::chrono::seconds>() + 2s);
+    m_node.peerman->SendMessages(peer.get());
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 1U);
+
+    // Answer on the last moment of the grace: the request expired at CLSIG_REQUEST_INTERVAL, and
+    // this peer was the only announcer, so the tracker drops the record entirely rather than keeping
+    // a COMPLETED one -- there is nothing left for it to consult.
+    SetMockTime(GetTime<std::chrono::seconds>() + CLSIG_LATE_GRACE);
+    m_node.peerman->SendMessages(peer.get());
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 0U);
+
+    // The answer is late, not unsolicited: it must not be scored.
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, inv) == GetDataResponse::LATE);
+    // One GETDATA buys exactly one answer. Without this a peer could induce a single request and
+    // then replay that payload forever, unscored -- which is the abuse the gate exists to stop.
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, inv) == GetDataResponse::UNREQUESTED);
+
+    // A hash we never asked this peer for is still unsolicited.
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, CInv{MSG_CLSIG, uint256S("07")}) ==
+                GetDataResponse::UNREQUESTED);
+
+    m_node.peerman->FinalizeNode(*peer);
+    chainstate.ResetIbd();
+    SetMockTime(0s);
+}
+
+// Accepting an object from any source erases every peer's announcement of it (ForgetTxHash), which
+// likewise strands an in-flight request. Reachable in production whenever the object turns up
+// locally -- a ChainLock we sign ourselves, or one submitted over RPC -- while a GETDATA is out.
+BOOST_AUTO_TEST_CASE(forgotten_getdata_response_is_late_not_unrequested)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    TestChainState& chainstate = *static_cast<TestChainState*>(&m_node.chainman->ActiveChainstate());
+    chainstate.JumpOutOfIbd();
+
+    auto peer{MakeTestPeer(/*id=*/0)};
+    m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
+
+    const CInv inv{MSG_CLSIG, uint256S("08")};
+    ProcessInv(*m_node.peerman, *peer, inv);
+
+    SetMockTime(GetTime<std::chrono::seconds>() + 2s);
+    m_node.peerman->SendMessages(peer.get());
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 1U);
+
+    // The object arrives from somewhere else while our GETDATA is still in flight.
+    WITH_LOCK(::cs_main, m_node.peerman->PeerForgetObjectRequest(inv));
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 0U);
+
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, inv) == GetDataResponse::LATE);
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, inv) == GetDataResponse::UNREQUESTED);
+
+    m_node.peerman->FinalizeNode(*peer);
+    chainstate.ResetIbd();
+    SetMockTime(0s);
+}
+
+// The type in an INV is whatever the peer said it was, and is not bound to the payload until that
+// payload arrives. So a peer can announce the hash of an object of one gated type under another --
+// no hash collision needed, it picks the hash -- collect our GETDATA, and answer with the object it
+// meant all along. The grace must be tied to the type we asked for, not the one we are handed, or
+// the request authorises the substitute and lends it the wrong type's window as well.
+BOOST_AUTO_TEST_CASE(getdata_response_grace_does_not_cross_inv_types)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    TestChainState& chainstate = *static_cast<TestChainState*>(&m_node.chainman->ActiveChainstate());
+    chainstate.JumpOutOfIbd();
+
+    auto peer{MakeTestPeer(/*id=*/0)};
+    m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
+
+    // Announced as a ChainLock, so that is what we ask for.
+    const uint256 hash{uint256S("0b")};
+    ProcessInv(*m_node.peerman, *peer, CInv{MSG_CLSIG, hash});
+    SetMockTime(GetTime<std::chrono::seconds>() + 2s);
+    m_node.peerman->SendMessages(peer.get());
+
+    // Strand the request so only the recorded grace is left to consult, then answer with a DKG
+    // message carrying that hash, inside the interval that type would have been given (120s) but
+    // outside the one the ChainLock request actually earned (10s).
+    WITH_LOCK(::cs_main, m_node.peerman->PeerForgetObjectRequest(CInv{MSG_CLSIG, hash}));
+    SetMockTime(GetTime<std::chrono::seconds>() + CLSIG_LATE_GRACE + 1s);
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, CInv{MSG_QUORUM_CONTRIB, hash}) ==
+                GetDataResponse::UNREQUESTED);
+
+    m_node.peerman->FinalizeNode(*peer);
+    chainstate.ResetIbd();
+    SetMockTime(0s);
+}
+
+// The grace is bounded in time, not just in count. Without that a peer could induce a GETDATA, never
+// answer it, and spend the authorisation an arbitrarily long time later -- banking one per request.
+BOOST_AUTO_TEST_CASE(getdata_response_grace_expires)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    TestChainState& chainstate = *static_cast<TestChainState*>(&m_node.chainman->ActiveChainstate());
+    chainstate.JumpOutOfIbd();
+
+    auto peer{MakeTestPeer(/*id=*/0)};
+    m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
+
+    const CInv inv{MSG_CLSIG, uint256S("0a")};
+    ProcessInv(*m_node.peerman, *peer, inv);
+    SetMockTime(GetTime<std::chrono::seconds>() + 2s);
+    m_node.peerman->SendMessages(peer.get());
+
+    // Exactly one second past the boundary that expired_getdata_response_is_late_not_unrequested
+    // sits on, so the two cases together pin it from both sides.
+    SetMockTime(GetTime<std::chrono::seconds>() + CLSIG_LATE_GRACE + 1s);
+    m_node.peerman->SendMessages(peer.get());
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 0U);
+
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, inv) == GetDataResponse::UNREQUESTED);
 
     m_node.peerman->FinalizeNode(*peer);
     chainstate.ResetIbd();

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -15,6 +15,7 @@
 #include <serialize.h>
 #include <span.h>
 #include <streams.h>
+#include <test/util/net.h>
 #include <test/util/random.h>
 #include <test/util/validation.h>
 #include <timedata.h>
@@ -38,25 +39,6 @@ using namespace std::literals;
 BOOST_FIXTURE_TEST_SUITE(net_tests, RegTestingSetup)
 
 namespace {
-std::unique_ptr<CNode> MakeTestPeer(NodeId id)
-{
-    in_addr peer_in_addr{};
-    peer_in_addr.s_addr = htonl(0x01020304 + id);
-    auto peer{std::make_unique<CNode>(id,
-                                      /*sock=*/nullptr,
-                                      /*addrIn=*/CAddress{CService{peer_in_addr, 8333}, NODE_NETWORK},
-                                      /*nKeyedNetGroupIn=*/0,
-                                      /*nLocalHostNonceIn=*/0,
-                                      /*addrBindIn=*/CAddress{},
-                                      /*addrNameIn=*/std::string{},
-                                      /*conn_type_in=*/ConnectionType::OUTBOUND_FULL_RELAY,
-                                      /*inbound_onion=*/false)};
-    peer->nVersion = PROTOCOL_VERSION;
-    peer->SetCommonVersion(PROTOCOL_VERSION);
-    peer->fSuccessfullyConnected = true;
-    return peer;
-}
-
 void ProcessInv(PeerManager& peerman, CNode& peer, const CInv& inv)
     EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex)
 {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -39,6 +39,11 @@ using namespace std::literals;
 BOOST_FIXTURE_TEST_SUITE(net_tests, RegTestingSetup)
 
 namespace {
+GetDataResponse ConsumeGetDataResponse(PeerManager& peerman, const CNode& peer, const CInv& inv)
+{
+    return WITH_LOCK(::cs_main, return peerman.PeerConsumeGetDataResponse(peer.GetId(), inv));
+}
+
 void ProcessInv(PeerManager& peerman, CNode& peer, const CInv& inv)
     EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex)
 {
@@ -126,23 +131,24 @@ BOOST_AUTO_TEST_CASE(peer_getdata_response_requires_an_inflight_request)
     auto peer{MakeTestPeer(/*id=*/0)};
     m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
 
+    // MSG_SPORK is not a GETDATA-only type (see IsGetDataOnlyObject), so nothing here is ever
+    // softened to LATE and the strict in-flight requirement is visible on its own.
     const CInv inv{MSG_SPORK, uint256S("04")};
     ProcessInv(*m_node.peerman, *peer, inv);
     // Announced but not yet requested: the looser check accepts this, the stricter one must not.
-    BOOST_CHECK(!WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeGetDataResponse(peer->GetId(), inv)));
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, inv) == GetDataResponse::UNREQUESTED);
     // The rejection left the candidate intact, so the GETDATA is still pending.
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 1U);
 
     // After SendMessages issues the GETDATA the announcement is REQUESTED and authorises once.
     SetMockTime(GetTime<std::chrono::seconds>() + 61s);
     m_node.peerman->SendMessages(peer.get());
-    BOOST_CHECK(WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeGetDataResponse(peer->GetId(), inv)));
-    BOOST_CHECK(!WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeGetDataResponse(peer->GetId(), inv)));
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, inv) == GetDataResponse::REQUESTED);
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, inv) == GetDataResponse::UNREQUESTED);
 
     // Never announced at all: rejected, and no trace left behind.
     const CInv never_announced{MSG_SPORK, uint256S("05")};
-    BOOST_CHECK(!WITH_LOCK(::cs_main,
-                           return m_node.peerman->PeerConsumeGetDataResponse(peer->GetId(), never_announced)));
+    BOOST_CHECK(ConsumeGetDataResponse(*m_node.peerman, *peer, never_announced) == GetDataResponse::UNREQUESTED);
     BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 0U);
 
     m_node.peerman->FinalizeNode(*peer);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -129,6 +129,45 @@ BOOST_AUTO_TEST_CASE(peer_requested_object_authorizes_and_erases_per_peer_state)
     SetMockTime(0s);
 }
 
+// GETDATA-only object types use the stricter PeerConsumeGetDataResponse, which -- unlike
+// PeerConsumeObjectRequest -- must reject a bare announcement. Otherwise a peer could authorise its
+// own payload by sending INV immediately followed by the object, before SendMessages ever turned
+// that announcement into a request.
+BOOST_AUTO_TEST_CASE(peer_getdata_response_requires_an_inflight_request)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    TestChainState& chainstate =
+        *static_cast<TestChainState*>(&m_node.chainman->ActiveChainstate());
+    chainstate.JumpOutOfIbd();
+
+    auto peer{MakeTestPeer(/*id=*/0)};
+    m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
+
+    const CInv inv{MSG_SPORK, uint256S("04")};
+    ProcessInv(*m_node.peerman, *peer, inv);
+    // Announced but not yet requested: the looser check accepts this, the stricter one must not.
+    BOOST_CHECK(!WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeGetDataResponse(peer->GetId(), inv)));
+    // The rejection left the candidate intact, so the GETDATA is still pending.
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 1U);
+
+    // After SendMessages issues the GETDATA the announcement is REQUESTED and authorises once.
+    SetMockTime(GetTime<std::chrono::seconds>() + 61s);
+    m_node.peerman->SendMessages(peer.get());
+    BOOST_CHECK(WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeGetDataResponse(peer->GetId(), inv)));
+    BOOST_CHECK(!WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeGetDataResponse(peer->GetId(), inv)));
+
+    // Never announced at all: rejected, and no trace left behind.
+    const CInv never_announced{MSG_SPORK, uint256S("05")};
+    BOOST_CHECK(!WITH_LOCK(::cs_main,
+                           return m_node.peerman->PeerConsumeGetDataResponse(peer->GetId(), never_announced)));
+    BOOST_CHECK_EQUAL(WITH_LOCK(::cs_main, return m_node.peerman->GetRequestedObjectCount(peer->GetId())), 0U);
+
+    m_node.peerman->FinalizeNode(*peer);
+    chainstate.ResetIbd();
+    SetMockTime(0s);
+}
+
 BOOST_AUTO_TEST_CASE(cnode_simple_test)
 {
     NodeId id = 0;

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -15,6 +15,7 @@
 #include <serialize.h>
 #include <span.h>
 
+#include <memory>
 #include <vector>
 
 void ConnmanTestMsg::Handshake(CNode& node,
@@ -135,4 +136,23 @@ std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candida
         });
     }
     return candidates;
+}
+
+std::unique_ptr<CNode> MakeTestPeer(NodeId id)
+{
+    in_addr peer_in_addr{};
+    peer_in_addr.s_addr = htonl(0x01020304 + id);
+    auto peer{std::make_unique<CNode>(id,
+                                      /*sock=*/nullptr,
+                                      /*addrIn=*/CAddress{CService{peer_in_addr, 8333}, NODE_NETWORK},
+                                      /*nKeyedNetGroupIn=*/0,
+                                      /*nLocalHostNonceIn=*/0,
+                                      /*addrBindIn=*/CAddress{},
+                                      /*addrNameIn=*/std::string{},
+                                      /*conn_type_in=*/ConnectionType::OUTBOUND_FULL_RELAY,
+                                      /*inbound_onion=*/false)};
+    peer->nVersion = PROTOCOL_VERSION;
+    peer->SetCommonVersion(PROTOCOL_VERSION);
+    peer->fSuccessfullyConnected = true;
+    return peer;
 }

--- a/src/test/util/net.cpp
+++ b/src/test/util/net.cpp
@@ -14,8 +14,14 @@
 #include <random.h>
 #include <serialize.h>
 #include <span.h>
+#include <streams.h>
+#include <util/check.h>
+#include <util/time.h>
 
+#include <atomic>
+#include <chrono>
 #include <memory>
+#include <string>
 #include <vector>
 
 void ConnmanTestMsg::Handshake(CNode& node,
@@ -155,4 +161,24 @@ std::unique_ptr<CNode> MakeTestPeer(NodeId id)
     peer->SetCommonVersion(PROTOCOL_VERSION);
     peer->fSuccessfullyConnected = true;
     return peer;
+}
+
+void SendMessage(PeerManager& peerman, CNode& peer, const std::string& msg_type, CDataStream&& payload)
+{
+    std::atomic<bool> interrupt_dummy{false};
+    peerman.ProcessMessage(peer, msg_type, payload, GetTime<std::chrono::microseconds>(), interrupt_dummy);
+}
+
+void AnnounceInv(PeerManager& peerman, CNode& peer, const CInv& inv)
+{
+    CDataStream inv_stream{SER_NETWORK, PROTOCOL_VERSION};
+    inv_stream << std::vector<CInv>{inv};
+    SendMessage(peerman, peer, NetMsgType::INV, std::move(inv_stream));
+}
+
+int MisbehaviorScore(PeerManager& peerman, const CNode& peer)
+{
+    CNodeStateStats stats;
+    Assert(peerman.GetNodeStateStats(peer.GetId(), stats));
+    return stats.m_misbehavior_score;
 }

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -12,6 +12,8 @@
 #include <netaddress.h>
 #include <node/connection_types.h>
 #include <node/eviction.h>
+#include <protocol.h>
+#include <streams.h>
 #include <sync.h>
 #include <util/sock.h>
 
@@ -235,5 +237,18 @@ std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candida
 /** Build a fully connected outbound peer with no socket, suitable for driving PeerManager message
  *  handling directly. Each id gets a distinct address so that per-peer state stays separate. */
 std::unique_ptr<CNode> MakeTestPeer(NodeId id);
+
+/** Hand one message to PeerManager as if it had arrived from `peer`, taking the real dispatch path
+ *  rather than calling a subsystem handler directly. */
+void SendMessage(PeerManager& peerman, CNode& peer, const std::string& msg_type, CDataStream&& payload)
+    EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex);
+
+/** Announce a single inv from `peer`. Note that this only creates a request candidate: the GETDATA
+ *  goes out later, from SendMessages. */
+void AnnounceInv(PeerManager& peerman, CNode& peer, const CInv& inv)
+    EXCLUSIVE_LOCKS_REQUIRED(NetEventsInterface::g_msgproc_mutex);
+
+/** Misbehavior score PeerManager currently holds against `peer`. */
+int MisbehaviorScore(PeerManager& peerman, const CNode& peer);
 
 #endif // BITCOIN_TEST_UTIL_NET_H

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -232,4 +232,8 @@ private:
 
 std::vector<NodeEvictionCandidate> GetRandomNodeEvictionCandidates(int n_candidates, FastRandomContext& random_context);
 
+/** Build a fully connected outbound peer with no socket, suitable for driving PeerManager message
+ *  handling directly. Each id gets a distinct address so that per-peer state stays separate. */
+std::unique_ptr<CNode> MakeTestPeer(NodeId id);
+
 #endif // BITCOIN_TEST_UTIL_NET_H

--- a/src/txrequest.cpp
+++ b/src/txrequest.cpp
@@ -669,6 +669,16 @@ public:
         return true;
     }
 
+    bool ReceivedRequestedResponse(NodeId peer, const CInv& txhash)
+    {
+        // A REQUESTED announcement is never the CANDIDATE_BEST for its txhash, so only the
+        // (peer, false, txhash) half of the ByPeer index can hold it.
+        auto it = m_index.get<ByPeer>().find(ByPeerView{peer, false, txhash});
+        if (it == m_index.get<ByPeer>().end() || it->GetState() != State::REQUESTED) return false;
+        MakeCompleted(m_index.project<ByTxHash>(it));
+        return true;
+    }
+
     size_t CountInFlight(NodeId peer) const
     {
         auto it = m_peerinfo.find(peer);
@@ -733,6 +743,11 @@ void TxRequestTracker::RequestedTx(NodeId peer, const CInv& txhash, std::chrono:
 bool TxRequestTracker::ReceivedResponse(NodeId peer, const CInv& txhash)
 {
     return m_impl->ReceivedResponse(peer, txhash);
+}
+
+bool TxRequestTracker::ReceivedRequestedResponse(NodeId peer, const CInv& txhash)
+{
+    return m_impl->ReceivedRequestedResponse(peer, txhash);
 }
 
 std::vector<CInv> TxRequestTracker::GetRequestable(NodeId peer, std::chrono::microseconds now,

--- a/src/txrequest.h
+++ b/src/txrequest.h
@@ -189,6 +189,18 @@ public:
      */
     bool ReceivedResponse(NodeId peer, const CInv& txhash);
 
+    /** Like ReceivedResponse, but only succeeds for an announcement we actually sent a GETDATA for.
+     *
+     * ReceivedResponse also accepts a CANDIDATE, which exists from the moment a peer's INV is processed.
+     * For object types that are only ever sent in reply to a GETDATA that is too weak to authorise an
+     * incoming object: a peer could announce a hash and immediately push the payload, before
+     * SendMessages had any chance to turn the announcement into a request.
+     *
+     * Returns false without altering the announcement unless it is in the REQUESTED state, so a
+     * premature payload leaves the candidate intact and the normal GETDATA still goes out.
+     */
+    bool ReceivedRequestedResponse(NodeId peer, const CInv& txhash);
+
     // The operations below inspect the data structure.
 
     /** Count how many REQUESTED announcements a peer has. */

--- a/test/functional/feature_llmq_dkg_intake.py
+++ b/test/functional/feature_llmq_dkg_intake.py
@@ -12,6 +12,8 @@ Adversarial P2P tests for DKG message-intake hardening:
     from a verified peer.
   - structural pre-validation: malformed DKG payloads (valid quorum prefix, garbage
     body) are rejected before retention even from a verified peer.
+  - a well-formed DKG message that the peer never announced and was never asked for
+    is dropped before retention, even from a verified peer.
 
 The node must not crash; the sending peer must be scored (Misbehaving).
 """
@@ -119,6 +121,7 @@ class DkgIntakeTest(DashTestFramework):
         self.test_oversized_rejected(mn_node)
         self.test_malformed_rejected(mn_node)
         self.test_under_min_contribution_blobs_rejected(mn_node)
+        self.test_unrequested_rejected(mn_node)
 
     def test_unverified_sender_rejected(self, node):
         self.log.info("Pushed DKG messages from a non-verified peer are rejected (Misbehaving 10 each)")
@@ -168,6 +171,20 @@ class DkgIntakeTest(DashTestFramework):
             peer.send_message(msg_dkg_raw(b"qcontrib", self.qcontrib_payload(blob_count=1)))
             peer.sync_with_ping()
         wait_for_banscore(node, peer_id, 100)
+        node.disconnect_p2ps()
+
+    def test_unrequested_rejected(self, node):
+        self.log.info("A well-formed but unrequested DKG message is dropped (Misbehaving 10)")
+        peer, peer_id = self.add_verified_peer(node)
+        wait_for_banscore(node, peer_id, 0)
+        # Passes every earlier check (verified sender, known quorum, size, structure) and is
+        # rejected purely because the peer neither announced it nor was asked for it. DKG
+        # messages only ever travel inv -> getdata, so a pushed one is unsolicited by
+        # definition and must not reach the pending queues.
+        with node.assert_debug_log(["unrequested DKG message"]):
+            peer.send_message(msg_dkg_raw(b"qcontrib", self.qcontrib_payload(blob_count=2)))
+            peer.sync_with_ping()
+        wait_for_banscore(node, peer_id, 10)
         node.disconnect_p2ps()
 
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Several P2P object types travel `inv` → `getdata` → object and are never pushed on their own. When such a message arrives that we never asked for, we process it anyway, and for some of them the rejection path costs the sender nothing at all.

The clearest case is `CLSIG`. `ChainlockHandler::ProcessNewChainLock` short-circuits with **no misbehaviour penalty** for any CLSIG at or below our best ChainLock — the height check runs before BLS verification, deliberately, to avoid a verification DoS. Because every distinct signature blob hashes differently, the seen-cache dedup above it never catches a varied blob, so a peer can repeat that work indefinitely for free: churning the (bounded) 1024-entry seen cache and competing with real LLMQ traffic, since `CLSIG` sits on the quorum priority queue (`IsQuorumPriorityMessage`).

`QFCOMMITMENT` has the same shape. Most of the checks in `CQuorumBlockProcessor::ProcessMessage` return without scoring the peer — deliberately, since we may just be lagging behind or on another chain — so an unsolicited sender can drive the block lookups and mineable-commitment probes repeatedly at no cost. The DKG messages are retained in the per-phase pending queues until a worker gets round to verifying their signatures.

The net layer already tracks, per peer, what we asked for, and governance objects and votes already authorise incoming payloads against it. These three object types simply weren't doing so — the underlying `ReceivedResponse` was called and its return value discarded.

## What was done?

Authorise three object types against the request tracker, dropping and scoring anything we have no in-flight GETDATA for.

The existing `PeerConsumeObjectRequest` is too weak for this. It resolves to `TxRequestTracker::ReceivedResponse`, which succeeds for any non-`COMPLETED` announcement — including the `CANDIDATE` created the moment an INV is processed. The transition to `REQUESTED` only happens later, when `SendMessages` schedules the GETDATA. A peer could therefore send `INV(hash)` immediately followed by the payload and authorise itself, which defeats the gate entirely; completing a sole candidate also erases it, so the per-peer announcement cap does not bound the repetition. This is reachable in production, not just in tests: sends for masternode connections are deliberately batched at ~100 ms intervals.

So this adds `TxRequestTracker::ReceivedRequestedResponse`, which succeeds only in the `REQUESTED` state, exposed as `PeerConsumeGetDataResponse`. On failure it leaves the announcement untouched, so a premature payload is rejected without suppressing the legitimate GETDATA that follows. Governance keeps the existing announced-or-requested semantics via `PeerConsumeObjectRequest`, which is unchanged.

The three call sites:

* **`CLSIG`** — `net_processing.cpp`. Authorised after the spork-19 gate, so a CLSIG dropped while ChainLocks are disabled does not burn a later retransmit.
* **`QCONTRIB` / `QCOMPLAINT` / `QJUSTIFICATION` / `QPCOMMITMENT`** — `llmq/net_dkg.cpp`. The check is placed last, after the MNAuth, size and structural checks, so every existing rejection path and its score is unchanged. Replaces the previous `PeerEraseObjectRequest` call, which discarded the answer.
* **`QFCOMMITMENT`** — `llmq/blockprocessor.cpp`. Runs before any of the lookups above — the opposite placement from the DKG site, deliberately. There the pre-existing checks are cheap (MNAuth, size, structure) and gating last preserves their heavier penalties; here the pre-existing checks *are* the expensive part — block-index lookups and mineable-commitment probes under `::cs_main` — so an unsolicited sender must be turned away before reaching them. (The gate takes `::cs_main` too, but only for a tracker probe: a brief, bounded hold rather than chain-state traversal on the sender's behalf.) This knowingly softens the penalty for unsolicited *garbage* from 100 to 10 — such a peer now survives ten messages instead of one — but each of those messages is now a deserialize-hash-drop instead of chain lookups, and anything we actually requested still faces the full existing penalties. `CQuorumBlockProcessor` holds no `PeerManagerInternal` reference (`net_processing` already includes this header, so taking one would make the dependency circular), so the check is passed in as a predicate from the call site. Replaces the `m_to_erase` round-trip, which resolved to the weaker `ReceivedResponse`.

A shared `UNREQUESTED_OBJECT_MISBEHAVIOR_SCORE{10}` lives in `msg_result.h`, matching the existing "moderate" penalties nearby (`mnauth` from an unknown masternode, a DKG message from a non-verified peer, an invalid CLSIG).

### Late and superseded answers are not misbehaviour

(The four commits addressing this are authored by UdjinM6, from review.)

A strict in-flight-only gate conflates an unsolicited push with an honest answer to a GETDATA of ours whose tracker entry is simply gone. Two routine paths remove it: **expiry** — a REQUESTED announcement past `GetObjectInterval()` (only 5s for `MSG_CLSIG`) is completed, and deleted outright when it was the sole announcement for its hash, the common case; and **`ForgetTxHash`** — accepting the object from any source (a ChainLock we signed ourselves, or one submitted over RPC) erases every peer's announcement, stranding an in-flight request. Neither is misbehaviour, but both would have been scored 10 — and since the score does not decay within a connection, a run of them discourages the peer's address. On the long-lived masternode connections these object types travel over, that is the wrong outcome.

So `SendMessages` additionally records, per peer, the GETDATA-only objects we actually sent a GETDATA for, and `PeerConsumeGetDataResponse` now reports `REQUESTED`, `LATE` or `UNREQUESTED`; only `UNREQUESTED` is scored, and `LATE` is processed as before. Only we ever write to that record, so a peer still cannot authorise its own payload by announcing it first. The record is bounded on three axes, each closing an abuse: **consumption** — an entry is erased by the answer it authorises, so one GETDATA buys exactly one accepted object and the induced payload cannot be replayed; **time** — entries age out after two request intervals of the requested type, so an unanswered request cannot be banked and redeemed later; **type** — both the match and the window come from the type *we requested*, never from the answer, so announcing a hash as `MSG_CLSIG` and answering with a DKG message is not authorised. The 256-entry per-peer LRU cap is only a memory ceiling: early eviction costs the grace for the oldest requests, never correctness.

The gated types are now named once in `IsGetDataOnlyObject`, together with why the other inv-driven types are excluded.

### What the gate does not close

For the DKG messages and `QFCOMMITMENT` the gate is the substance of the fix: those payloads were retained in pending queues or driving block lookups before any cheap check could reject them, and requiring a GETDATA bounds that work outright.

For `CLSIG` the picture is narrower than the motivation above may suggest. The gate closes the *push* path, but a peer can still get itself solicited: announce the hash, and on non-masternode connections `SendMessages` runs after every processed message, so the GETDATA goes out almost immediately (masternode connections batch sends at ~100 ms, same outcome slightly later). A stale solicited CLSIG — at or below our best ChainLock — is then still processed and still costs the sender nothing, since `ProcessNewChainLock`'s height check deliberately exits without penalty. So for the stale-CLSIG churn scenario specifically, the gate adds one INV and one GETDATA round-trip per blob rather than eliminating the free work; what it does guarantee is that nothing reaches the handler without our request, and that each request pays for exactly one payload. Closing the remainder means scoring stale *solicited* CLSIGs or rate-limiting per-peer CLSIG requests — both touch honest relay timing (a peer lagging behind us is normal) and are left as a follow-up.

### Deliberately not gated

`PLATFORMBAN` looks like it belongs in this set — it is only ever pushed from `ProcessGetData` in-tree — but it has **no local ingress**: no RPC, no internal producer. The originating Dash Platform node injects a ban by pushing the P2P message straight to a Dash Core peer, so the first hop is always unsolicited by design. `p2p_platform_ban.py` covers this. A comment at the handler records the reasoning so the omission does not read as an oversight.

The remaining inv-driven types were considered and left alone because each has a legitimate unsolicited-push path that would need a carve-out rather than a plain gate: `QSIGREC` (proactive relay to peers that sent `QSENDRECSIGS`), `MSG_DSQ` (`SENDDSQUEUE` / `WantsDSQ::ALL`), `ISDLOCK` (pushed alongside `MERKLEBLOCK` for BIP37 clients), and `SPORK` (bulk push in reply to `GETSPORKS`). `MSG_TX` / `MSG_DSTX` keep upstream Bitcoin semantics.

## How Has This Been Tested?

Built with autotools on macOS (aarch64-apple-darwin).

New coverage:

* `src/test/llmq_chainlock_tests.cpp` — `unrequested_clsig_is_dropped_and_scored`. An unsolicited peer's CLSIG never reaches `ProcessNewChainLock`, asserted via the handler's `AlreadyHave` (i.e. the hash was never recorded in the seen cache). It is sent twice and charged for both: without the gate the second copy would hit the seen-cache dedup and cost nothing, so this is what distinguishes the gate from the pre-existing invalid-CLSIG penalty. A peer whose GETDATA is in flight gets through, and its score is asserted exactly, so the gate charging an authorised peer as well would fail the test.
* `src/test/net_tests.cpp` — `peer_getdata_response_requires_an_inflight_request`. A bare announcement is rejected and leaves the candidate intact; the same inv authorises exactly once after `SendMessages` has issued the GETDATA.
* `src/test/llmq_chainlock_tests.cpp` also covers the INV-then-payload race directly: announcing and immediately pushing the CLSIG is scored, and the identical payload is only accepted after `SendMessages` runs. It also gains an end-to-end replay: the same CLSIG, accepted once, is scored when sent again.
* `test/functional/feature_llmq_dkg_intake.py` — a well-formed `QCONTRIB` that passes every earlier check (verified sender, known quorum, size, structure) and is rejected purely for being unrequested.
* `src/test/net_tests.cpp` — four cases pinning the late-answer grace and its bounds: the expiry and `ForgetTxHash` paths each yield `LATE` for the first answer (asserting the tracker record is gone entirely, not merely COMPLETED) and `UNREQUESTED` for a second copy; a hash announced as `MSG_CLSIG` and answered as `MSG_QUORUM_CONTRIB` inside the window is not authorised; and an answer one second past the two-interval boundary is `UNREQUESTED`. The boundary cases are expressed in the CLSIG request-interval constants so they sit exactly on the edge — relaxing `<=` to `<` fails them.
* `src/test/fuzz/txrequest.cpp` — `ReceivedRequestedResponse` is modelled in the harness as a new command, asserting against the naive model that the call completes an announcement precisely when it was REQUESTED and leaves everything else, notably an INV-created CANDIDATE, untouched.

Both unit tests were mutation-checked: disabling the CLSIG gate fails 3 assertions, and relaxing `ReceivedRequestedResponse` back to the `ReceivedResponse` semantics fails 4.

Full `make check` passes. Functional tests run: `feature_llmq_chainlocks.py`, `feature_llmq_signing.py` (both variants), `feature_llmq_rotation.py`, `feature_llmq_is_cl_conflicts.py`, `feature_llmq_dkgerrors.py`, `feature_llmq_dkg_intake.py`, `rpc_verifychainlock.py`, `p2p_platform_ban.py` — all pass. `lint-circular-dependencies.py`, `lint-python.py` and `lint-whitespace.py` are clean.

Re-verified at the current head, i.e. with the four review follow-up commits included: full `make check`, `feature_llmq_chainlocks.py`, `feature_llmq_dkg_intake.py` and `p2p_platform_ban.py` all pass, the fuzz harness TU compiles, and the three lints above are clean.

`p2p_platform_ban.py` is what caught the `PLATFORMBAN` case: it was gated in an earlier revision of this branch and the test failed, which is what prompted checking for a local ingress.

## Breaking Changes

None for peers running Dash Core. All three message types have been inv/getdata-only since they were introduced (`CLSIG` since "Implement and enforce ChainLocks", 2019), so no released version pushes them unsolicited.

Third-party software that pushes these messages rather than waiting for our GETDATA will now be scored 10 per message and disconnected after ten of them. No such producer exists for these three types — that property is exactly what separates them from `PLATFORMBAN`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)



