### PR TITLE
fix: guard VerifyContributionShares against an empty verification-vector set

### DIFF
--- a/src/active/dkgsession.cpp
+++ b/src/active/dkgsession.cpp
@@ -146,10 +146,13 @@ void ActiveDKGSession::VerifyPendingContributions()
         dkgManager.WriteEncryptedContributions(params.type, m_quorum_base_block_index, m->dmn->proTxHash, *vecEncryptedContributions[idx]);
     }
 
-    // All pending members may have been marked bad (e.g. double contributions)
-    // after they were enqueued. The pre-filter empty check above does not catch
-    // that; skip the BLS worker call rather than relying on its empty-input guard.
+    // Defence in depth: every pending member may have been marked bad (e.g. a
+    // double contribution) after it was enqueued, which the pre-filter check
+    // above cannot catch. AsyncVerifyContributionShares guards empty input too,
+    // but keep the call site correct on its own terms - this path terminated the
+    // node before that guard existed.
     if (memberIndexes.empty()) {
+        logger.Batch("all %d pending contributions were from bad or complained-about members, nothing to verify", pendingContributionVerifications.size());
         pendingContributionVerifications.clear();
         return;
     }

--- a/src/active/dkgsession.cpp
+++ b/src/active/dkgsession.cpp
@@ -146,6 +146,14 @@ void ActiveDKGSession::VerifyPendingContributions()
         dkgManager.WriteEncryptedContributions(params.type, m_quorum_base_block_index, m->dmn->proTxHash, *vecEncryptedContributions[idx]);
     }
 
+    // All pending members may have been marked bad (e.g. double contributions)
+    // after they were enqueued. The pre-filter empty check above does not catch
+    // that; skip the BLS worker call rather than relying on its empty-input guard.
+    if (memberIndexes.empty()) {
+        pendingContributionVerifications.clear();
+        return;
+    }
+
     auto result = blsWorker.VerifyContributionShares(myId, vvecs, skContributions);
     if (result.size() != memberIndexes.size()) {
         logger.Batch("VerifyContributionShares returned result of size %d but size %d was expected, something is wrong", result.size(), memberIndexes.size());

--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -681,6 +681,20 @@ CBLSPublicKey CBLSWorker::BuildPubKeyShare(const BLSVerificationVectorPtr& vvec,
 void CBLSWorker::AsyncVerifyContributionShares(const CBLSId& forId, Span<BLSVerificationVectorPtr> vvecs, Span<CBLSSecretKey> skShares,
                                                bool parallel, bool aggregated, std::function<void(const std::vector<bool>&)> doneCallback)
 {
+    // Empty input is degenerate: VerifyVerificationVectors() returns true for an
+    // empty span (its loop body never runs), and ContributionVerifier::Start then
+    // schedules zero work (batchCount==0 or zero-length one-by-one batch). Nothing
+    // ever invokes doneCallback, so the promise held by the future-based wrappers
+    // is destroyed without set_value and .get() throws std::future_error
+    // (broken_promise). ActiveDKGSession::VerifyPendingContributions can reach
+    // this path when every pending member has been marked bad between enqueue
+    // and flush (e.g. double-contribution MarkBadMember). Mirror the empty-input
+    // short-circuit already present on AsyncBuildQuorumVerificationVector and
+    // AsyncAggregateHelper.
+    if (vvecs.empty()) {
+        doneCallback(std::vector<bool>{});
+        return;
+    }
     if (!forId.IsValid() || !VerifyVerificationVectors(vvecs)) {
         std::vector<bool> result;
         result.assign(vvecs.size(), false);

--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -681,16 +681,9 @@ CBLSPublicKey CBLSWorker::BuildPubKeyShare(const BLSVerificationVectorPtr& vvec,
 void CBLSWorker::AsyncVerifyContributionShares(const CBLSId& forId, Span<BLSVerificationVectorPtr> vvecs, Span<CBLSSecretKey> skShares,
                                                bool parallel, bool aggregated, std::function<void(const std::vector<bool>&)> doneCallback)
 {
-    // Empty input is degenerate: VerifyVerificationVectors() returns true for an
-    // empty span (its loop body never runs), and ContributionVerifier::Start then
-    // schedules zero work (batchCount==0 or zero-length one-by-one batch). Nothing
-    // ever invokes doneCallback, so the promise held by the future-based wrappers
-    // is destroyed without set_value and .get() throws std::future_error
-    // (broken_promise). ActiveDKGSession::VerifyPendingContributions can reach
-    // this path when every pending member has been marked bad between enqueue
-    // and flush (e.g. double-contribution MarkBadMember). Mirror the empty-input
-    // short-circuit already present on AsyncBuildQuorumVerificationVector and
-    // AsyncAggregateHelper.
+    // Empty input never schedules any work, so doneCallback would never fire and the
+    // future-based wrappers would throw broken_promise. Mirror the empty-input
+    // short-circuit in AsyncBuildQuorumVerificationVector / AsyncAggregateHelper.
     if (vvecs.empty()) {
         doneCallback(std::vector<bool>{});
         return;
@@ -702,7 +695,7 @@ void CBLSWorker::AsyncVerifyContributionShares(const CBLSId& forId, Span<BLSVeri
         return;
     }
 
-    auto verifier = std::make_shared<ContributionVerifier>(forId, vvecs, skShares, 8, parallel, aggregated, workerPool, std::move(doneCallback));
+    auto verifier = std::make_shared<ContributionVerifier>(forId, vvecs, skShares, CONTRIBUTION_VERIFY_BATCH_SIZE, parallel, aggregated, workerPool, std::move(doneCallback));
     verifier->Start();
 }
 

--- a/src/bls/bls_worker.h
+++ b/src/bls/bls_worker.h
@@ -100,6 +100,9 @@ public:
     // Calculate public key share from public key vector and id. Not parallelized
     static CBLSPublicKey BuildPubKeyShare(const BLSVerificationVectorPtr& vvec, const CBLSId& id);
 
+    // Number of contributions aggregated into one batch by AsyncVerifyContributionShares
+    static constexpr size_t CONTRIBUTION_VERIFY_BATCH_SIZE{8};
+
     // The following functions verify multiple verification vectors and contributions for the same id
     // This is parallelized by performing batched verification. The verification vectors and the contributions of
     // a batch are aggregated (in parallel, see AsyncBuildQuorumVerificationVector and AsyncBuildSecretKeyShare). The

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -515,6 +515,55 @@ BOOST_AUTO_TEST_CASE(bls_verify_contribution_share_null_vvec_tests)
     FuncVerifyContributionShareNullVvec(false);
 }
 
+// Regression: an empty verification-vector set must not break the
+// promise held by AsyncVerifyContributionShares.
+//
+// Pre-fix reproduction (unpatched tree, 2026-07-25):
+//   ./src/test/test_dash --run_test=bls_tests/v022_empty_vvecs_repro
+// with a temporary test that called VerifyContributionShares(validId, {}, {})
+// threw:
+//   std::future_error: "The associated promise has been destructed prior to the
+//   associated state becoming ready." (std::future_errc::broken_promise)
+// In production that exception is thrown from VerifyPendingContributions on the
+// DKG phase-handler thread (NetDKG::PhaseHandlerThread only catches
+// AbortPhaseException), so util::TraceThread rethrows and std::terminate aborts
+// dashd. Sibling helpers AsyncBuildQuorumVerificationVector / AsyncAggregateHelper
+// already short-circuit empty input; this path did not.
+//
+// Post-fix contract: return an empty result vector (no throw).
+void FuncVerifyContributionSharesEmptyVvecs(const bool legacy_scheme)
+{
+    bls::bls_legacy_scheme.store(legacy_scheme);
+
+    CBLSWorker worker;
+    worker.Start(1);
+
+    const CBLSId id{uint256::ONE};
+    BOOST_REQUIRE(id.IsValid());
+
+    std::vector<BLSVerificationVectorPtr> vvecs; // empty
+    std::vector<CBLSSecretKey> skShares;         // empty
+
+    // Must return gracefully (empty result) instead of destroying the promise.
+    const auto result = worker.VerifyContributionShares(id, vvecs, skShares);
+    BOOST_CHECK(result.empty());
+
+    // Same for the non-aggregated path (batchCount default is 1 and would also
+    // schedule zero per-entry work without the empty-input guard).
+    const auto result_no_agg = worker.VerifyContributionShares(id, vvecs, skShares,
+                                                               /*parallel=*/true,
+                                                               /*aggregated=*/false);
+    BOOST_CHECK(result_no_agg.empty());
+
+    worker.Stop();
+}
+
+BOOST_AUTO_TEST_CASE(bls_verify_contribution_shares_empty_vvecs_tests)
+{
+    FuncVerifyContributionSharesEmptyVvecs(true);
+    FuncVerifyContributionSharesEmptyVvecs(false);
+}
+
 // A dummy BLS object that satisfies the minimal interface expected by CBLSLazyWrapper.
 class DummyBLS
 {

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -564,6 +564,95 @@ BOOST_AUTO_TEST_CASE(bls_verify_contribution_shares_empty_vvecs_tests)
     FuncVerifyContributionSharesEmptyVvecs(false);
 }
 
+// Positive control accompanying the empty-input guard: the guard must not
+// change which contributions are ACCEPTED. Accepting an invalid share would
+// corrupt the recovered quorum key; rejecting an honest one would stall DKG.
+// Until now this property was only covered by src/bench/bls_dkg.cpp, which does
+// not run under `make check`, so a regression here was invisible to CI.
+//
+// QUORUM_SIZE is deliberately larger than ContributionVerifier's batch size of 8
+// so that the aggregated path builds more than one batch. Corrupting a share in
+// the first batch only must therefore (a) fail batch verification for that batch
+// and fall back to per-contribution verification, (b) identify exactly the
+// corrupted index, and (c) leave the untouched second batch accepted wholesale.
+// That is the property batch verification could silently break: an invalid share
+// must never be masked by the valid shares it is aggregated with.
+void FuncVerifyContributionSharesHonest(const bool legacy_scheme)
+{
+    bls::bls_legacy_scheme.store(legacy_scheme);
+
+    constexpr size_t QUORUM_SIZE{10}; // > batch size 8, so aggregation uses 2 batches
+    constexpr int THRESHOLD{6};
+
+    CBLSWorker worker;
+    worker.Start(4);
+
+    std::vector<CBLSId> ids;
+    ids.reserve(QUORUM_SIZE);
+    for (const size_t i : util::irange(QUORUM_SIZE)) {
+        uint256 id;
+        WriteLE64(id.begin(), i + 1);
+        ids.emplace_back(id);
+    }
+
+    // Every member runs GenerateContributions and broadcasts its vvec; member i's
+    // share for us (member 0) is skShares[i][0].
+    std::vector<BLSVerificationVectorPtr> vvecs;
+    std::vector<CBLSSecretKey> skContributions;
+    vvecs.reserve(QUORUM_SIZE);
+    skContributions.reserve(QUORUM_SIZE);
+    for ([[maybe_unused]] const size_t i : util::irange(QUORUM_SIZE)) {
+        BLSVerificationVectorPtr vvec;
+        std::vector<CBLSSecretKey> skShares;
+        BOOST_REQUIRE(worker.GenerateContributions(THRESHOLD, ids, vvec, skShares));
+        BOOST_REQUIRE(vvec != nullptr);
+        BOOST_REQUIRE_EQUAL(vvec->size(), size_t(THRESHOLD));
+        BOOST_REQUIRE_EQUAL(skShares.size(), QUORUM_SIZE);
+        vvecs.emplace_back(std::move(vvec));
+        skContributions.emplace_back(skShares[0]); // the share addressed to ids[0]
+    }
+
+    const CBLSId& myId = ids[0];
+
+    // 1. All-honest input must be accepted in full, on both code paths.
+    for (const bool aggregated : {true, false}) {
+        const auto result = worker.VerifyContributionShares(myId, vvecs, skContributions,
+                                                            /*parallel=*/true, aggregated);
+        BOOST_REQUIRE_EQUAL(result.size(), QUORUM_SIZE);
+        for (const size_t i : util::irange(QUORUM_SIZE)) {
+            BOOST_CHECK_MESSAGE(result[i], "honest contribution " << i << " rejected (aggregated="
+                                                                  << aggregated << ")");
+        }
+    }
+
+    // 2. Corrupt one share in the first batch. Batch verification of that batch
+    //    must fail and fall back to per-contribution verification, which must
+    //    blame exactly that index and nobody else. The second batch stays valid.
+    constexpr size_t kBadIdx{3};
+    auto corrupted = skContributions;
+    corrupted[kBadIdx].MakeNewKey(); // valid key, wrong value -> pk mismatch
+
+    for (const bool aggregated : {true, false}) {
+        const auto result = worker.VerifyContributionShares(myId, vvecs, corrupted,
+                                                            /*parallel=*/true, aggregated);
+        BOOST_REQUIRE_EQUAL(result.size(), QUORUM_SIZE);
+        for (const size_t i : util::irange(QUORUM_SIZE)) {
+            const bool expected = (i != kBadIdx);
+            BOOST_CHECK_MESSAGE(result[i] == expected,
+                                "index " << i << " expected " << expected << " got " << result[i]
+                                         << " (aggregated=" << aggregated << ")");
+        }
+    }
+
+    worker.Stop();
+}
+
+BOOST_AUTO_TEST_CASE(bls_verify_contribution_shares_honest_tests)
+{
+    FuncVerifyContributionSharesHonest(true);
+    FuncVerifyContributionSharesHonest(false);
+}
+
 // A dummy BLS object that satisfies the minimal interface expected by CBLSLazyWrapper.
 class DummyBLS
 {

--- a/src/test/bls_tests.cpp
+++ b/src/test/bls_tests.cpp
@@ -515,22 +515,13 @@ BOOST_AUTO_TEST_CASE(bls_verify_contribution_share_null_vvec_tests)
     FuncVerifyContributionShareNullVvec(false);
 }
 
-// Regression: an empty verification-vector set must not break the
-// promise held by AsyncVerifyContributionShares.
-//
-// Pre-fix reproduction (unpatched tree, 2026-07-25):
-//   ./src/test/test_dash --run_test=bls_tests/v022_empty_vvecs_repro
-// with a temporary test that called VerifyContributionShares(validId, {}, {})
-// threw:
-//   std::future_error: "The associated promise has been destructed prior to the
-//   associated state becoming ready." (std::future_errc::broken_promise)
-// In production that exception is thrown from VerifyPendingContributions on the
-// DKG phase-handler thread (NetDKG::PhaseHandlerThread only catches
-// AbortPhaseException), so util::TraceThread rethrows and std::terminate aborts
-// dashd. Sibling helpers AsyncBuildQuorumVerificationVector / AsyncAggregateHelper
-// already short-circuit empty input; this path did not.
-//
-// Post-fix contract: return an empty result vector (no throw).
+// Regression: an empty verification-vector set schedules no work at all, so
+// before the guard nothing ever invoked doneCallback and .get() threw
+// std::future_error(broken_promise). In production that throw escapes
+// VerifyPendingContributions on the DKG phase-handler thread, which only catches
+// AbortPhaseException, and std::terminate aborts dashd.
+// Contract: return an empty result vector, on both the aggregated and the
+// one-by-one path.
 void FuncVerifyContributionSharesEmptyVvecs(const bool legacy_scheme)
 {
     bls::bls_legacy_scheme.store(legacy_scheme);
@@ -548,8 +539,6 @@ void FuncVerifyContributionSharesEmptyVvecs(const bool legacy_scheme)
     const auto result = worker.VerifyContributionShares(id, vvecs, skShares);
     BOOST_CHECK(result.empty());
 
-    // Same for the non-aggregated path (batchCount default is 1 and would also
-    // schedule zero per-entry work without the empty-input guard).
     const auto result_no_agg = worker.VerifyContributionShares(id, vvecs, skShares,
                                                                /*parallel=*/true,
                                                                /*aggregated=*/false);
@@ -564,24 +553,22 @@ BOOST_AUTO_TEST_CASE(bls_verify_contribution_shares_empty_vvecs_tests)
     FuncVerifyContributionSharesEmptyVvecs(false);
 }
 
-// Positive control accompanying the empty-input guard: the guard must not
-// change which contributions are ACCEPTED. Accepting an invalid share would
-// corrupt the recovered quorum key; rejecting an honest one would stall DKG.
-// Until now this property was only covered by src/bench/bls_dkg.cpp, which does
-// not run under `make check`, so a regression here was invisible to CI.
+// Positive control for the empty-input guard: it must not change which
+// contributions are accepted. Accepting an invalid share would corrupt the
+// recovered quorum key; rejecting an honest one would stall DKG. This property
+// was previously only covered by src/bench/bls_dkg.cpp, which does not run under
+// `make check`.
 //
-// QUORUM_SIZE is deliberately larger than ContributionVerifier's batch size of 8
-// so that the aggregated path builds more than one batch. Corrupting a share in
-// the first batch only must therefore (a) fail batch verification for that batch
-// and fall back to per-contribution verification, (b) identify exactly the
-// corrupted index, and (c) leave the untouched second batch accepted wholesale.
-// That is the property batch verification could silently break: an invalid share
-// must never be masked by the valid shares it is aggregated with.
+// QUORUM_SIZE exceeds CONTRIBUTION_VERIFY_BATCH_SIZE so the aggregated path
+// builds more than one batch. Corrupting a share in the first batch must then
+// fail that batch, fall back to per-contribution verification, blame exactly the
+// corrupted index, and leave the second batch accepted wholesale - an invalid
+// share must never be masked by the valid shares it is aggregated with.
 void FuncVerifyContributionSharesHonest(const bool legacy_scheme)
 {
     bls::bls_legacy_scheme.store(legacy_scheme);
 
-    constexpr size_t QUORUM_SIZE{10}; // > batch size 8, so aggregation uses 2 batches
+    constexpr size_t QUORUM_SIZE{CBLSWorker::CONTRIBUTION_VERIFY_BATCH_SIZE + 2};
     constexpr int THRESHOLD{6};
 
     CBLSWorker worker;
@@ -625,19 +612,23 @@ void FuncVerifyContributionSharesHonest(const bool legacy_scheme)
         }
     }
 
-    // 2. Corrupt one share in the first batch. Batch verification of that batch
-    //    must fail and fall back to per-contribution verification, which must
-    //    blame exactly that index and nobody else. The second batch stays valid.
-    constexpr size_t kBadIdx{3};
+    // 2. Corrupt one share and expect exactly that index to be blamed, nobody else.
+    //    With aggregated=true the corrupted index sits in the first batch, so that
+    //    batch must fail and fall back to per-contribution verification while the
+    //    second batch stays accepted wholesale. With aggregated=false there is a
+    //    single batch verified one-by-one, so only the blame-exactness holds.
+    constexpr size_t BAD_IDX{3};
+    static_assert(BAD_IDX < CBLSWorker::CONTRIBUTION_VERIFY_BATCH_SIZE,
+                  "corrupted index must land in the first batch");
     auto corrupted = skContributions;
-    corrupted[kBadIdx].MakeNewKey(); // valid key, wrong value -> pk mismatch
+    corrupted[BAD_IDX].MakeNewKey(); // valid key, wrong value -> pk mismatch
 
     for (const bool aggregated : {true, false}) {
         const auto result = worker.VerifyContributionShares(myId, vvecs, corrupted,
                                                             /*parallel=*/true, aggregated);
         BOOST_REQUIRE_EQUAL(result.size(), QUORUM_SIZE);
         for (const size_t i : util::irange(QUORUM_SIZE)) {
-            const bool expected = (i != kBadIdx);
+            const bool expected{i != BAD_IDX};
             BOOST_CHECK_MESSAGE(result[i] == expected,
                                 "index " << i << " expected " << expected << " got " << result[i]
                                          << " (aggregated=" << aggregated << ")");


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CBLSWorker::AsyncVerifyContributionShares()` terminates the node when handed an empty
verification-vector set.

The path is degenerate rather than obviously wrong, which is why it survives review:

- `VerifyVerificationVectors()` returns `true` for an empty span — its loop body never runs.
- `ContributionVerifier::Start()` then schedules zero work (`batchCount == 0` when aggregated,
  or a zero-length one-by-one batch when not).
- Nothing ever invokes `doneCallback`. No scheduled lambda captured `shared_from_this()`, so
  the `ContributionVerifier` is released as soon as `Start()` returns, the promise held by the
  future-based wrapper is destroyed without `set_value()`, and `.get()` throws
  `std::future_error(broken_promise)`.

The DKG phase handler in `net_dkg.cpp` only catches `AbortPhaseException`, so that throw
propagates out of the phase-handler thread and `std::terminate` aborts the node.

### Reachability

`ActiveDKGSession::VerifyPendingContributions()` is the only caller that can produce an empty
input. It early-returns on `pendingContributionVerifications.empty()`, but then filters the
pending set by `m->bad || m->weComplain`. If every pending member was marked bad between
enqueue and flush — a duplicate contribution triggering `MarkBadMember()` is the way in — the
filtered `vvecs` is empty while the pre-filter check passed.

Getting there is hard, and the constraints are worth spelling out so the severity is not
over-estimated:

- **An attacker can only mark its own masternodes bad.** Message signatures are batch-verified
  (`BatchVerifyMessageSigs`) before `ReceiveMessage()` runs, so the duplicate contribution that
  triggers `MarkBadMember()` must be validly signed by that member's own operator key. Honest
  members cannot be poisoned into the bad set.
- **Our own contribution is always in the pending list.** `EnqueueOwn()` feeds the local
  contribution through the same `ReceiveMessage()` path at the start of the contribute phase,
  and we never mark ourselves bad. The filtered set can therefore only be empty if the
  32-entry flush inside `ReceiveMessage()` already cleared our own entry — i.e. the node must
  have accepted at least 33 contributions.
- That rules out every quorum smaller than 33 outright: all test/devnet params and
  `llmq_25_67` cannot reach this code path at all. Only sizes 50/60/100/400 are candidates,
  and there an attacker additionally has to place its members entirely in the post-flush tail
  (`N - t ≡ 0 mod 32` → 18/50, 28/60, 4/100, 16/400 members) while winning an ordering race
  against state it cannot directly observe.
- The 32-entry flush path cannot produce the empty case by itself: each member enqueues at
  most once, and the flush fires synchronously on the 32nd enqueue, so the just-enqueued
  member is never bad at that instant. Only the `VerifyAndComplain()` call can observe an
  all-bad pending set.

The practical reading: this is defensive hardening of a crash path, not a readily exploitable
DoS. It is still a `std::terminate` reachable from network input, the guard costs three lines,
and the same degenerate input will bite the next caller that shows up.

Note that the reachability constraints above are also why no existing test caught this — the
functional-test quorums are far too small to ever flush the pending set.

## What was done?

Two commits, at two layers:

1. **`CBLSWorker::AsyncVerifyContributionShares()`** short-circuits on empty input and
   invokes `doneCallback` with an empty result. This mirrors the empty-input handling that
   `AsyncBuildQuorumVerificationVector()` and `AsyncAggregateHelper()` already have, so the
   worker API is now consistent about degenerate input.

2. **`ActiveDKGSession::VerifyPendingContributions()`** skips the worker call entirely when
   the post-filter member set is empty, rather than relying on the guard above. This avoids a
   pointless async round-trip and keeps the call site correct on its own terms.

The first commit is the fix; the second is defence in depth.

## How Has This Been Tested?

Unit tests in `src/test/bls_tests.cpp`:

- `bls_verify_contribution_shares_empty_vvecs_tests` — without the fix this fails with
  `std::future_error: The associated promise has been destructed prior to the associated
  state becoming ready.`, the exact production failure. With the fix it returns an empty
  result on both the aggregated and non-aggregated paths.
- `bls_verify_contribution_shares_honest_tests` — asserts that acceptance behaviour for
  non-empty input is unchanged, so the guard cannot mask a real verification failure. The
  quorum size (10) is deliberately larger than `ContributionVerifier`'s batch size of 8, so
  corrupting one share in the first batch must fail that batch, fall back to per-contribution
  verification, blame exactly the corrupted index, and leave the second batch accepted
  wholesale. That property previously had no coverage under `make check` at all — only
  `src/bench/bls_dkg.cpp` exercised it, and benches do not run in CI.

Full `bls_tests` suite passes. Built and run on macOS/arm64 against current `develop`.

## Breaking Changes

None. The change only affects an input shape that previously terminated the process.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
