### PR TITLE
fix: bound DomainPort string deserialization and stop swallowing deser failures

### DIFF
--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -20,8 +20,6 @@ static std::once_flag g_main_params_flag;
 
 /** Maximum length of a label in a domain per RFC 1035 */
 static constexpr uint8_t DOMAIN_LABEL_MAX_LEN{63};
-/** Maximum possible length of a ASCII FQDN */
-static constexpr uint8_t DOMAIN_MAX_LEN{253};
 /** Minimum length of a FQDN */
 static constexpr uint8_t DOMAIN_MIN_LEN{3};
 

--- a/src/evo/netinfo.h
+++ b/src/evo/netinfo.h
@@ -19,6 +19,11 @@ class UniValue;
 /** Maximum entries that can be stored in an ExtNetInfo per purpose code */
 static constexpr uint8_t MAX_ENTRIES_EXTNETINFO{4};
 
+/** Maximum possible length of an ASCII FQDN (RFC 1035). Applied at the
+ *  serialization layer so oversized CompactSize claims are rejected before
+ *  allocate-and-zero; ValidateDomain enforces the same ceiling after decode. */
+static constexpr size_t DOMAIN_MAX_LEN{253};
+
 enum class NetInfoStatus : uint8_t {
     // Managing entries
     BadInput,
@@ -170,7 +175,7 @@ public:
 
     SERIALIZE_METHODS(DomainPort, obj)
     {
-        READWRITE(obj.m_addr);
+        READWRITE(LIMITED_STRING(obj.m_addr, DOMAIN_MAX_LEN));
         READWRITE(Using<BigEndianFormatter<2>>(obj.m_port));
     }
 
@@ -246,11 +251,14 @@ public:
                 if (!service.IsValid()) { Clear(); } // Invalid CService, mark as invalid
             } catch (const std::ios_base::failure&) { Clear(); } // Deser failed, mark as invalid
         } else if (m_type == NetInfoType::Domain) {
-            try {
-                auto& domain{m_data.emplace<DomainPort>()};
-                s >> domain;
-                if (!domain.IsValid()) { Clear(); } // Invalid DomainPort, mark as invalid
-            } catch (const std::ios_base::failure&) { Clear(); } // Deser failed, mark as invalid
+            // Do not swallow deserialization failures: a short/oversized domain
+            // body would otherwise leave the stream position unmoved (or only
+            // advanced by CompactSize) while the enclosing vector loop continues,
+            // amplifying a few attacker bytes into repeated allocations.
+            // Propagate ios_base::failure so the whole ProTx payload is rejected.
+            auto& domain{m_data.emplace<DomainPort>()};
+            s >> domain;
+            if (!domain.IsValid()) { Clear(); } // Invalid DomainPort, mark as invalid
         } else { Clear(); } // Invalid type code, mark as invalid
     }
 

--- a/src/test/evo_netinfo_tests.cpp
+++ b/src/test/evo_netinfo_tests.cpp
@@ -497,6 +497,92 @@ BOOST_AUTO_TEST_CASE(domainport_rules)
     }
 }
 
+// DomainPort used a bare std::string unserialize path (bounded only by
+// MAX_SIZE == 32 MiB) and NetInfoEntry::Unserialize swallowed ios_base::failure.
+// That combination allowed a tiny ProTx ExtNetInfo payload to force repeated
+// allocate-and-zero of multi-megabyte strings. These tests pin the serialization
+// layer to reject oversized domain claims without performing the large allocation.
+static CDataStream MakeOversizedDomainPortStream(const size_t claimed_len)
+{
+    CDataStream ds(SER_DISK, CLIENT_VERSION);
+    WriteCompactSize(ds, claimed_len);
+    // Provide a full body so pre-fix code can complete the string read; the
+    // bound must reject based on the CompactSize alone, not on a short read.
+    const std::string body(claimed_len, 'a');
+    if (!body.empty()) {
+        ds.write(MakeByteSpan(body));
+    }
+    ser_writedata16be(ds, 443);
+    return ds;
+}
+
+BOOST_AUTO_TEST_CASE(domainport_deser_rejects_oversized_string)
+{
+    // DOMAIN_MAX_LEN is 253; a fully-formed 1000-byte domain must be rejected at
+    // deserialization time (LIMITED_STRING), not accepted then failed later in
+    // ValidateDomain.
+    constexpr size_t kOversized{1000};
+    CDataStream ds{MakeOversizedDomainPortStream(kOversized)};
+
+    DomainPort domain;
+    BOOST_CHECK_THROW(ds >> domain, std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(netinfoentry_domain_deser_rejects_oversized_string)
+{
+    // NetInfoEntry must not swallow the length-limit failure: rethrow so the
+    // enclosing ProTx payload deserialization aborts and the peer is penalised.
+    constexpr size_t kOversized{1000};
+    CDataStream ds(SER_DISK, CLIENT_VERSION);
+    ds << uint8_t{NetInfoEntry::NetInfoType::Domain};
+    {
+        CDataStream body{MakeOversizedDomainPortStream(kOversized)};
+        ds.write(MakeByteSpan(body));
+    }
+
+    NetInfoEntry entry;
+    BOOST_CHECK_THROW(ds >> entry, std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(domainport_deser_rejects_huge_claimed_length)
+{
+    // CompactSize claims 1 MiB with no body. Pre-fix this would allocate 1 MiB
+    // then throw on short-read; post-fix LIMITED_STRING rejects before resize.
+    // Either way the operation must throw; the important property is that a
+    // declared length above DOMAIN_MAX_LEN never produces a successful DomainPort.
+    CDataStream ds(SER_DISK, CLIENT_VERSION);
+    WriteCompactSize(ds, size_t{1} << 20);
+
+    DomainPort domain;
+    BOOST_CHECK_THROW(ds >> domain, std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(extnetinfo_domain_amplification_rejected)
+{
+    // Simulate the attack shape: ExtNetInfo vector of Domain entries each
+    // claiming a large string length from a small stream. Pre-fix,
+    // NetInfoEntry swallows the short-read and the vector loop continues
+    // (stream position does not advance on the failed body read), producing
+    // repeated large allocations. Post-fix the first oversized claim throws
+    // and aborts the whole ExtNetInfo unserialize.
+    constexpr size_t kClaimed{1 << 16}; // 64 KiB — large enough to prove, small enough to not OOM pre-fix
+    constexpr size_t kEntries{8};
+
+    CDataStream ds(SER_DISK, CLIENT_VERSION);
+    ds << uint8_t{1}; // ExtNetInfo version
+    WriteCompactSize(ds, 1); // one purpose
+    ds << NetInfoPurpose::PLATFORM_HTTPS;
+    WriteCompactSize(ds, kEntries);
+    for (size_t i = 0; i < kEntries; ++i) {
+        ds << uint8_t{NetInfoEntry::NetInfoType::Domain};
+        // Claim kClaimed bytes but supply none — CompactSize only.
+        WriteCompactSize(ds, kClaimed);
+    }
+
+    ExtNetInfo netInfo;
+    BOOST_CHECK_THROW(ds >> netInfo, std::ios_base::failure);
+}
+
 BOOST_FIXTURE_TEST_CASE(extnetinfo_validate_deser, RegTestingSetup)
 {
     // The in-memory builder (AddEntry/ProcessCandidate) refuses duplicates, domains


### PR DESCRIPTION
## Issue being fixed or feature implemented

`DomainPort` deserializes an unbounded `std::string`, and `NetInfoEntry::Unserialize()`
swallows the resulting `ios_base::failure`. Together these give a large allocate-and-zero
amplification factor from a small ProTx payload.

Mechanism:

- `DomainPort`'s serializer reads `m_addr` as a plain `std::string`, so an attacker-chosen
  `CompactSize` drives `resize()` before any length check. `ValidateDomain()` enforces the
  253-byte RFC 1035 ceiling, but only *after* the allocation has already happened.
- When the body is short or oversized and deserialization throws, `NetInfoEntry::Unserialize()`
  catches `ios_base::failure` and calls `Clear()`. The stream position is left unmoved (or
  advanced only by the `CompactSize`), so the enclosing vector loop keeps going and repeats
  the allocation.

The result is that a few attacker-controlled bytes turn into repeated multi-megabyte
allocate-and-zero cycles while the payload is parsed.

## What was done?

- `DomainPort`'s serializer now uses `LIMITED_STRING(obj.m_addr, DOMAIN_MAX_LEN)`, so an
  oversized `CompactSize` claim is rejected *before* `resize()` rather than after.
  `LimitedStringFormatter` checks the length and throws without allocating.
- `DOMAIN_MAX_LEN` moved from `netinfo.cpp` to `netinfo.h` (and `uint8_t` → `size_t` for the
  template parameter) so the serialization layer and `ValidateDomain()` share one constant
  and cannot drift apart.
- The `Domain` branch of `NetInfoEntry::Unserialize()` no longer swallows
  `ios_base::failure`. It propagates, so a malformed domain entry rejects the whole ProTx
  payload instead of leaving the stream desynchronised for the rest of the loop.

The `Service` branch deliberately still catches. A `CService` is fixed-size, so a malformed
one cannot desynchronise the stream or amplify allocation — there is nothing to defend
against there, and changing it would alter behaviour for no benefit.

### Note on deployment status

This tightens a serialization rule, so the natural question is whether it needs gating.
It does not: `DEPLOYMENT_V24` is `NEVER_ACTIVE` on both mainnet (`chainparams.cpp:213`) and
testnet (`chainparams.cpp:415`), so `ExtNetInfo` — and therefore `DomainPort` — cannot
appear in any mainnet or testnet chain data. There is nothing already mined for the stricter
rule to retroactively invalidate.

## How Has This Been Tested?

Unit tests in `src/test/evo_netinfo_tests.cpp`, added in the commit *preceding* the fix:

- `domainport_deser_rejects_oversized_string`
- `netinfoentry_domain_deser_rejects_oversized_string`
- `extnetinfo_domain_amplification_rejected`

Without the fix all three fail with `exception std::ios_base::failure expected but not
raised`. With the fix the full `evo_netinfo_tests` suite passes (14 cases), confirming
well-formed domains up to the 253-byte ceiling still round-trip.

Built and run on macOS/arm64 against current `develop`.

## Breaking Changes

None reachable on mainnet or testnet, per the deployment note above. On devnet/regtest,
a ProTx carrying a domain entry longer than 253 bytes is now rejected at deserialization
instead of being cleared and then rejected by netinfo validation — same outcome, earlier
and cheaper.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
