### PR TITLE
docs: clarify comment style and commit bisectability guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,10 @@ changes, update the other in the same commit.
   the tree during merge.
 - Do not edit generated release artifacts, Guix/release files, vendored code, or
   translations unless the task is specifically about those files.
+- Code should be readable on its own. Needing a significant comment usually
+  means the code itself should be clearer. Avoid comments that restate the
+  code; reserve them for things that genuinely need explaining (non-obvious
+  invariants, workaround rationale, non-local side effects).
 
 ## Repository Map
 
@@ -172,9 +176,13 @@ For these areas, prefer small tests that prove the invariant being changed.
 
 ## PR Hygiene
 
-- Use atomic commits. Each commit should build and make sense on its own.
+- Use atomic commits. Each commit should make sense on its own and generally
+  build and pass tests. An intentionally non-building commit (e.g. a
+  regression test landing before its fix) is fine if called out explicitly so
+  it isn't mistaken for an oversight.
 - PR titles follow Conventional Commits, including `backport:` for Bitcoin Core
-  backports.
+  backports. Valid types/scopes are enforced by CI; see
+  `.github/workflows/semantic-pull-request.yml`.
 - PR descriptions must follow `.github/PULL_REQUEST_TEMPLATE.md`: remove the
   italicized helper prompts, fill in the required sections, and keep the
   checklist accurate for the change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ changes, update the other in the same commit.
   the tree during merge.
 - Do not edit generated release artifacts, Guix/release files, vendored code, or
   translations unless the task is specifically about those files.
+- Code should be readable on its own. Needing a significant comment usually
+  means the code itself should be clearer. Avoid comments that restate the
+  code; reserve them for things that genuinely need explaining (non-obvious
+  invariants, workaround rationale, non-local side effects).
 
 ## Repository Map
 
@@ -172,9 +176,13 @@ For these areas, prefer small tests that prove the invariant being changed.
 
 ## PR Hygiene
 
-- Use atomic commits. Each commit should build and make sense on its own.
+- Use atomic commits. Each commit should make sense on its own and generally
+  build and pass tests. An intentionally non-building commit (e.g. a
+  regression test landing before its fix) is fine if called out explicitly so
+  it isn't mistaken for an oversight.
 - PR titles follow Conventional Commits, including `backport:` for Bitcoin Core
-  backports.
+  backports. Valid types/scopes are enforced by CI; see
+  `.github/workflows/semantic-pull-request.yml`.
 - PR descriptions must follow `.github/PULL_REQUEST_TEMPLATE.md`: remove the
   italicized helper prompts, fill in the required sections, and keep the
   checklist accurate for the change.


### PR DESCRIPTION
## Issue being fixed or feature being added
Agent guidance in `CLAUDE.md`/`AGENTS.md` didn't address comment verbosity, allow non-building commits (e.g. a regression test before its fix), or point at the CI check that validates PR titles.

## What was done
- Added guidance that code should be readable on its own; comments shouldn't restate the code and are reserved for things that genuinely need explaining.
- Relaxed the atomic-commit rule: commits should generally build and pass tests, but an intentionally non-building commit is fine if called out explicitly.
- Pointed the PR-title rule at `.github/workflows/semantic-pull-request.yml`, which enforces the valid Conventional Commit types/scopes.
- Kept `CLAUDE.md` and `AGENTS.md` in sync as required.

## How Has This Been Tested
Docs-only change; diffed the two files to confirm they still match.

## Breaking Changes
None.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone