### PR TITLE
fix: invalidate CbTx quorum hash caches when mined commitments change

### DIFF
--- a/src/evo/cbtx.cpp
+++ b/src/evo/cbtx.cpp
@@ -46,68 +46,8 @@ bool CheckCbTx(const CCbTx& cbTx, const CBlockIndex* pindexPrev, TxValidationSta
     return true;
 }
 
-using QcHashMap = std::map<Consensus::LLMQType, std::vector<uint256>>;
-using QcIndexedHashMap = std::map<Consensus::LLMQType, std::map<int16_t, uint256>>;
-
-/**
- * Handles the calculation or caching of qcHashes and qcIndexedHashes
- * @param pindexPrev The const CBlockIndex* (ie a block) of a block. Both the Quorum list and quorum rotation activation status will be retrieved based on this block.
- * @return nullopt if quorumCommitment was unable to be found, otherwise returns the qcHashes and qcIndexedHashes that were calculated or cached
- */
-auto CachedGetQcHashesQcIndexedHashes(const CBlockIndex* pindexPrev, const llmq::CQuorumBlockProcessor& quorum_block_processor) ->
-        std::optional<std::pair<QcHashMap /*qcHashes*/, QcIndexedHashMap /*qcIndexedHashes*/>> {
-    auto quorums = quorum_block_processor.GetMinedAndActiveCommitmentsUntilBlock(pindexPrev);
-
-    static Mutex cs_cache;
-    static std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> quorums_cached GUARDED_BY(cs_cache);
-    static std::map<Consensus::LLMQType, Uint256LruHashMap<std::pair<uint256, int>>> qc_hashes_cached GUARDED_BY(cs_cache);
-    static QcHashMap qcHashes_cached GUARDED_BY(cs_cache);
-    static QcIndexedHashMap qcIndexedHashes_cached GUARDED_BY(cs_cache);
-
-    LOCK(cs_cache);
-    if (quorums == quorums_cached) {
-        return std::make_pair(qcHashes_cached, qcIndexedHashes_cached);
-    }
-
-    // Quorums set is different, reset cached values
-    quorums_cached.clear();
-    qcHashes_cached.clear();
-    qcIndexedHashes_cached.clear();
-    if (qc_hashes_cached.empty()) {
-        llmq::utils::InitQuorumsCache(qc_hashes_cached, Params().GetConsensus());
-    }
-
-    for (const auto& [llmqType, vecBlockIndexes] : quorums) {
-        const auto& llmq_params_opt = Params().GetLLMQ(llmqType);
-        assert(llmq_params_opt.has_value());
-        bool rotation_enabled = llmq::IsQuorumRotationEnabled(llmq_params_opt.value(), pindexPrev);
-        auto& vec_hashes = qcHashes_cached[llmqType];
-        vec_hashes.reserve(vecBlockIndexes.size());
-        auto& map_indexed_hashes = qcIndexedHashes_cached[llmqType];
-        for (const auto& blockIndex : vecBlockIndexes) {
-            uint256 block_hash{blockIndex->GetBlockHash()};
-
-            std::pair<uint256, int> qc_hash;
-            if (!qc_hashes_cached[llmqType].get(block_hash, qc_hash)) {
-                auto [pqc, dummy_hash] = quorum_block_processor.GetMinedCommitment(llmqType, block_hash);
-                if (dummy_hash == uint256::ZERO) {
-                    // this should never happen
-                    return std::nullopt;
-                }
-                qc_hash.first = ::SerializeHash(pqc);
-                qc_hash.second = rotation_enabled ? pqc.quorumIndex : 0;
-                qc_hashes_cached[llmqType].insert(block_hash, qc_hash);
-            }
-            if (rotation_enabled) {
-                map_indexed_hashes[qc_hash.second] = qc_hash.first;
-            } else {
-                vec_hashes.emplace_back(qc_hash.first);
-            }
-        }
-    }
-    std::swap(quorums_cached, quorums);
-    return std::make_pair(qcHashes_cached, qcIndexedHashes_cached);
-}
+using llmq::QcHashMap;
+using llmq::QcIndexedHashMap;
 
 auto CalcHashCountFromQCHashes(const QcHashMap& qcHashes)
 {
@@ -124,7 +64,7 @@ bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPre
 
     int64_t nTime1 = GetTimeMicros();
 
-    auto retVal = CachedGetQcHashesQcIndexedHashes(pindexPrev, quorum_block_processor);
+    auto retVal = quorum_block_processor.GetQcHashes(pindexPrev);
     if (!retVal) {
         return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "commitment-not-found");
     }
@@ -132,7 +72,7 @@ bool CalcCbTxMerkleRootQuorums(const CBlock& block, const CBlockIndex* pindexPre
     auto [qcHashes, qcIndexedHashes] = retVal.value();
 
     int64_t nTime2 = GetTimeMicros(); nTimeMined += nTime2 - nTime1;
-    LogPrint(BCLog::BENCHMARK, "            - CachedGetQcHashesQcIndexedHashes: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeMined * 0.000001);
+    LogPrint(BCLog::BENCHMARK, "            - GetQcHashes: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeMined * 0.000001);
 
     // now add the commitments from the current block, which are not returned by GetMinedAndActiveCommitmentsUntilBlock
     // due to the use of pindexPrev (we don't have the tip index here)

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -367,6 +367,11 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
         m_evoDb.Write(BuildInversedHeightKey(llmq_params.type, nHeight), pQuorumBaseBlockIndex->nHeight);
     }
 
+    // Only once this commitment's state change is complete, so the caches can never be
+    // repopulated from a half-updated view. Callers all hold cs_main today, but the
+    // invalidation should not depend on that.
+    DropQcHashesCache();
+
     {
         LOCK(minableCommitmentsCs);
         mapHasMinedCommitmentCache[qc.llmqType].erase(qc.quorumHash);
@@ -378,6 +383,68 @@ bool CQuorumBlockProcessor::ProcessCommitment(int nHeight, const uint256& blockH
              std23::to_underlying(qc.llmqType), qc.quorumIndex, quorumHash.ToString());
 
     return true;
+}
+
+void CQuorumBlockProcessor::DropQcHashesCache()
+{
+    LOCK(m_qc_hashes_cache_mutex);
+    m_quorums_cached.clear();
+    m_qc_hashes_cached.clear();
+    m_qc_indexed_hashes_cached.clear();
+    // Clear per-type LRU contents but keep the map entries so InitQuorumsCache is not
+    // required on every subsequent miss.
+    for (auto& [_, cache] : m_qc_hashes_lru) {
+        cache.clear();
+    }
+}
+
+std::optional<std::pair<QcHashMap, QcIndexedHashMap>> CQuorumBlockProcessor::GetQcHashes(const CBlockIndex* pindexPrev) const
+{
+    auto quorums = GetMinedAndActiveCommitmentsUntilBlock(pindexPrev);
+
+    LOCK(m_qc_hashes_cache_mutex);
+    if (quorums == m_quorums_cached) {
+        return std::make_pair(m_qc_hashes_cached, m_qc_indexed_hashes_cached);
+    }
+
+    // Quorums set is different, reset cached values
+    m_quorums_cached.clear();
+    m_qc_hashes_cached.clear();
+    m_qc_indexed_hashes_cached.clear();
+    if (m_qc_hashes_lru.empty()) {
+        utils::InitQuorumsCache(m_qc_hashes_lru, Params().GetConsensus());
+    }
+
+    for (const auto& [llmqType, vecBlockIndexes] : quorums) {
+        const auto& llmq_params_opt = Params().GetLLMQ(llmqType);
+        assert(llmq_params_opt.has_value());
+        bool rotation_enabled = IsQuorumRotationEnabled(llmq_params_opt.value(), pindexPrev);
+        auto& vec_hashes = m_qc_hashes_cached[llmqType];
+        vec_hashes.reserve(vecBlockIndexes.size());
+        auto& map_indexed_hashes = m_qc_indexed_hashes_cached[llmqType];
+        for (const auto& blockIndex : vecBlockIndexes) {
+            uint256 block_hash{blockIndex->GetBlockHash()};
+
+            std::pair<uint256, int> qc_hash;
+            if (!m_qc_hashes_lru[llmqType].get(block_hash, qc_hash)) {
+                auto [pqc, dummy_hash] = GetMinedCommitment(llmqType, block_hash);
+                if (dummy_hash == uint256::ZERO) {
+                    // this should never happen
+                    return std::nullopt;
+                }
+                qc_hash.first = ::SerializeHash(pqc);
+                qc_hash.second = rotation_enabled ? pqc.quorumIndex : 0;
+                m_qc_hashes_lru[llmqType].insert(block_hash, qc_hash);
+            }
+            if (rotation_enabled) {
+                map_indexed_hashes[qc_hash.second] = qc_hash.first;
+            } else {
+                vec_hashes.emplace_back(qc_hash.first);
+            }
+        }
+    }
+    std::swap(m_quorums_cached, quorums);
+    return std::make_pair(m_qc_hashes_cached, m_qc_indexed_hashes_cached);
 }
 
 bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex)
@@ -407,6 +474,9 @@ bool CQuorumBlockProcessor::UndoBlock(const CBlock& block, gsl::not_null<const C
         } else {
             m_evoDb.Erase(BuildInversedHeightKey(qc.llmqType, pindex->nHeight));
         }
+
+        // Only once this commitment's state change is complete; see ProcessCommitment.
+        DropQcHashesCache();
 
         WITH_LOCK(minableCommitmentsCs, mapHasMinedCommitmentCache[qc.llmqType].erase(qc.quorumHash));
 

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -38,6 +38,11 @@ namespace llmq
 class CFinalCommitment;
 class CQuorumSnapshotManager;
 
+//! Serialized hashes of the commitments mined for the active quorums, by LLMQ type.
+using QcHashMap = std::map<Consensus::LLMQType, std::vector<uint256>>;
+//! As above, but keyed by quorumIndex, for rotation-enabled types.
+using QcIndexedHashMap = std::map<Consensus::LLMQType, std::map<int16_t, uint256>>;
+
 class CQuorumBlockProcessor
 {
 private:
@@ -54,6 +59,18 @@ private:
 
     mutable std::map<Consensus::LLMQType, Uint256LruHashMap<bool>> mapHasMinedCommitmentCache GUARDED_BY(minableCommitmentsCs);
 
+    // Memoizes GetQcHashes(). The whole-result cache is keyed on the set of active
+    // quorum base blocks, the LRU on those base-block hashes; neither key identifies
+    // which CFinalCommitment was mined for a base, so both are dropped whenever mined
+    // commitment state changes (see DropQcHashesCache). Owning them here keeps that
+    // invalidation next to the writes it has to follow, and ties their lifetime to the
+    // block index whose CBlockIndex* the outer cache stores.
+    mutable Mutex m_qc_hashes_cache_mutex;
+    mutable std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> m_quorums_cached GUARDED_BY(m_qc_hashes_cache_mutex);
+    mutable std::map<Consensus::LLMQType, Uint256LruHashMap<std::pair<uint256, int>>> m_qc_hashes_lru GUARDED_BY(m_qc_hashes_cache_mutex);
+    mutable QcHashMap m_qc_hashes_cached GUARDED_BY(m_qc_hashes_cache_mutex);
+    mutable QcIndexedHashMap m_qc_indexed_hashes_cached GUARDED_BY(m_qc_hashes_cache_mutex);
+
 public:
     CQuorumBlockProcessor() = delete;
     CQuorumBlockProcessor(const CQuorumBlockProcessor&) = delete;
@@ -66,9 +83,9 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!minableCommitmentsCs);
 
     bool ProcessBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, BlockValidationState& state,
-                      bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs);
+                      bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs, !m_qc_hashes_cache_mutex);
     bool UndoBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex)
-        EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs);
+        EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs, !m_qc_hashes_cache_mutex);
 
     //! it returns hash of commitment if it should be relay, otherwise nullopt
     std::optional<CInv> AddMineableCommitment(const CFinalCommitment& fqc) EXCLUSIVE_LOCKS_REQUIRED(!minableCommitmentsCs);
@@ -84,6 +101,15 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(!minableCommitmentsCs);
     std::pair<CFinalCommitment, uint256> GetMinedCommitment(Consensus::LLMQType llmqType, const uint256& quorumHash) const;
 
+    /**
+     * Serialized hashes of the commitments mined for the quorums active as of pindexPrev.
+     *
+     * Memoized; returns nullopt if a commitment recorded as mined could not be read back,
+     * which should never happen.
+     */
+    std::optional<std::pair<QcHashMap, QcIndexedHashMap>> GetQcHashes(const CBlockIndex* pindexPrev) const
+        EXCLUSIVE_LOCKS_REQUIRED(!m_qc_hashes_cache_mutex);
+
     std::vector<const CBlockIndex*> GetMinedCommitmentsUntilBlock(Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindex, size_t maxCount) const;
     std::map<Consensus::LLMQType, std::vector<const CBlockIndex*>> GetMinedAndActiveCommitmentsUntilBlock(gsl::not_null<const CBlockIndex*> pindex) const;
 
@@ -93,9 +119,12 @@ public:
                                                                                     size_t cycle) const;
     std::optional<const CBlockIndex*> GetLastMinedCommitmentsByQuorumIndexUntilBlock(Consensus::LLMQType llmqType, const CBlockIndex* pindex, int quorumIndex, size_t cycle) const;
 private:
+    //! Called from every site that writes or erases mined commitment state.
+    void DropQcHashesCache() EXCLUSIVE_LOCKS_REQUIRED(!m_qc_hashes_cache_mutex);
+
     static bool GetCommitmentsFromBlock(const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, std::multimap<Consensus::LLMQType, CFinalCommitment>& ret, BlockValidationState& state) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool ProcessCommitment(int nHeight, const uint256& blockHash, const CFinalCommitment& qc, BlockValidationState& state,
-                           bool fJustCheck) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs);
+                           bool fJustCheck) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs, !m_qc_hashes_cache_mutex);
     size_t GetNumCommitmentsRequired(const Consensus::LLMQParams& llmqParams, int nHeight) const
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs);
     static uint256 GetQuorumBlockHash(const Consensus::LLMQParams& llmqParams, const CChain& active_chain, int nHeight, int quorumIndex) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/src/test/evo_cbtx_tests.cpp
+++ b/src/test/evo_cbtx_tests.cpp
@@ -2,24 +2,41 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <test/util/llmq_tests.h>
 #include <test/util/setup_common.h>
 
 #include <bls/bls.h>
 #include <chain.h>
 #include <chainlock/chainlock.h>
 #include <chainparams.h>
+#include <compat/endian.h>
+#include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <evo/cbtx.h>
+#include <evo/evodb.h>
+#include <evo/specialtx.h>
 #include <evo/specialtxman.h>
+#include <hash.h>
+#include <llmq/blockprocessor.h>
+#include <llmq/commitment.h>
 #include <llmq/context.h>
-#include <llmq/quorumsman.h>
+#include <llmq/params.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
 #include <uint256.h>
 #include <validation.h>
 
 #include <cstdint>
 #include <limits>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
+
+using namespace llmq;
+using namespace llmq::testutils;
 
 BOOST_AUTO_TEST_SUITE(evo_cbtx_tests)
 
@@ -65,6 +82,140 @@ BOOST_FIXTURE_TEST_CASE(check_cbtx_best_chainlock_rejects_excessive_height_diff,
     BlockValidationState state_big;
     BOOST_CHECK(!CheckCbTxBestChainlock(cbTx, &pindex, consensus_params, chain, qman, chainlocks, state_big));
     BOOST_CHECK_EQUAL(state_big.GetRejectReason(), "bad-cbtx-cldiff");
+}
+
+namespace {
+// Mirrors private DB keys in llmq/blockprocessor.cpp so tests can install
+// mined-commitment state without a full DKG/mining path.
+static const std::string DB_MINED_COMMITMENT = "q_mc";
+static const std::string DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT = "q_mcih";
+
+std::tuple<std::string, Consensus::LLMQType, uint32_t> BuildInversedHeightKey(Consensus::LLMQType llmqType, int nMinedHeight)
+{
+    return std::make_tuple(DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT, llmqType,
+                           htobe32_internal(std::numeric_limits<uint32_t>::max() - nMinedHeight));
+}
+
+// Store a mined commitment as if it was mined at `mined_height` for the genesis
+// quorum base (quorumHeight 0). GetMinedCommitmentsUntilBlock iterates inverted-
+// height keys in [pindex->nHeight, 0), so scan height must be >= mined_height
+// and mined_height must be > 0 for the entry to be returned.
+void WriteMinedCommitment(CEvoDB& evoDb, const CFinalCommitment& qc, const uint256& mined_block_hash, int mined_height)
+{
+    assert(mined_height > 0);
+    evoDb.Write(std::make_pair(DB_MINED_COMMITMENT, std::make_pair(qc.llmqType, qc.quorumHash)),
+                std::make_pair(qc, mined_block_hash));
+    evoDb.Write(BuildInversedHeightKey(qc.llmqType, mined_height), /*quorumHeight=*/0);
+}
+
+CTransactionRef MakeCommitmentTx(const CFinalCommitment& qc, int height)
+{
+    CFinalCommitmentTxPayload payload;
+    payload.nHeight = height;
+    payload.commitment = qc;
+
+    CMutableTransaction tx;
+    tx.nVersion = 3;
+    tx.nType = TRANSACTION_QUORUM_COMMITMENT;
+    SetTxPayload(tx, payload);
+    return MakeTransactionRef(std::move(tx));
+}
+
+uint256 CalcQuorumMerkleRootForCommitment(const CFinalCommitment& qc)
+{
+    std::vector<uint256> hashes{::SerializeHash(qc)};
+    bool mutated{false};
+    return ComputeMerkleRoot(hashes, &mutated);
+}
+
+CFinalCommitment MakeDistinctCommitment(const Consensus::LLMQParams& params, const uint256& quorum_hash, uint8_t salt)
+{
+    CFinalCommitment qc = CreateValidCommitment(params, quorum_hash);
+    // Force a deterministic difference even if random BLS material collides.
+    qc.quorumVvecHash = uint256{std::vector<unsigned char>(32, salt)};
+    return qc;
+}
+
+CBlock MakeEmptyBlock()
+{
+    CBlock block;
+    block.vtx.emplace_back(MakeTransactionRef(CMutableTransaction{}));
+    return block;
+}
+
+void ExpectQuorumMerkleRoot(const CBlock& block, const CBlockIndex* pindex, const CQuorumBlockProcessor& qblockman,
+                            const CFinalCommitment& qc)
+{
+    uint256 merkle_root;
+    BlockValidationState state;
+    BOOST_REQUIRE(CalcCbTxMerkleRootQuorums(block, pindex, qblockman, merkle_root, state));
+    BOOST_CHECK_EQUAL(merkle_root.ToString(), CalcQuorumMerkleRootForCommitment(qc).ToString());
+}
+
+const CBlockIndex* GenesisIndex(const node::NodeContext& node)
+{
+    LOCK(cs_main);
+    return node.chainman->ActiveChain()[0];
+}
+} // anonymous namespace
+
+// Activate DIP0003 immediately so GetCommitmentsFromBlock accepts the payload
+// at a low height without a long fake chain.
+struct Dip3ActiveSetup : public RegTestingSetup {
+    Dip3ActiveSetup() :
+        RegTestingSetup({"-dip3params=1:1"})
+    {
+    }
+};
+
+// End to end: disconnecting the block that mined a commitment must make a replacement
+// commitment for the same quorum base visible, even though the active base-block list
+// that keys the caches is unchanged across the swap.
+BOOST_FIXTURE_TEST_CASE(qc_hash_cache_invalidated_by_undoblock, Dip3ActiveSetup)
+{
+    auto& evoDb = *Assert(m_node.evodb);
+    auto& qblockman = *Assert(m_node.llmq_ctx)->quorum_block_processor;
+    const auto& params = GetLLMQParams(Consensus::LLMQType::LLMQ_TEST);
+
+    const CBlockIndex* pindex_genesis = GenesisIndex(m_node);
+    BOOST_REQUIRE(pindex_genesis != nullptr);
+    const uint256 quorum_hash = pindex_genesis->GetBlockHash();
+
+    const CFinalCommitment qc_a = MakeDistinctCommitment(params, quorum_hash, /*salt=*/0x33);
+    const CFinalCommitment qc_b = MakeDistinctCommitment(params, quorum_hash, /*salt=*/0x44);
+    BOOST_REQUIRE(::SerializeHash(qc_a) != ::SerializeHash(qc_b));
+
+    const uint256 mined_hash_a = GetTestBlockHash(11);
+    const uint256 mined_hash_b = GetTestBlockHash(12);
+    constexpr int mined_height = 1;
+
+    {
+        auto dbTx = evoDb.BeginTransaction();
+        WriteMinedCommitment(evoDb, qc_a, mined_hash_a, mined_height);
+        dbTx->Commit();
+    }
+
+    CBlockIndex pindex_mined;
+    pindex_mined.nHeight = mined_height;
+    pindex_mined.pprev = const_cast<CBlockIndex*>(pindex_genesis);
+    pindex_mined.phashBlock = &mined_hash_a;
+
+    CBlock block_with_qc = MakeEmptyBlock();
+    block_with_qc.vtx.emplace_back(MakeCommitmentTx(qc_a, mined_height));
+    const CBlock empty_block = MakeEmptyBlock();
+
+    ExpectQuorumMerkleRoot(empty_block, &pindex_mined, qblockman, qc_a);
+
+    {
+        LOCK(cs_main);
+        auto dbTx = evoDb.BeginTransaction();
+        BOOST_REQUIRE(qblockman.UndoBlock(block_with_qc, &pindex_mined));
+        // Install the replacement while the disconnect transaction is still open.
+        WriteMinedCommitment(evoDb, qc_b, mined_hash_b, mined_height);
+        dbTx->Commit();
+    }
+
+    ExpectQuorumMerkleRoot(empty_block, &pindex_mined, qblockman, qc_b);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CalcCbTxMerkleRootQuorums` memoized into two function-local statics in `src/evo/cbtx.cpp`: an outer whole-result cache keyed on the vector of active quorum base `CBlockIndex*`, and an inner per-LLMQ-type LRU keyed on those base-block hashes.

**Keying defect.** Neither key identifies which `CFinalCommitment` was actually mined for a base on the active chain. Different valid branches can mine different valid commitments for the same base list. On a disconnect the evoDb state is rolled back correctly, but the caches were not invalidated, so both layers kept serving hashes from the abandoned branch. `CalcCbTxMerkleRootQuorums` could then reject an otherwise valid replacement branch with `bad-cbtx-quorummerkleroot`.

Concretely: branch A mines `QC_A` for base `B` at height H. A reorg disconnects H and connects H' mining `QC_B` for the same base `B`. Validating H'+1 uses a base-block list identical to branch A's, so the outer cache hits and returns branch A's hashes wholesale; even on an outer miss the LRU still returns `hash(QC_A)` for base `B`.

Triggerability on Dash is lower than in a pure PoS setting because of PoW and ChainLocks, but the keying is branch-dependent and therefore a correctness bug.

**Lifetime defect.** The caches lived for the whole process, while the block index whose `CBlockIndex*` the outer cache stores is per-node. The outer cache's hit test is a pointer comparison, so after a chainstate teardown a recycled address can make two unrelated chains compare equal. In the unit-test binary this leaks state between fixtures, since `TestChainSetup::CreateBlock` populates the caches.

This is an alternative to PR #7476, which fixes the keying defect only, via a process-global cache plus an exported invalidation function called from `UndoBlock`.

## What was done?

Moved both cache layers onto `llmq::CQuorumBlockProcessor` as `mutable` members guarded by a new `m_qc_hashes_cache_mutex`, and replaced the free helper with `GetQcHashes(pindexPrev) const`. Every caller already receives a `CQuorumBlockProcessor&`, so no signatures changed.

Ownership removes the cross-instance hazard by construction: a fresh `CQuorumBlockProcessor` starts with empty caches, so no node or test fixture can observe another's entries, and the pointer-comparison hit test can no longer report a match between unrelated chains.

It also bounds the stored `CBlockIndex*` lifetime. `CBlockIndex` objects are held by value in `BlockManager::m_block_index` and are never cleared or erased at runtime, so they are freed only with the `ChainstateManager`; both teardown paths destroy the quorum block processor first (`init.cpp` calls `DashChainstateSetupClose` before `chainman.reset()`, and in tests `~TestingSetup` runs before the base `~ChainTestingSetup` which resets chainman).

It also puts the caches in the same class as the only two sites that mutate mined commitment state, so the keying defect is handled by a private `DropQcHashesCache()` called from the write in `ProcessCommitment` and the erase in `UndoBlock` — a private detail rather than a cross-module call. The drop runs only after that commitment's evoDb writes/erases are complete, so the caches cannot be repopulated from a half-updated view; every caller holds `cs_main` today, but the invalidation should not depend on a lock discipline enforced elsewhere.

Notes for review:

- `DB_MINED_COMMITMENT` and the inverted-height index are always mutated as a pair, in those two functions only, so guarding both together is sufficient.
- `fJustCheck` returns before the write, so `TestBlockValidity` and the miner's speculative validation do not churn the caches.
- Lock ordering is unchanged: `GetMinedAndActiveCommitmentsUntilBlock` is still called before the cache lock, and the only call made while holding it is `GetMinedCommitment`, a bare evoDb read that takes no other lock.
- A rolled-back evoDb transaction leaves an empty cache that repopulates from committed state; it can never retain uncommitted commitment hashes.

Two commits: the fix, then the regression test.

## How Has This Been Tested?

Built on macOS arm64 against the depends prefix with `--enable-debug
--enable-crash-hooks --enable-werror`.

- Full unit suite `./src/test/test_dash`: 760 test cases, no errors.
- `./src/test/test_dash --run_test=evo_cbtx_tests`: passes.
- The first commit was checked out and built on its own to confirm it compiles and passes the full suite independently.
- Falsification: with the `UndoBlock` cache drop removed, the new `qc_hash_cache_invalidated_by_undoblock` case fails on a merkle-root mismatch; restored and re-confirmed green. The test therefore genuinely covers the bug rather than passing vacuously.
- `test/lint/all-lint.py`: only `lint-cppcheck-dash.py` fails, on files untouched by this change (`llmq/params.h`, `evo/dmn_types.h`, `evo/netinfo.h`); reproduced identically on an unmodified checkout. `lint-circular-dependencies.py` passes.

Functional tests were not run; the change is confined to the CbTx merkle-root cache path and is covered by unit tests.

## Breaking Changes

None. Consensus rules are unchanged; this only affects caching of values that were already being computed.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
