### PR TITLE
perf: use std::nth_element instead of full sort when pruning bounded caches

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -204,6 +204,7 @@ BITCOIN_TESTS =\
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \
   test/uint256_tests.cpp \
+  test/unordered_lru_cache_tests.cpp \
   test/util_tests.cpp \
   test/validation_block_tests.cpp \
   test/validation_chainstate_tests.cpp \

--- a/src/chainlock/handler.h
+++ b/src/chainlock/handler.h
@@ -57,12 +57,12 @@ private:
     //! Number of recently seen CLSIG hashes retained once `seenChainLocks` is pruned.
     static constexpr size_t SEEN_CHAINLOCKS_RETAINED_SIZE{1024};
     //! Size `seenChainLocks` may grow to before the next insertion prunes it back down to
-    //! SEEN_CHAINLOCKS_RETAINED_SIZE. Pruning sorts every entry, and CLSIG hashes are recorded
-    //! before the signature is verified, so pruning on each insertion past the retained size
-    //! lets a peer turn a stream of unique CLSIG hashes into a stream of O(n log n) sorts under
-    //! `cs`. Pruning only after twice the retained size amortises that cost over the entries
-    //! dropped in a single batch, at the price of a larger transient cache. The 2x ratio matches
-    //! the default in unordered_lru_cache.
+    //! SEEN_CHAINLOCKS_RETAINED_SIZE. Pruning partitions every entry, and CLSIG hashes are
+    //! recorded before the signature is verified, so pruning on each insertion past the retained
+    //! size lets a peer turn a stream of unique CLSIG hashes into a stream of full-map partition
+    //! passes under `cs`. Pruning only after twice the retained size amortises that cost over the
+    //! entries dropped in a single batch, at the price of a larger transient cache. The 2x ratio
+    //! matches the default in unordered_lru_cache.
     static constexpr size_t SEEN_CHAINLOCKS_PRUNE_AFTER_SIZE{2 * SEEN_CHAINLOCKS_RETAINED_SIZE};
 
     const CBlockIndex* lastNotifyChainLockBlockIndex GUARDED_BY(cs){nullptr};

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -97,20 +97,20 @@ public:
             return;
         }
 
-        std::vector<iterator> sortedIterators;
-        sortedIterators.reserve(map.size());
+        std::vector<iterator> iterators;
+        iterators.reserve(map.size());
         for (auto it = map.begin(); it != map.end(); ++it) {
-            sortedIterators.emplace_back(it);
+            iterators.emplace_back(it);
         }
-        std::sort(sortedIterators.begin(), sortedIterators.end(), [](const iterator& it1, const iterator& it2) {
-            return it1->second < it2->second;
-        });
-
         size_type tooMuch = map.size() - nMaxSize;
-        assert(tooMuch > 0);
-        sortedIterators.resize(tooMuch);
+        // nPruneAfterSize >= nMaxSize > 0 keeps tooMuch inside the vector, which nth_element relies on
+        assert(tooMuch > 0 && tooMuch < iterators.size());
+        // Only the entries below the eviction boundary have to be identified, their relative order does not matter
+        std::nth_element(iterators.begin(), iterators.begin() + tooMuch, iterators.end(),
+                         [](const iterator& it1, const iterator& it2) { return it1->second < it2->second; });
+        iterators.resize(tooMuch);
 
-        for (auto& it : sortedIterators) {
+        for (auto& it : iterators) {
             map.erase(it);
         }
     }

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -33,9 +33,9 @@ protected:
 public:
     //! nMaxSizeIn is the number of elements retained after a prune. nPruneAfterSizeIn is the size
     //! the map may grow to before the next insertion prunes it; it defaults to nMaxSizeIn, which
-    //! means prune() -- and therefore a sort of every element -- runs on *every* insertion past
-    //! nMaxSizeIn. Callers whose keys are attacker-supplied should pass a larger value (e.g.
-    //! 2 * nMaxSizeIn) so that sorting is amortised over a batch of evictions instead.
+    //! means prune() -- and therefore a partition of every element -- runs on *every* insertion
+    //! past nMaxSizeIn. Callers whose keys are attacker-supplied should pass a larger value (e.g.
+    //! 2 * nMaxSizeIn) so that partitioning is amortised over a batch of evictions instead.
     explicit unordered_limitedmap(size_type nMaxSizeIn, size_type nPruneAfterSizeIn = 0)
     {
         assert(nMaxSizeIn > 0);

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
 // A map constructed with a prune-after size larger than its retained size must not prune on
 // every insertion past the retained size. Instead it is allowed to grow up to the prune-after
 // size and is then pruned back down to the retained size in a single batch. This amortises the
-// cost of prune() -- which sorts every element -- over many insertions.
+// cost of prune() -- which partitions every element -- over many insertions.
 BOOST_AUTO_TEST_CASE(limitedmap_prune_after_size_test)
 {
     constexpr int RETAINED_SIZE{10};

--- a/src/test/unordered_lru_cache_tests.cpp
+++ b/src/test/unordered_lru_cache_tests.cpp
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <unordered_lru_cache.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+using IntCache = unordered_lru_cache<int, int, std::hash<int>>;
+
+BOOST_FIXTURE_TEST_SUITE(unordered_lru_cache_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(no_truncation_below_threshold)
+{
+    // the default truncate threshold is twice the max size
+    IntCache cache(10);
+    BOOST_CHECK_EQUAL(cache.max_size(), 10U);
+
+    for (int i = 0; i < 20; i++) {
+        cache.insert(i, i);
+    }
+
+    // reaching the threshold is not enough to trigger truncation
+    for (int i = 0; i < 20; i++) {
+        BOOST_CHECK(cache.exists(i));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(truncation_keeps_most_recent)
+{
+    IntCache cache(10);
+
+    // exceeding the threshold truncates down to the max size
+    for (int i = 0; i < 21; i++) {
+        cache.insert(i, i);
+    }
+
+    for (int i = 0; i < 21; i++) {
+        BOOST_CHECK_EQUAL(cache.exists(i), i >= 11);
+    }
+
+    // the retained values are intact
+    for (int i = 11; i < 21; i++) {
+        int value{0};
+        BOOST_CHECK(cache.get(i, value));
+        BOOST_CHECK_EQUAL(value, i);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(truncation_honors_explicit_threshold)
+{
+    IntCache cache(5, 6);
+    BOOST_CHECK_EQUAL(cache.max_size(), 5U);
+
+    for (int i = 0; i < 6; i++) {
+        cache.insert(i, i);
+    }
+    for (int i = 0; i < 6; i++) {
+        BOOST_CHECK(cache.exists(i));
+    }
+
+    cache.insert(6, 6);
+    for (int i = 0; i < 7; i++) {
+        BOOST_CHECK_EQUAL(cache.exists(i), i >= 2);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(get_refreshes_recency)
+{
+    IntCache cache(4);
+
+    // fill up to the threshold without triggering truncation
+    for (int i = 0; i < 8; i++) {
+        cache.insert(i, i);
+    }
+
+    // make the oldest entry the most recently used one
+    int value{0};
+    BOOST_CHECK(cache.get(0, value));
+    BOOST_CHECK_EQUAL(value, 0);
+
+    // this insert exceeds the threshold and truncates
+    cache.insert(8, 8);
+
+    // the refreshed entry survives, the entries it outranks do not
+    for (int i = 0; i < 9; i++) {
+        const bool expected = i == 0 || i >= 6;
+        BOOST_CHECK_EQUAL(cache.exists(i), expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(exists_refreshes_recency)
+{
+    IntCache cache(4);
+
+    for (int i = 0; i < 8; i++) {
+        cache.insert(i, i);
+    }
+
+    BOOST_CHECK(cache.exists(1));
+
+    cache.insert(8, 8);
+
+    for (int i = 0; i < 9; i++) {
+        const bool expected = i == 1 || i >= 6;
+        BOOST_CHECK_EQUAL(cache.exists(i), expected);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(erase_and_clear)
+{
+    IntCache cache(10);
+
+    for (int i = 0; i < 5; i++) {
+        cache.insert(i, i);
+    }
+
+    cache.erase(2);
+    BOOST_CHECK(!cache.exists(2));
+    BOOST_CHECK(cache.exists(1));
+
+    // erasing an absent key is a no-op
+    cache.erase(2);
+    cache.erase(100);
+    BOOST_CHECK(cache.exists(1));
+
+    cache.clear();
+    for (int i = 0; i < 5; i++) {
+        BOOST_CHECK(!cache.exists(i));
+    }
+
+    // the cache is still usable afterwards
+    cache.insert(7, 7);
+    int value{0};
+    BOOST_CHECK(cache.get(7, value));
+    BOOST_CHECK_EQUAL(value, 7);
+}
+
+BOOST_AUTO_TEST_CASE(emplace_inserts_and_overwrites)
+{
+    IntCache cache(10);
+    int value{0};
+
+    cache.emplace(1, 10);
+    BOOST_CHECK(cache.get(1, value));
+    BOOST_CHECK_EQUAL(value, 10);
+
+    // emplacing a key that is already present replaces its value
+    cache.emplace(1, 20);
+    BOOST_CHECK(cache.get(1, value));
+    BOOST_CHECK_EQUAL(value, 20);
+
+    cache.insert(1, 30);
+    BOOST_CHECK(cache.get(1, value));
+    BOOST_CHECK_EQUAL(value, 30);
+}
+
+BOOST_AUTO_TEST_CASE(overwrite_does_not_grow_map)
+{
+    IntCache cache(4);
+
+    // fill up to the threshold without triggering truncation
+    for (int i = 0; i < 8; i++) {
+        cache.insert(i, i);
+    }
+
+    // overwriting an existing key must not grow the map, so this stays at the threshold rather than exceeding it
+    cache.insert(0, 100);
+    for (int i = 0; i < 8; i++) {
+        BOOST_CHECK(cache.exists(i));
+    }
+
+    int value{0};
+    BOOST_CHECK(cache.get(0, value));
+    BOOST_CHECK_EQUAL(value, 100);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/unordered_lru_cache.h
+++ b/src/unordered_lru_cache.h
@@ -29,6 +29,8 @@ public:
     {
         // either specify maxSize through template arguments or the constructor and fail otherwise
         assert(_maxSize != 0);
+        // truncate_if_needed() only runs past truncateThreshold, so this is what keeps maxSize inside the vector
+        assert(truncateThreshold >= maxSize);
     }
 
     size_t max_size() const { return maxSize; }
@@ -101,8 +103,8 @@ private:
         for (auto it = cacheMap.begin(); it != cacheMap.end(); ++it) {
             vec.emplace_back(it);
         }
-        // sort by last access time (descending order)
-        std::sort(vec.begin(), vec.end(), [](const Iterator& it1, const Iterator& it2) {
+        // partition by last access time (descending order), the entries to keep end up in the first maxSize slots
+        std::nth_element(vec.begin(), vec.begin() + maxSize, vec.end(), [](const Iterator& it1, const Iterator& it2) {
             return it1->second.second > it2->second.second;
         });
 

--- a/test/util/data/non-backported.txt
+++ b/test/util/data/non-backported.txt
@@ -66,6 +66,7 @@ src/test/evo*.cpp
 src/test/llmq*.cpp
 src/test/masternode_payments_tests.cpp
 src/test/spork_tests.cpp
+src/test/unordered_lru_cache_tests.cpp
 src/test/util/llmq_tests.h
 src/test/governance*.cpp
 src/unordered_lru_cache.h


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two bounded caches do strictly more work than they need to when they evict:

- `unordered_limitedmap::prune()` (`src/limitedmap.h`) collects an iterator to every entry in the map and fully sorts that vector ascending by mapped value, then throws away everything except the `tooMuch = size - nMaxSize` smallest entries.
- `unordered_lru_cache::truncate_if_needed()` (`src/unordered_lru_cache.h`) does the same thing with a full descending sort by access counter, then erases everything past index `maxSize`.

In both cases the total order is discarded immediately. All that is actually needed is a partition around the eviction boundary, so the sort is `O(n log n)` work where `O(n)` suffices. This matters because these caches are not small: `unordered_lru_cache` instances in the tree are sized at 10000 (`islockCache`, `txidCache`, `outpointCache`) and 30000 (`hasSigForIdCache`, `hasSigForSessionCache`, `hasSigForHashCache`), and truncation runs on the insert path.

This came out of review of https://github.com/dashpay/dash/pull/7482, which also touches `src/limitedmap.h`. This PR is deliberately scoped so the two can merge in either order without conflicting: it only rewrites the body of `prune()`, leaves the constructor and the `max_size()` / prune-threshold accessors alone, and does not touch `src/test/limitedmap_tests.cpp` at all. The existing limitedmap tests already pin the prune membership semantics that must be preserved.

## What was done?

Replaced `std::sort` with `std::nth_element` in both eviction paths, using the same comparator in each case:

- `unordered_limitedmap::prune()`: `tooMuch` is now computed before the partition, and `std::nth_element(begin, begin + tooMuch, end, cmp)` places the `tooMuch` smallest entries in the leading range. The subsequent `resize(tooMuch)` and erase loop are unchanged.
- `unordered_lru_cache::truncate_if_needed()`: `std::nth_element(vec.begin(), vec.begin() + maxSize, vec.end(), cmp)` leaves the `maxSize` most recently accessed entries in the leading range, and the existing loop erases everything from `maxSize` onward.

This is behaviour preserving for the *set* of evicted entries. The relative order within the evicted group and within the retained group was never observable, and ties between equal values were already broken arbitrarily because `std::sort` is not a stable sort.

Two supporting changes:

- Added `assert(truncateThreshold >= maxSize)` to the `unordered_lru_cache` constructor. `vec.begin() + maxSize` is only a valid iterator because truncation runs only when `size > truncateThreshold`, so that invariant now has to hold rather than merely happening to hold. Every instantiation in `src/` passes only `maxSize` and therefore gets the default `truncateThreshold = 2 * maxSize`, so no caller is affected. `unordered_limitedmap` already has the equivalent `assert(nPruneAfterSize >= nMaxSize)`.
- Added `src/test/unordered_lru_cache_tests.cpp`. The class previously had no unit test coverage at all.

## How Has This Been Tested?

Built on macOS arm64 (aarch64-apple-darwin, clang, `--enable-debug --enable-crash-hooks --enable-stacktraces --without-gui --enable-tests`), against the `depends` prefix.

- `make -C src test/test_dash` at both commits of this branch, to confirm each commit builds on its own.
- `./src/test/test_dash --run_test=limitedmap_tests,unordered_lru_cache_tests` — 6 test cases, no errors.
- `./src/test/test_dash` (full unit test suite) — 770 test cases, no errors. This is the check that the new constructor assert does not fire for any existing cache instantiation.
- `test/lint/lint-whitespace.py`, `test/lint/lint-git-commit-check.py` (with `COMMIT_RANGE` set to this branch), `test/lint/lint-tests.py`, `test/lint/lint-includes.py`, `test/lint/lint-include-guards.py` — all clean.

The new tests cover: no truncation while the size is at or below the truncate threshold (which also pins the default threshold at `2 * max_size`); truncation down to exactly `max_size`, keeping the most recently accessed entries and leaving their values intact; an explicitly supplied truncate threshold; and that both `get()` and `exists()` refresh an entry's recency so an otherwise-oldest entry survives truncation.

Not run: functional tests, since no behaviour reachable from RPC or P2P changes.

## Breaking Changes

None. Both changes preserve the set of entries evicted, and no consensus, network, or RPC behaviour is affected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
