### PR TITLE
test: use cheaper quorum setup in governance ChainLocks test

### DIFF
--- a/test/functional/feature_governance_cl.py
+++ b/test/functional/feature_governance_cl.py
@@ -50,7 +50,9 @@ class DashGovernanceTest (DashTestFramework):
 
         self.nodes[0].sporkupdate("SPORK_17_QUORUM_DKG_ENABLED", 0)
         self.wait_for_sporks_same()
-        self.mine_cycle_quorum()
+        # ChainLocks use llmq_test on regtest, and the 10-minute mocktime bump below keeps
+        # proposal collateral transactions safe with this shorter quorum setup.
+        self.mine_quorum()
 
         self.sync_blocks()
         self.wait_for_chainlocked_block_all_nodes(self.nodes[0].getbestblockhash())


### PR DESCRIPTION
## Issue being fixed or feature implemented

`feature_governance_cl.py` only needs a signing-capable ChainLocks quorum before exercising governance behavior. It currently builds a full DIP0024 rotation cycle even though regtest ChainLocks use `llmq_test`.

## What was done?

Replace `mine_cycle_quorum()` with `mine_quorum()` and document why rotation setup is unnecessary. The existing ChainLock wait still proves that the quorum is ready before the governance assertions begin.

## How Has This Been Tested?

- `python3 -m py_compile test/functional/feature_governance_cl.py`
- `git diff --check upstream/develop...HEAD`
- Exact-head code review: ship, zero findings
- Six balanced A/B functional runs using the same local `dashd` build, alternating baseline and candidate with unique datadirs and port seeds; all runs passed

| Variant | Runs (seconds) | Median |
|---|---:|---:|
| `upstream/develop` | 36.570, 32.828, 32.536 | 32.828s |
| This PR | 30.440, 25.688, 26.723 | 26.723s |

Median improvement: **6.105 seconds (18.6%)**.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
