### PR TITLE
test: reduce nodes in LLMQ connections test

### DIFF
--- a/test/functional/feature_llmq_connections.py
+++ b/test/functional/feature_llmq_connections.py
@@ -23,7 +23,7 @@ class LLMQConnections(DashTestFramework):
         self.add_wallet_options(parser)
 
     def set_test_params(self):
-        self.set_dash_test_params(15, 14)
+        self.set_dash_test_params(11, 10)
         self.set_dash_llmq_test_params(5, 3)
         # Probes should age after this many seconds.
         # NOTE: mine_quorum() can bump mocktime quite often internally so make sure this number is high enough.
@@ -41,7 +41,7 @@ class LLMQConnections(DashTestFramework):
             count = self.get_mn_connection_count(mn.get_node(self))
             total_count += count
             assert_greater_than_or_equal(count, 2)
-        assert total_count < 40
+        assert total_count < 25
 
         self.check_reconnects(2)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`feature_llmq_connections.py` starts 14 masternodes although its quorum coverage remains intact with 10. The additional four processes increase setup, synchronization, connection, and teardown time without strengthening the assertions.

## What was done?

Reduce the topology from 15 nodes / 14 masternodes to 11 nodes / 10 masternodes, and tighten the pre-SPORK aggregate verified-MN connection bound from `< 40` to `< 25`. No quorum parameter changes are included.

Coverage remains intact:

- The regular test quorum remains size 5, so the probe, MNAUTH, and reconnect expectations are unchanged.
- Each DIP0024 cycle creates two size-4 quorums. Together they can cover 8 masternodes, leaving 2 additional masternodes as topology headroom.
- The tightened `< 25` aggregate bound preserves a substantial margin below all-to-all connectivity: the five inspected quorum members could have up to `5 × 9 = 45` verified masternode connections with 10 masternodes.

## How Has This Been Tested?

- `python3 -m py_compile test/functional/feature_llmq_connections.py`
- `git diff --check upstream/develop...HEAD`
- Exact-head code review: ship, zero findings
- Six balanced A/B functional runs using the same local `dashd` build, alternating baseline and candidate with unique datadirs and port seeds; all runs passed

| Variant | Runs (seconds) | Median |
|---|---:|---:|
| `upstream/develop` | 106.025, 97.427, 96.872 | 97.427s |
| This PR | 84.658, 84.309, 89.910 | 84.658s |

Median improvement: **12.769 seconds (13.1%)**.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
