### PR TITLE
test: parallelize data recovery masternode restarts

### DIFF
--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -38,20 +38,19 @@ class QuorumDataRecoveryTest(DashTestFramework):
         if qvvec_sync is None:
             qvvec_sync = []
 
+        # Sample the target height before the restarts stop any node
         wait_block_count = self.nodes[0].getblockcount() if reindex else None
 
-        def extra_args_cb(mn: MasternodeInfo):
-            args = ['-llmq-data-recovery=%d' % qdata_recovery_enabled]
-            for llmq_sync in qvvec_sync:
-                args.append('-llmq-qvvec-sync=%s:%d' % (llmq_type_strings[llmq_sync[0]], llmq_sync[1]))
-            if reindex:
-                args.append('-reindex')
-            return args
+        extra_args = ['-llmq-data-recovery=%d' % qdata_recovery_enabled]
+        for llmq_sync in qvvec_sync:
+            extra_args.append('-llmq-qvvec-sync=%s:%d' % (llmq_type_strings[llmq_sync[0]], llmq_sync[1]))
+        if reindex:
+            extra_args.append('-reindex')
 
         self.restart_masternodes(
             mns=mns,
             exclude=exclude,
-            extra_args_cb=extra_args_cb,
+            extra_args=extra_args,
             wait_block_count=wait_block_count,
         )
 

--- a/test/functional/feature_llmq_data_recovery.py
+++ b/test/functional/feature_llmq_data_recovery.py
@@ -10,7 +10,6 @@ from test_framework.test_framework import (
     DashTestFramework,
     MasternodeInfo,
 )
-from test_framework.util import force_finish_mnsync
 
 '''
 feature_llmq_data_recovery.py
@@ -35,40 +34,26 @@ class QuorumDataRecoveryTest(DashTestFramework):
         self.set_dash_test_params(7, 6, extra_args=extra_args)
         self.set_dash_llmq_test_params(4, 3)
 
-    def restart_mn(self, mn: MasternodeInfo, reindex=False, qvvec_sync=None, qdata_recovery_enabled=True):
-        args = self.extra_args[mn.nodeIdx] + ['-masternodeblsprivkey=%s' % mn.keyOperator,
-                                              '-llmq-data-recovery=%d' % qdata_recovery_enabled]
-        if qvvec_sync is None:
-            qvvec_sync = []
-        for llmq_sync in qvvec_sync:
-            args.append('-llmq-qvvec-sync=%s:%d' % (llmq_type_strings[llmq_sync[0]], llmq_sync[1]))
-        if reindex:
-            args.append('-reindex')
-            self.restart_node(mn.nodeIdx, args)
-        else:
-            self.restart_node(mn.nodeIdx, args)
-
-    def wait_restarted_mn(self, mn: MasternodeInfo, reindex=False, block_count=None):
-        if reindex:
-            self.wait_until(lambda: mn.get_node(self).getblockcount() >= block_count)
-
-        force_finish_mnsync(mn.get_node(self))
-        self.connect_nodes(mn.nodeIdx, 0)
-
     def restart_mns(self, mns=None, exclude=None, reindex=False, qvvec_sync=None, qdata_recovery_enabled=True):
-        if exclude is None:
-            exclude = []
         if qvvec_sync is None:
             qvvec_sync = []
 
-        block_count = self.nodes[0].getblockcount()
-        for mn in self.mninfo if mns is None else mns: # type: MasternodeInfo
-            if mn not in exclude:
-                self.restart_mn(mn, reindex, qvvec_sync, qdata_recovery_enabled)
+        wait_block_count = self.nodes[0].getblockcount() if reindex else None
 
-        for mn in self.mninfo if mns is None else mns: # type: MasternodeInfo
-            if mn not in exclude:
-                self.wait_restarted_mn(mn, reindex, block_count)
+        def extra_args_cb(mn: MasternodeInfo):
+            args = ['-llmq-data-recovery=%d' % qdata_recovery_enabled]
+            for llmq_sync in qvvec_sync:
+                args.append('-llmq-qvvec-sync=%s:%d' % (llmq_type_strings[llmq_sync[0]], llmq_sync[1]))
+            if reindex:
+                args.append('-reindex')
+            return args
+
+        self.restart_masternodes(
+            mns=mns,
+            exclude=exclude,
+            extra_args_cb=extra_args_cb,
+            wait_block_count=wait_block_count,
+        )
 
         if qdata_recovery_enabled:
             # trigger recovery threads and wait for them to start

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1799,12 +1799,81 @@ class DashTestFramework(BitcoinTestFramework):
         for idx in range(0, self.mn_count):
             self.connect_nodes(self.mninfo[idx].nodeIdx, 0)
 
+    def restart_masternodes(self, mns=None, exclude=None, extra_args_cb=None, wait_block_count=None):
+        """Restart masternodes with parallel process start, serial reconnect.
+
+        Stop uses the stop_nodes pattern (signal all selected nodes, then wait).
+        Start + force_finish_mnsync use ThreadPoolExecutor like start_masternodes.
+        connect_nodes to the controller stays serial (parallel connect is unsafe).
+
+        :param mns: masternodes to restart, defaults to all self.mninfo
+        :param exclude: masternodes to skip
+        :param extra_args_cb: optional callable(mn) -> extra args list for start
+        :param wait_block_count: if set, wait for this height after start and
+            before force_finish_mnsync (needed when restarting with -reindex)
+        :return: list of restarted MasternodeInfo
+        """
+        if exclude is None:
+            exclude = []
+        # Preserve caller order but drop duplicates: some tests pass multiset
+        # concatenations of quorum membership lists (e.g. feature_llmq_data_recovery).
+        selected = []
+        seen = set()
+        for mn in (self.mninfo if mns is None else mns):
+            if mn in exclude or mn.nodeIdx in seen:
+                continue
+            seen.add(mn.nodeIdx)
+            selected.append(mn)
+        if not selected:
+            return selected
+
+        self.log.info("Restarting %d masternodes in parallel", len(selected))
+
+        # Issue stop RPCs first, then wait — same ordering as stop_nodes()
+        for mn in selected:
+            self.nodes[mn.nodeIdx].stop_node(wait_until_stopped=False)
+        for mn in selected:
+            self.nodes[mn.nodeIdx].wait_until_stopped()
+
+        def restart_one(mn: MasternodeInfo):
+            extra_args = None if extra_args_cb is None else extra_args_cb(mn)
+            if wait_block_count is None:
+                self.start_masternode(mn, extra_args=extra_args)
+                return
+            # With -reindex, wait for height before force_finish_mnsync.
+            self.start_node(
+                mn.nodeIdx,
+                extra_args=self._masternode_start_args(mn, extra_args=extra_args),
+            )
+            # Default-arg capture avoids late-binding of mn in the wait predicate.
+            self.wait_until(lambda mn=mn: mn.get_node(self).getblockcount() >= wait_block_count)
+            force_finish_mnsync(mn.get_node(self))
+
+        executor = ThreadPoolExecutor(max_workers=20)
+        try:
+            jobs = [executor.submit(restart_one, mn) for mn in selected]
+            for job in jobs:
+                job.result()
+        finally:
+            executor.shutdown(wait=True)
+
+        # Connect serially to the controller only.
+        for mn in selected:
+            self.connect_nodes(mn.nodeIdx, 0)
+        return selected
+
     def start_masternode(self, mninfo: MasternodeInfo, extra_args=None):
+        self.start_node(
+            mninfo.nodeIdx,
+            extra_args=self._masternode_start_args(mninfo, extra_args=extra_args),
+        )
+        force_finish_mnsync(mninfo.get_node(self))
+
+    def _masternode_start_args(self, mninfo: MasternodeInfo, extra_args=None):
         args = ['-masternodeblsprivkey=%s' % mninfo.keyOperator] + self.extra_args[mninfo.nodeIdx]
         if extra_args is not None:
             args += extra_args
-        self.start_node(mninfo.nodeIdx, extra_args=args)
-        force_finish_mnsync(mninfo.get_node(self))
+        return args
 
     def dynamically_start_masternode(self, mnidx, extra_args=None):
         args = []

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -1799,24 +1799,23 @@ class DashTestFramework(BitcoinTestFramework):
         for idx in range(0, self.mn_count):
             self.connect_nodes(self.mninfo[idx].nodeIdx, 0)
 
-    def restart_masternodes(self, mns=None, exclude=None, extra_args_cb=None, wait_block_count=None):
+    def restart_masternodes(self, mns=None, exclude=None, extra_args=None, wait_block_count=None):
         """Restart masternodes with parallel process start, serial reconnect.
 
         Stop uses the stop_nodes pattern (signal all selected nodes, then wait).
         Start + force_finish_mnsync use ThreadPoolExecutor like start_masternodes.
-        connect_nodes to the controller stays serial (parallel connect is unsafe).
+        connect_nodes to the controller stays serial, matching start_masternodes.
 
         :param mns: masternodes to restart, defaults to all self.mninfo
         :param exclude: masternodes to skip
-        :param extra_args_cb: optional callable(mn) -> extra args list for start
+        :param extra_args: extra args appended to every restarted masternode
         :param wait_block_count: if set, wait for this height after start and
             before force_finish_mnsync (needed when restarting with -reindex)
-        :return: list of restarted MasternodeInfo
         """
         if exclude is None:
             exclude = []
-        # Preserve caller order but drop duplicates: some tests pass multiset
-        # concatenations of quorum membership lists (e.g. feature_llmq_data_recovery).
+        # Preserve caller order but drop duplicates: callers may pass concatenated
+        # quorum membership lists that contain the same masternode twice.
         selected = []
         seen = set()
         for mn in (self.mninfo if mns is None else mns):
@@ -1825,42 +1824,30 @@ class DashTestFramework(BitcoinTestFramework):
             seen.add(mn.nodeIdx)
             selected.append(mn)
         if not selected:
-            return selected
+            return
 
         self.log.info("Restarting %d masternodes in parallel", len(selected))
 
-        # Issue stop RPCs first, then wait — same ordering as stop_nodes()
+        # Issue stop RPCs first, then wait - same ordering as stop_nodes()
         for mn in selected:
             self.nodes[mn.nodeIdx].stop_node(wait_until_stopped=False)
         for mn in selected:
             self.nodes[mn.nodeIdx].wait_until_stopped()
 
         def restart_one(mn: MasternodeInfo):
-            extra_args = None if extra_args_cb is None else extra_args_cb(mn)
-            if wait_block_count is None:
-                self.start_masternode(mn, extra_args=extra_args)
-                return
-            # With -reindex, wait for height before force_finish_mnsync.
-            self.start_node(
-                mn.nodeIdx,
-                extra_args=self._masternode_start_args(mn, extra_args=extra_args),
-            )
-            # Default-arg capture avoids late-binding of mn in the wait predicate.
-            self.wait_until(lambda mn=mn: mn.get_node(self).getblockcount() >= wait_block_count)
+            self.start_node(mn.nodeIdx, extra_args=self._masternode_start_args(mn, extra_args=extra_args))
+            if wait_block_count is not None:
+                self.wait_until(lambda: mn.get_node(self).getblockcount() >= wait_block_count)
             force_finish_mnsync(mn.get_node(self))
 
-        executor = ThreadPoolExecutor(max_workers=20)
-        try:
+        with ThreadPoolExecutor(max_workers=20) as executor:
             jobs = [executor.submit(restart_one, mn) for mn in selected]
             for job in jobs:
                 job.result()
-        finally:
-            executor.shutdown(wait=True)
 
         # Connect serially to the controller only.
         for mn in selected:
             self.connect_nodes(mn.nodeIdx, 0)
-        return selected
 
     def start_masternode(self, mninfo: MasternodeInfo, extra_args=None):
         self.start_node(


### PR DESCRIPTION
## Issue being fixed or feature implemented

`feature_llmq_data_recovery.py` repeatedly restarts several masternodes serially. Process startup, reindexing, and mnsync waits dominate this restart-heavy functional test, especially under sanitizers.

## What was done?

Add a focused `DashTestFramework.restart_masternodes()` helper and migrate only the data-recovery test to it.

The helper:

- signals all selected nodes to stop, then waits for all of them;
- starts nodes and completes mnsync in parallel using the existing `ThreadPoolExecutor` pattern from `start_masternodes()`;
- reconnects each node to the controller serially, preserving the repository's historical avoidance of parallel `connect_nodes()` calls;
- preserves exclusion, reindex-height waiting, custom restart arguments, and exception propagation;
- deduplicates overlapping quorum-member lists by node index before scheduling restarts.

No polling changes or other functional-test callsites are included.

## How Has This Been Tested?

- `python3 -m py_compile test/functional/test_framework/test_framework.py test/functional/feature_llmq_data_recovery.py`
- `test/lint/lint-python.py`
- `git diff --check upstream/develop...HEAD`
- Exact-head code review: ship, zero findings
- Four balanced A/B functional runs using the same local `dashd` build, alternating baseline and candidate with unique datadirs and port seeds; all runs passed

| Variant | Runs (seconds) | Midpoint |
|---|---:|---:|
| `upstream/develop` | 168.270, 171.687 | 169.979s |
| This PR | 133.473, 129.478 | 131.476s |

Improvement: **38.503 seconds (22.7%)**.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
