### PR TITLE
test: batch DIP0008 activation with slow_mode=False

### DIFF
--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -119,7 +119,7 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         for n in self.nodes:
             n.invalidateblock(oldhash)
         self.sync_all()
-        first_quorum = self.test_dip8_quorum_merkle_root_activation(False, True)
+        first_quorum = self.test_dip8_quorum_merkle_root_activation(False)
 
         # Verify that the first quorum appears in MNLISTDIFF
         expectedDeleted = []
@@ -276,7 +276,7 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         cbtx = self.nodes[0].getblock(self.nodes[0].getbestblockhash(), 2)["tx"][0]
         assert cbtx["cbTx"]["version"] == 1
 
-        self.activate_by_name('dip0008', expected_activation_height=DIP0008_HEIGHT)
+        self.activate_by_name('dip0008', expected_activation_height=DIP0008_HEIGHT, slow_mode=slow_mode)
         self.log.info("Mine one more block with new rules of dip0008")
         self.generate(self.nodes[0], 1)
 

--- a/test/functional/feature_dip4_coinbasemerkleroots.py
+++ b/test/functional/feature_dip4_coinbasemerkleroots.py
@@ -115,11 +115,15 @@ class LLMQCoinbaseCommitmentsTest(DashTestFramework):
         oldhash = self.nodes[0].getbestblockhash()
 
         # Test DIP8 activation once with a pre-existing quorum and once without (we don't know in which order it will activate on mainnet)
-        self.test_dip8_quorum_merkle_root_activation(True)
+        self.test_dip8_quorum_merkle_root_activation(True, slow_mode=False)
         for n in self.nodes:
             n.invalidateblock(oldhash)
         self.sync_all()
-        first_quorum = self.test_dip8_quorum_merkle_root_activation(False)
+        # The other nodes still record the invalidated (higher work) tip as node0's best known
+        # block, which leaves headers direct fetch as the only way to reach them. That gives up on
+        # forks deeper than MAX_BLOCKS_IN_TRANSIT_PER_PEER (16), so slow_mode's batch of 10 is
+        # what keeps the replacement chain reachable here.
+        first_quorum = self.test_dip8_quorum_merkle_root_activation(False, slow_mode=True)
 
         # Verify that the first quorum appears in MNLISTDIFF
         expectedDeleted = []


### PR DESCRIPTION
## Issue being fixed or feature implemented

`feature_dip4_coinbasemerkleroots.py` used the default `slow_mode=True` path for the first DIP0008 activation, mining activation blocks in batches of 10 even though that initial path can reliably use larger batches.

## What was done?

Pass the existing `slow_mode` parameter through to `activate_by_name` and use an intentional split:

- The initial DIP0008 activation uses `slow_mode=False` (batch size 50) for the speedup.
- The post-`invalidateblock` replacement-chain activation keeps `slow_mode=True` (batch size 10).

The smaller second batch is required because the node can retain the higher-work invalidated branch as its best-known block. Replacement-fork direct fetch is limited to 16 blocks, so a 50-block replacement batch can stall block synchronization on slower CI configurations.

Coverage is preserved:

- Activation height is unchanged (`DIP0008_HEIGHT`).
- Softfork inactive/active assertions around the final blocks are unchanged.
- SPORK_17 remains disabled during activation mining and is restored afterward.
- Every generated batch still calls `sync_blocks()`.

## How Has This Been Tested?

- `python3 -m py_compile test/functional/feature_dip4_coinbasemerkleroots.py`
- `python3 test/lint/lint-python.py test/functional/feature_dip4_coinbasemerkleroots.py`
- Exact functional test `feature_dip4_coinbasemerkleroots.py` passed on the final split-path implementation.
- On current head `ccc385800a0358d6532882678e9565aa7a90a77b`, the changed test passed in the current TSAN job (133 seconds). The job's red result is an unrelated `feature_protx_version.py` timeout reproduced at the PR base and tracked in #6702.
- Exact-head PastaClaw review completed with no blockers.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
