### PR TITLE
test: condition-sync multikey spork negative wait

### DIFF
--- a/test/functional/feature_multikeysporks.py
+++ b/test/functional/feature_multikeysporks.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2018-2023 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-import time
 
 from test_framework.test_framework import BitcoinTestFramework
 
@@ -16,6 +15,13 @@ required signers to 3. We check 1 and 2 signers can't set the spork
 value, any 3 signers can change spork value and other 3 signers
 can change it again.
 '''
+
+
+# Spork IDs from src/spork.h — used only to match ProcessSpork debug lines.
+SPORK_IDS = {
+    'SPORK_2_INSTANTSEND_ENABLED': 10001,
+    'SPORK_19_CHAINLOCKS_ENABLED': 10018,
+}
 
 
 class MultiKeySporkTest(BitcoinTestFramework):
@@ -73,17 +79,58 @@ class MultiKeySporkTest(BitcoinTestFramework):
         # use InstantSend spork for tests
         return info[spork_name]
 
+    def wait_for_two_spork_signers(self, spork_name, value, observer_idxs,
+                                   log_offsets, timeout=10):
+        """Wait until pure observers store two ProcessSpork messages for value.
+
+        Local UpdateSpork does not log; only remote acceptance hits ProcessSpork
+        (LogPrintf). Two store lines on each non-signer prove both sub-threshold
+        signatures have propagated before we assert the value is still inactive.
+        """
+        spork_id = SPORK_IDS[spork_name]
+        # CSporkManager::ProcessSpork formats value with %10d
+        marker = f"id: {spork_id} value: {value:10d}"
+
+        def is_process_spork_store(line):
+            # Store path is LogPrintf; "seen" is the only non-store suffix.
+            return marker in line and " seen" not in line
+
+        def observers_have_two_signers():
+            for idx in observer_idxs:
+                node = self.nodes[idx]
+                offset = log_offsets[idx]
+                with open(node.debug_log_path, encoding="utf-8",
+                          errors="replace") as dl:
+                    dl.seek(offset)
+                    log = dl.read()
+                stores = sum(
+                    1 for line in log.splitlines()
+                    if is_process_spork_store(line)
+                )
+                if stores < 2:
+                    return False
+            return True
+
+        self.wait_until(observers_have_two_signers, timeout=timeout)
+
     def test_spork(self, spork_name, final_value):
         # check test spork default state
         for node in self.nodes:
             assert self.get_test_spork_value(node, spork_name) == 4070908800
 
         self.bump_mocktime(1)
+        # Snapshot logs before signing so in-flight ProcessSpork lines are visible.
+        log_offsets = [
+            node.debug_log_size(encoding="utf-8") for node in self.nodes
+        ]
         # first and second signers set spork value
         self.nodes[0].sporkupdate(spork_name, 1)
         self.nodes[1].sporkupdate(spork_name, 1)
-        # spork change requires at least 3 signers
-        time.sleep(10)
+        # Wait until both signatures are stored on non-signers, then assert the
+        # value is still inactive: nMinSporkKeys=3 requires a third signer.
+        self.wait_for_two_spork_signers(
+            spork_name, 1, observer_idxs=(2, 3, 4), log_offsets=log_offsets
+        )
         for node in self.nodes:
             assert self.get_test_spork_value(node, spork_name) != 1
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`feature_multikeysporks.py` sleeps for ten seconds after two of the required three signers broadcast the same spork value. The test needs to prove that both sub-threshold signatures propagated before checking that the value remains inactive, but the fixed sleep is both slow and only an indirect propagation signal.

## What was done?

Replace the fixed sleep with a positive propagation barrier based on the existing `CSporkManager::ProcessSpork` store logs.

Before the two signer updates, the test snapshots each node's debug-log offset. It then waits until each pure observer has stored both signed messages for the tested spork value. Only after that condition is met does it assert that every node still reports the value as inactive because `-minsporkkeys=3` requires a third signer.

This avoids polling `get_test_spork_value()` during propagation, which would advance mocktime on every call. Both `SPORK_2_INSTANTSEND_ENABLED` and `SPORK_19_CHAINLOCKS_ENABLED` remain covered.

## How Has This Been Tested?

- `python3 -m py_compile test/functional/feature_multikeysporks.py`
- `test/lint/lint-python.py`
- `git diff --check upstream/develop...HEAD`
- Exact-head code-review gate: `ship`, zero findings
- Five repeated final-head functional runs passed
- Three additional exact-head interleaved A/B pairs passed using the same local `dashd` binary, cachedir, and host; the PR changes only Python test orchestration

| Variant | Runs (seconds) | Median |
|---|---:|---:|
| `upstream/develop` | 41.264, 41.218, 43.401 | 41.264s |
| This PR | 24.401, 22.670, 23.521 | 23.521s |

Median improvement: **17.743 seconds (43.0%)**.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
