### PR TITLE
test: don't expect zero connections after protx operator-key change/revoke

### DIFF
--- a/test/functional/feature_protx_version.py
+++ b/test/functional/feature_protx_version.py
@@ -58,6 +58,18 @@ class ProTxVersionTest(DashTestFramework):
         ]] * 6
         self.set_dash_test_params(6, 5, evo_count=2, extra_args=self.extra_args)
 
+    def get_peer_ids(self, node_idx):
+        return {peer['id'] for peer in self.nodes[node_idx].getpeerinfo()}
+
+    def wait_for_peers_disconnected(self, node_idx, peer_ids):
+        """Wait until none of `peer_ids` is connected to node `node_idx` anymore.
+
+        Don't wait for getconnectioncount() to hit zero instead: intra-quorum connections are
+        re-established concurrently, as the masternode remains a member of previously formed
+        quorums, so zero might never be observable.
+        """
+        assert peer_ids, "no peers to wait for, the disconnect assertion would pass trivially"
+        self.wait_until(lambda: peer_ids.isdisjoint(self.get_peer_ids(node_idx)))
 
     def run_test(self):
         # Connect all nodes to node1 so that we always have the whole network connected
@@ -193,13 +205,15 @@ class ProTxVersionTest(DashTestFramework):
         legacy_mn.keyOperator = new_operator['secret']
         migrate_result = legacy_mn.update_registrar(node, submit=True, fundsAddr=legacy_mn.fundsAddr)
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
+        assert legacy_mn.nodeIdx is not None
+        old_peer_ids = self.get_peer_ids(legacy_mn.nodeIdx)
         tip = self.generate(node, 1, sync_fun=self.no_op)[0]
         assert_equal(node.getrawtransaction(migrate_result, 1, tip)['proUpRegTx']['version'], 3)
         assert_equal(node.protx('info', legacy_mn.proTxHash)['state']['version'], 3)
-        # Changing the operator key PoSe-bans the masternode, which results in disconnects. Wait for
-        # them to happen and then reconnect its node back to let sync_all finish correctly.
-        assert legacy_mn.nodeIdx is not None
-        self.wait_until(lambda: self.nodes[legacy_mn.nodeIdx].getconnectioncount() == 0)
+        # Changing the operator key makes every peer drop its existing connections to this
+        # masternode. Wait for that to happen and then reconnect its node back to let sync_all
+        # finish correctly.
+        self.wait_for_peers_disconnected(legacy_mn.nodeIdx, old_peer_ids)
         self.connect_nodes(legacy_mn.nodeIdx, 0)
         self.sync_all()
 
@@ -234,11 +248,13 @@ class ProTxVersionTest(DashTestFramework):
 
         protx_result = revoke_mn.revoke(self.nodes[0], submit=True, reason=1, fundsAddr=funds_address)
         self.bump_mocktime(10 * 60 + 1) # to make tx safe to include in block
+        old_peer_ids = self.get_peer_ids(node_idx)
         tip = self.generate(self.nodes[0], 1, sync_fun=self.no_op)[0]
         assert_equal(self.nodes[0].getrawtransaction(protx_result, 1, tip)['confirmations'], 1)
-        # Revoking a MN results in disconnects. Wait for disconnects to actually happen
-        # and then reconnect the corresponding node back to let sync_blocks finish correctly.
-        self.wait_until(lambda: self.nodes[node_idx].getconnectioncount() == 0)
+        # Revoking a MN makes every peer drop its existing connections to it. Wait for that to
+        # happen and then reconnect the corresponding node back to let sync_blocks finish
+        # correctly.
+        self.wait_for_peers_disconnected(node_idx, old_peer_ids)
         self.connect_nodes(node_idx, 0)
         self.sync_all()
         self.log.info(f"Successfully revoked={revoke_mn.proTxHash}")


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes the currently worst-offending functional-test flake, #6702 (`feature_protx_version.py`, formerly `feature_dip3_v19.py`). The two most recent CI occurrences (2026-07-30, one under TSAN and one under multiprocess, both exhausting all three retries) time out at the same predicate:

```text
self.wait_until(lambda: self.nodes[node_idx].getconnectioncount() == 0)
AssertionError: ... not true after 240.0 seconds
```

at line 202 (operator-key change / v1→v3 migration path) and line 241 (`test_revoke_protx`).

The root cause is a race in the test, not an implementation bug. Two correct behaviors compose into a predicate that is not guaranteed to ever be observable:

1. Changing a masternode's operator key (or revoking it) makes every peer that verified its MNAUTH drop the connection once it processes the trigger block (`CMNAuth::NotifyMasternodeListChanged`). This part works: in every captured failure, all pre-existing peers of the affected node are disconnected within ~1 second.
2. The masternode remains a member of previously formed quorums (membership is snapshotted at DKG time), so `CConnman::ThreadOpenMasternodeConnections` on *both* sides legitimately re-establishes intra-quorum connections on its 100 ms–1 s retry loop, and the affected node also keeps accepting inbound quorum connections. These replacement connections are not dropped again, because the node stops sending MNAUTH once its configured operator key no longer matches the list.

Under load the replacement connections land before the teardown finishes, so `getconnectioncount()` never transiently reaches zero and the wait can only pass by timing luck. The zero-wait was itself introduced as the fix for the previous incarnation of this flake (#5863), where `connect_nodes` raced the disconnect storm — it traded one race for another.

The other `getconnectioncount() == 0` waits in the tree (`feature_llmq_signing.py`, `feature_llmq_simplepose.py`) are not affected: they call `setnetworkactive(false)` first, which also blocks reconnections.

## What was done?
Test-only change. Instead of expecting an instantaneous zero, the test now snapshots the affected node's peer ids immediately before mining the trigger transaction and waits until none of those ids remain in `getpeerinfo()`. Peer ids are monotonically increasing per node, so this deterministically detects that the key change/revocation dropped every pre-existing connection while tolerating concurrent (legitimate) quorum reconnections. Both call sites use a shared helper.

The alternative of quiescing the network via `setnetworkactive(false)` was deliberately not used: it would drop all connections regardless of whether the ban-disconnect logic works, gutting the behavioral assertion the wait provides.

## How Has This Been Tested?
Reproduced and verified on macOS (M-series, 14 cores) at develop `a61ade2ef84` with 15 concurrent copies of the test:

```bash
python3 test/functional/test_runner.py --jobs=15 --attempts=1 $(for _ in $(seq 15); do echo feature_protx_version.py; done)
```

- Before the change: 6/15, 5/15 and 9/15 runs failed across three batches — every single failure at the line 202/241 zero-wait (no unrelated contention failures).
- After the change: 45/45 runs passed (three batches of 15).
- Re-checked out the pre-fix state afterwards and re-ran one batch: 9/15 failures returned, all matching the signature.
- The 60 s local timeout vs. 240 s in CI is `TEST_RUNNER_TIMEOUT_FACTOR=4` (`ci/test/00_setup_env.sh`); same predicate, same bug.
- Sequential run of the fixed test passes in ~150 s, matching CI's passing runtime.

## Breaking Changes
n/a

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
