### PR TITLE
fix: reject duplicate session collateral in CoinJoin dsa acceptance

### DIFF
--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -758,12 +758,26 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
         return false;
     }
 
-    // start new session
-    nMessageIDRet = MSG_NOERR;
-    nSessionID = GetRand<int>(/*nMax=*/999999) + 1;
-    nSessionDenom = dsa.nDenom;
+    {
+        LOCK(cs_coinjoin);
 
-    SetState(POOL_STATE_QUEUE);
+        // A scheduler-thread timeout can reset the session via SetNull() between the checks
+        // above and taking cs_coinjoin, so revalidate: the session state and the collateral
+        // that opened it have to be committed as one unit.
+        if (nSessionID != 0 || nState != POOL_STATE_IDLE) {
+            nMessageIDRet = ERR_MODE;
+            return false;
+        }
+
+        // start new session
+        nMessageIDRet = MSG_NOERR;
+        nSessionID = GetRand<int>(/*nMax=*/999999) + 1;
+        nSessionDenom = dsa.nDenom;
+
+        SetState(POOL_STATE_QUEUE);
+
+        vecSessionCollaterals.push_back(MakeTransactionRef(dsa.txCollateral));
+    }
 
     if (!fUnitTest) {
         //broadcast that I'm accepting entries, only if it's the first entry through
@@ -775,7 +789,6 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
         m_queueman.AddQueue(std::move(dsq));
     }
 
-    vecSessionCollaterals.push_back(MakeTransactionRef(dsa.txCollateral));
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CreateNewSession -- new session created, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
         nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), vecSessionCollaterals.size(), CoinJoin::GetMaxPoolParticipants());
 
@@ -801,6 +814,16 @@ bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolM
         LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- incompatible denom %d (%s) != nSessionDenom %d (%s)\n",
             dsa.nDenom, CoinJoin::DenominationToString(dsa.nDenom), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
         nMessageIDRet = ERR_DENOM;
+        return false;
+    }
+
+    LOCK(cs_coinjoin);
+
+    // A scheduler-thread timeout can reset the session via SetNull() between the checks above
+    // and taking cs_coinjoin, so revalidate: a collateral must never be committed to a session
+    // that no longer exists.
+    if (nSessionID == 0 || nState != POOL_STATE_QUEUE) {
+        nMessageIDRet = ERR_MODE;
         return false;
     }
 

--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -283,6 +283,7 @@ void CCoinJoinServer::SetNull()
     AssertLockHeld(cs_coinjoin);
     // MN side
     vecSessionCollaterals.clear();
+    setSessionCollateralPrevouts.clear();
 
     CCoinJoinBaseSession::SetNull();
     m_queueman.SetNull();
@@ -743,6 +744,15 @@ bool CCoinJoinServer::IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& n
     return true;
 }
 
+void CCoinJoinServer::CommitSessionCollateral(const CMutableTransaction& txCollateral)
+{
+    AssertLockHeld(cs_coinjoin);
+    vecSessionCollaterals.push_back(MakeTransactionRef(txCollateral));
+    for (const auto& txin : txCollateral.vin) {
+        setSessionCollateralPrevouts.insert(txin.prevout);
+    }
+}
+
 bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet)
 {
     if (nSessionID != 0) return false;
@@ -776,7 +786,7 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
 
         SetState(POOL_STATE_QUEUE);
 
-        vecSessionCollaterals.push_back(MakeTransactionRef(dsa.txCollateral));
+        CommitSessionCollateral(dsa.txCollateral);
     }
 
     if (!fUnitTest) {
@@ -827,10 +837,22 @@ bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolM
         return false;
     }
 
+    // Session collaterals are only ever test-accepted, never added to the mempool, so nothing
+    // pins their identity: the same UTXO can be re-signed into arbitrarily many distinct txids.
+    // Match on input prevouts so a resent or replayed dsa cannot be counted as a new participant.
+    for (const auto& txin : dsa.txCollateral.vin) {
+        if (setSessionCollateralPrevouts.contains(txin.prevout)) {
+            LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- collateral %s spends prevout %s already committed to this session\n",
+                dsa.txCollateral.GetHash().ToString(), txin.prevout.ToStringShort());
+            nMessageIDRet = ERR_ALREADY_HAVE;
+            return false;
+        }
+    }
+
     // count new user as accepted to an existing session
 
     nMessageIDRet = MSG_NOERR;
-    vecSessionCollaterals.push_back(MakeTransactionRef(dsa.txCollateral));
+    CommitSessionCollateral(dsa.txCollateral);
 
     LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- new user accepted, nSessionID: %d  nSessionDenom: %d (%s)  vecSessionCollaterals.size(): %d  CoinJoin::GetMaxPoolParticipants(): %d\n",
         nSessionID, nSessionDenom, CoinJoin::DenominationToString(nSessionDenom), vecSessionCollaterals.size(), CoinJoin::GetMaxPoolParticipants());

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -66,8 +66,8 @@ private:
 
     /// Is this nDenom and txCollateral acceptable?
     bool IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) const;
-    bool CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet);
-    bool AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet);
+    bool CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
+    bool AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Do we have enough users to take entries?
     bool IsSessionReady() const;
 
@@ -85,7 +85,7 @@ private:
     void RelayStatus(PoolStatusUpdate nStatusUpdate, PoolMessage nMessageID = MSG_NOERR) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     void RelayCompletedTransaction(PoolMessage nMessageID) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
 
-    void ProcessDSACCEPT(CNode& peer, CDataStream& vRecv);
+    void ProcessDSACCEPT(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     void ProcessDSQUEUE(NodeId from, CDataStream& vRecv);
     void ProcessDSVIN(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     void ProcessDSSIGNFINALTX(CNode& peer, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -10,6 +10,9 @@
 #include <net_processing.h>
 #include <net_types.h>
 #include <protocol.h>
+#include <util/hasher.h>
+
+#include <unordered_set>
 
 class CActiveMasternodeManager;
 class CConnman;
@@ -43,6 +46,9 @@ private:
     // Mixing uses collateral transactions to trust parties entering the pool
     // to behave honestly. If they don't it takes their money.
     std::vector<CTransactionRef> vecSessionCollaterals;
+    // Input prevouts of every transaction in vecSessionCollaterals, so a dsa whose collateral
+    // reuses one of them can be rejected without rescanning them all.
+    std::unordered_set<COutPoint, SaltedOutpointHasher> setSessionCollateralPrevouts GUARDED_BY(cs_coinjoin);
 
     bool fUnitTest;
 
@@ -66,6 +72,8 @@ private:
 
     /// Is this nDenom and txCollateral acceptable?
     bool IsAcceptableDSA(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) const;
+    /// Record an accepted collateral and index its input prevouts
+    void CommitSessionCollateral(const CMutableTransaction& txCollateral) EXCLUSIVE_LOCKS_REQUIRED(cs_coinjoin);
     bool CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     bool AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet) EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Do we have enough users to take entries?


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CCoinJoinServer::AddUserToExistingSession` never checks whether the incoming `dsa.txCollateral` was already accepted into the current session — `IsAcceptableDSA` only validates the denomination and the collateral itself. A client that resends its `dsa` (or an attacker replaying an observed one) is `push_back`'d into `vecSessionCollaterals` again and counted as an extra participant. This inflates the count that `IsSessionReady` compares against the min/max pool participant thresholds, so a session can look "ready" with fewer real participants than required. Each phantom slot expects a DSVIN entry that never arrives, so such sessions stall until timeout, and `ChargeFees` may then consume the replayed collateral — but the participant-count inflation itself is wrong regardless.

Committing the rejection requires a lock, and taking one exposes a second, pre-existing defect. `CreateNewSession` and `AddUserToExistingSession` run on the message-handler thread and mutate session state with no lock held, while the scheduler thread resets that same state every second via `CheckTimeout` → `SetNull()` under `cs_coinjoin` (`Schedule`, 1s interval). The check-then-mutate sequence in both functions is therefore not atomic, and the unlocked `push_back` into `vecSessionCollaterals` races `SetNull()`'s `clear()` outright. The window is not theoretical: `IsAcceptableDSA` sits between the state checks and the mutation and performs a mempool test-accept under `cs_main`.

## What was done?

Two commits.

**`fix: commit CoinJoin session state and its collateral atomically`** takes `cs_coinjoin` for the commit itself in both functions and revalidates the session state under it, so the state and the collateral that goes with it land as one unit. The `dsq` signing and relay in `CreateNewSession` stay outside the lock scope, so `cs_coinjoin` is never held across BLS signing, network relay, or `cs_main`. A `dsa` that loses this race is now answered with `ERR_MODE` instead of being committed into a session that no longer exists.

**`fix: reject duplicate session collateral in CoinJoin dsa acceptance`** tracks the input prevouts of every committed collateral in `setSessionCollateralPrevouts` and refuses a `dsa` whose collateral reuses one of them, reporting the existing `ERR_ALREADY_HAVE` pool message ("Already have that input."). No new enum value is introduced, so there is no protocol change; old clients handle it as an ordinary `dssu` rejection. `CommitSessionCollateral` is the single place that appends to `vecSessionCollaterals` and indexes its prevouts, so the two cannot drift apart.

The obvious check — comparing collateral txids — is insufficient and deliberately not used. Session collaterals are only ever test-accepted against the mempool, never actually added to it, so nothing pins the transaction's identity: a malicious client can re-sign the same collateral UTXO with a varied change output (or just a different signature, since collaterals are malleable pre-broadcast) and produce arbitrarily many distinct txids for what is economically the same collateral. Every one of those variants would sail past a `GetHash()` comparison and the participant inflation would survive. Prevout overlap closes that hole: no matter how the transaction is re-signed, it must spend the same UTXO, and identical transactions necessarily share prevouts, so the prevout check strictly subsumes the txid check.

Honest participants can never collide on a prevout: distinct wallets cannot spend the same UTXO, and a wallet mixing in multiple sessions locks its collateral inputs per session, so each concurrent session gets a collateral built from disjoint inputs.

Scope note: `vecSessionCollaterals` itself still carries no `GUARDED_BY` and is read without `cs_coinjoin` in `ProcessDSACCEPT`, `IsSessionReady`, `CheckPool`, `CheckForCompleteQueue`, `ChargeFees`, `ChargeRandomFees` and `AddEntry`. Every write to it now holds the lock, so the new prevout index cannot drift from it, but those unlocked reads remain a pre-existing race. Annotating the member and repairing all seven call sites — along with `SetState`, which writes `nState` unlocked, and `nSessionDenom`, which is neither atomic nor guarded — is left to a follow-up PR so this one stays reviewable.

## How Has This Been Tested?

- Compile-verified `src/coinjoin/server.cpp` with `clang++ -fsyntax-only -Wthread-safety` using the project's `compile_commands.json` flags, clean.
- No unit test added: exercising `AddUserToExistingSession` requires driving `ProcessDSACCEPT`, which needs the server's active masternode registered in the deterministic MN list at chain tip plus a mempool-valid collateral transaction (the `fUnitTest` bypass is private and never enabled anywhere). None of that scaffolding exists in the current CoinJoin unit tests (`src/test/coinjoin_inouts_tests.cpp` only reaches the DSSIGNFINALTX path), and building it out is beyond the scope of this fix.
- A full build / functional-test run was not performed for this change.

## Breaking Changes

None. The rejection reuses an existing pool message code, so wire compatibility is unchanged; only `dsa` messages whose collateral reuses an input prevout already committed to the session, or which race a session reset, are now refused.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
