### PR TITLE
test: keep node 2 in IBD in p2p_node_network_limited

### DIFF
--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -42,6 +42,11 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 3
         self.extra_args = [['-prune=550'], [], []]
+        # This test needs node 2 to actually be in IBD, so that it does not ask
+        # the NODE_NETWORK_LIMITED peer for historical blocks and get dropped for
+        # it. The framework's default genesis mocktime would leave node 2's tip
+        # permanently "fresh" and IsInitialBlockDownload() would latch to false.
+        self.disable_mocktime = True
 
     def disconnect_all(self):
         self.disconnect_nodes(0, 1)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes #7288.

`p2p_node_network_limited.py --v2transport` intermittently fails on the
`linux64_tsan-test` lane, always with the same signature:

```
File "test/functional/p2p_node_network_limited.py", line 83, in run_test
    self.connect_nodes(0, 2)
...
File "test/functional/test_framework/test_framework.py", line 732, in check_bytesrecv
    assert peer is not None, "Error: peer disconnected"
AssertionError: Error: peer disconnected
```

Six CI occurrences are recorded on the issue, most recently 2026-07-29. It is not
a timeout — the failure lands in ~5 s.

**Root cause.** The test says, in its own comment, that node 2 cannot sync
"because node 2 is in IBD". That premise is true upstream and false in Dash.

The functional test framework pins every node to `-mocktime=TIME_GENESIS_BLOCK`
(`test/functional/test_framework/test_framework.py:899`); Bitcoin Core's does
not. So node 2's genesis tip is never older than `nMaxTipAge`, and
`Chainstate::IsInitialBlockDownload()` (`src/validation.cpp:1665`) latches to
false on its very first call:

| | tip time | `GetTime()` | tip age | in IBD? |
| --- | --- | --- | --- | --- |
| Bitcoin Core | 2011 regtest genesis | wall clock | ~15 years | yes |
| Dash | 1417713337 | 1417713337 (frozen) | 0 s | **no** |

Node 2 therefore passes the block-download gate at `src/net_processing.cpp:6636`,
syncs headers from node 0, and immediately asks it for blocks 1..16. Node 0 runs
`-prune=550`, signals `NODE_NETWORK_LIMITED` without `NODE_NETWORK`, and answers a
request below the threshold by dropping the peer (`src/net_processing.cpp:2715`).

`connect_nodes()` cannot survive that. After the handshake it polls
`getpeerinfo()` until it observes a `pong` from both sides, asserting
`peer is not None` on every poll
(`test/functional/test_framework/test_framework.py:732`). Whenever node 0 drops
node 2 before the next poll lands, the helper asserts instead of returning. From
the CI combined log:

```
node2 21:08:57.315815  sending getdata (577 bytes) peer=0
node0 21:08:57.318655  Ignore block request below NODE_NETWORK_LIMITED threshold, disconnect peer=2
node0 21:08:57.331313  ThreadRPCServer method=getpeerinfo     <- peer already gone
test  21:08:57.332000  AssertionError: Error: peer disconnected
```

`--v2transport` is the variant hit in practice because the v2 handshake's extra
round trip shifts the ping/pong later relative to the header sync that triggers
the disconnect; the race itself is transport-agnostic.

## What was done?

Restored the premise rather than working around it: `self.disable_mocktime = True`
in `set_test_params()`.

With mocktime disabled node 2 is genuinely in IBD, so it never requests those
blocks, node 0 never drops it, and the race **cannot occur** rather than merely
being unlikely. The body of the test — including the inherited comment, which is
now accurate again — stays identical to upstream, so future backports of this file
apply cleanly.

There is established precedent for exactly this problem class:
`p2p_ibd_stalling.py`, `p2p_ibd_txrelay.py` and `p2p_initial_headers_sync.py` all
set `disable_mocktime` because the framework's genesis mocktime denies them the
IBD state they are written to exercise.

No coverage is lost. The "limited peer drops whoever requests historical blocks"
behaviour is still tested directly and deterministically by the `P2PIgnoreInv`
mininode earlier in `run_test()`. What is gained is the coverage upstream actually
intended here, which Dash was silently missing: a node in IBD does not even
attempt to sync from a `NODE_NETWORK_LIMITED` peer.

## How Has This Been Tested?

Reproduced and verified locally with the `--v2transport` variant on a 14-core
M-series host, using parallel `test_runner.py` batches. Patched and unpatched arms
were interleaved and **order-swapped between rounds**, so neither arm could
systematically draw a busier slot, with host load recorded before and after every
batch.

| arm | runs | failures with the CI signature |
| --- | --- | --- |
| unpatched | 180 | 31 |
| patched | 195 | 0 |

The patched figure includes 120 runs at 30-way parallelism (deliberate
self-inflicted contention) and 15 runs of `--v1transport`. The unpatched control
was re-confirmed at that same 30-way parallelism (8/30 failures), so the clean
patched batches are meaningful rather than an artifact of an easy configuration.

Every unpatched failure was classified against the CI signature — same file:line,
same predicate, and the same `Ignore block request below NODE_NETWORK_LIMITED
threshold, disconnect peer=2` immediately preceding it in node 0's `debug.log`.
Failures from unrelated causes (a port held by an unrelated process; RPC timeouts
inside `generate(292)` when the host was saturated by an unrelated parallel run)
were counted separately and excluded from both arms.

Mechanism confirmed directly in the logs: with the patch, node 2 issues **zero**
block requests to node 0, and node 0 logs **exactly one** threshold-disconnect —
the intended one against the mininode.

Also run: `test/lint/lint-python.py` (no issues in 312 source files).

Test-only change; no rebuild required.

## Note on `disconnect_all()`

This change makes `disconnect_all()` do slightly more work. Today
`disconnect_nodes(0, 2)` is a no-op — node 0 has already dropped node 2, and the
run logs `disconnect_nodes: 0 and 2 were not connected`. With the patch that
connection is alive, so all three pairs are genuinely torn down.

Measured, instrumenting `disconnect_all()` over 135 runs of each variant at 45-way
parallelism. The budget per wait is 20 s (`timeout=5` scaled by
`TEST_RUNNER_TIMEOUT_FACTOR=4`; see `test/functional/test_framework/util.py:272`):

| | `disconnect_all()` total | worst single-pair wait |
| --- | --- | --- |
| this PR | p50 1.18 s, p90 1.47 s, max 1.54 s | 0.55 s |
| unpatched shape | p50 0.96 s, p90 0.98 s, max 1.08 s | 0.63 s |

The extra ~0.5 s is the additional pair, not slower teardown — the worst
individual wait is in fact lower than without the patch. Roughly 13x headroom
against the 20 s budget.

## Note on runtime

The test gets ~20 s slower per run in CI. That is not overhead this change adds,
it is the test finally performing the wait it was always written to perform:
`sync_blocks([node0, node2], timeout=5)` (20 s at `TEST_RUNNER_TIMEOUT_FACTOR=4`).
Today that call aborts after ~1 s, because node 2 has already been disconnected
and `sync_blocks` bails on its "each peer has at least one connection" assert
(`test/functional/test_framework/test_framework.py:841`). Upstream pays this wait
too. It could be trimmed later if it matters, but doing so here would mean
touching behaviour this issue is not about.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
