### PR TITLE
test: fix remaining feature_asset_locks flake from autonomous MnEHF signal txs

### DIFF
--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -45,6 +45,7 @@ from test_framework.util import (
 from test_framework.wallet_util import bytes_to_wif
 
 llmq_type_test = 106 # LLMQType::LLMQ_TEST_PLATFORM
+MNEHF_SIGNAL_TX_TYPE = 7 # TRANSACTION_MNHF_SIGNAL
 tiny_amount = int(Decimal("0.0007") * COIN)
 blocks_in_one_day = 100
 HEIGHT_DIFF_EXPIRING = 48
@@ -175,9 +176,13 @@ class AssetLocksTest(DashTestFramework):
         return expected
 
     def check_mempool_size(self):
+        # Masternodes submit the MnEHF signal transaction on their own as soon as a quorum
+        # able to sign it exists, so it is not part of what this test puts in the mempool.
         self.sync_mempools()
         for node in self.nodes:
-            assert_equal(node.getmempoolinfo()['size'], self.mempool_size)
+            own = [txid for txid in node.getrawmempool()
+                   if node.getrawtransaction(txid, 1)['type'] != MNEHF_SIGNAL_TX_TYPE]
+            assert_equal(len(own), self.mempool_size)
 
     def check_mempool_result(self, result_expected, tx):
         """Wrapper to check result of testmempoolaccept on node_0's mempool"""

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -2151,20 +2151,13 @@ class DashTestFramework(BitcoinTestFramework):
 
         self.wait_until(check_dkg_session, timeout=timeout, sleep=sleep)
 
-    def node_has_quorum_commitment(self, node, quorum_hash, llmq_type):
+    def node_quorum_commitment_types(self, node, quorum_hash):
         s = node.quorum("dkgstatus")
-        if "minableCommitments" not in s:
-            return False
-        commits = s["minableCommitments"]
-        for c in commits:
-            if c["llmqType"] != llmq_type:
-                continue
-            if c["quorumHash"] != quorum_hash:
-                continue
-            if c["quorumPublicKey"] == '0' * 96:
-                continue
-            return True
-        return False
+        return {c["llmqType"] for c in s.get("minableCommitments", [])
+                if c["quorumHash"] == quorum_hash and c["quorumPublicKey"] != '0' * 96}
+
+    def node_has_quorum_commitment(self, node, quorum_hash, llmq_type):
+        return llmq_type in self.node_quorum_commitment_types(node, quorum_hash)
 
     def wait_for_quorum_commitment(self, quorum_hash, mninfos, llmq_type=100, timeout=15):
         def check_dkg_comitments():
@@ -2174,6 +2167,20 @@ class DashTestFramework(BitcoinTestFramework):
             return True
 
         self.wait_until(check_dkg_comitments, timeout=timeout)
+
+    def wait_for_quorum_commitments_on_miner(self, quorum_hash, mninfos, timeout=15):
+        # The final-commitment block carries a commitment for every llmq type whose mining
+        # window is open, so a commitment that has not reached the mining node in time is
+        # mined as a null one and its quorum is silently skipped for the whole cycle. Only
+        # commitments the masternodes actually produced are awaited, so a type whose DKG
+        # legitimately produced nothing does not hold this up.
+        def check_miner_commitments():
+            expected = set()
+            for mn in mninfos:
+                expected |= self.node_quorum_commitment_types(mn.get_node(self), quorum_hash)
+            return expected <= self.node_quorum_commitment_types(self.nodes[0], quorum_hash)
+
+        self.wait_until(check_miner_commitments, timeout=timeout)
 
     def wait_for_quorum_list(self, quorum_hash, nodes, timeout=15, llmq_type_name="llmq_test"):
         def wait_func():
@@ -2285,8 +2292,8 @@ class DashTestFramework(BitcoinTestFramework):
         self.log.info("Waiting final commitment")
         self.wait_for_quorum_commitment(q, mninfos_online, llmq_type=llmq_type)
 
-        self.log.info("Waiting final commitment on mining node")
-        self.wait_until(lambda: self.node_has_quorum_commitment(self.nodes[0], q, llmq_type), timeout=15)
+        self.log.info("Waiting final commitments on mining node")
+        self.wait_for_quorum_commitments_on_miner(q, mninfos_online)
 
         self.log.info("Mining final commitment")
         self.bump_mocktime(1)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #7411, which closed #7310. The same test kept failing after that
closure, so the fix was only partial.

Sorting the post-closure reports on #7310 by the tree they actually ran on
splits them in two:

- The `wait_for_quorum_list()` timeouts in `test_v24_fork` -> `mine_quorum_2_nodes`
  all ran on PR heads that predate #7411. #7422's head `9f030351b` and #7350's
  head do not contain #7411's merge `cbab2549bc4`, and the #7418 report says so
  explicitly. That failure mode is fixed.
- The exact-mempool-count failure — `test_asset_unlocks` -> `check_mempool_result`
  -> `check_mempool_size` -> `AssertionError: not(1 == 0)` — still reproduces on
  current `develop` with #7411 present.

This PR fixes the second one and the race that lets it happen.

## What was done?

Two related changes.

**1. `mine_quorum()` only waited for the commitment of the type it was mining.**

#7411 added a wait for the mining node to hold the final commitment, but only
for `llmq_type`, the type the caller asked for. The block `mine_quorum()` then
generates carries a commitment for *every* LLMQ type whose mining window is
open, and in regtest all test types share `dkgInterval = 24`, so they all
finalize on the same block. A type whose real commitment has not reached the
mining node yet is mined as a **null** commitment
(`src/llmq/blockprocessor.cpp:842-846`); null commitments are accepted without
being recorded as mined (`src/llmq/blockprocessor.cpp:322-331`), so that quorum
is silently skipped for the whole cycle.

Captured from a failing run, at final-commitment block 178, for the undriven
`llmq_test`:

```text
GetMineableCommitments cf height[178] content: { created nversion[3] quorumIndex[0] }
ProcessCommitment -- processing commitment for block height=178, type=100,
  quorumHash=1ffd275a..., signers=0, validMembers=0,
  quorumPublicKey=000000000000...0000
```

`created` rather than `cached` is the mining node synthesising a null commitment
because it held no real one.

`mine_quorum()` now waits for the mining node to hold every commitment the
masternodes actually produced for that quorum hash, not just the driven type.
Only commitments the masternodes already have are awaited, so a type whose DKG
legitimately produced nothing cannot hold a test up.

**2. `check_mempool_size()` asserted a global mempool count.**

regtest's `llmqTypeMnhf` is `LLMQ_TEST` (`src/chainparams.cpp:929`), so a skipped
`llmq_test` quorum defers the one-shot V24 MnEHF signal transaction to a later
cycle. `CEHFSignalsHandler` submits it from the masternodes on their own
(`src/llmq/ehf_signals.cpp:118`) at a moment the test does not control, while
`check_mempool_size()` compared `getmempoolinfo()['size']` against
`self.mempool_size`, which only ever modelled the test's own transactions:

```text
node2 ... Special EHF TX is created hash=1feb94ce...
node2 ... IsValidMNActivation: set MnEHF for bit=12 is valid   (bit 12 = DEPLOYMENT_V24)
node0 ... accepted 1feb94ce... (poolsz 1 txn, 0 kB)
test  ... AssertionError: not(1 == 0)
```

The count now excludes MnEHF signal transactions, so the assertion still says
exactly what it said before about the transactions this test submits, and no
longer depends on when the masternodes submit theirs. Deliberately not a
`wait_until` on the mempool size: that would also pass if an asset-unlock
transaction wrongly lingered, which is what the assertion exists to catch.

`mine_cycle_quorum()` has the same gap and does not wait for commitments at all,
but it drives rotated (dip0024) quorums and no failure in this family was traced
to it, so it is left alone.

## How Has This Been Tested?

Built from `upstream/develop` at `efe6dec7b9a` on macOS arm64,
`configure --prefix=depends/aarch64-apple-darwin25.3.0 --disable-bench`, `make -j13`.
Sequential control: `feature_asset_locks.py` passes in 167 s, matching CI's
passing runtime.

The natural rate of this flake is only ~3% locally, and it is gated by a discrete
precursor rather than a timing window, so raising `--jobs` does not amplify it —
at `-j20` the machine slows uniformly, which gives the `llmq_test` commitment
*more* time to arrive and suppressed the precursor entirely (0/20). The
before/after was therefore measured against a forced precursor: an
experiment-only patch, not part of this PR, that removes the "Mine block to empty
mempool" `generate()` in `test_asset_unlocks` — the block that would otherwise
sweep the MnEHF transaction. Same assertion, same transaction, same mechanism.

| Run | Result |
| --- | --- |
| 15x parallel, forced precursor, without this PR | **15/15 failed**, every one the `not(1 == 0)` signature |
| 15x parallel, forced precursor, with this PR | **15/15 passed** |
| 15x parallel, unforced, without this PR | 1/15 failed (the natural ~3% rate) |
| 15x parallel, unforced, with this PR | 30/30 passed across 2 batches; a 3rd batch is excluded, see below |

A third unforced 15x batch ran while the host was under an unrelated load spike
(load average 145 on a 14-core machine, from desktop applications rather than
the test run) and lost 14 of 15 copies to block-sync, mempool-sync,
recovered-signature and RPC timeouts. Those are host-contention failures, not
this signature, and are excluded from the table rather than counted as passes.
Across all 45 unforced runs with this PR there were zero `not(1 == 0)`
occurrences.

In the forced-and-unfixed runs the single mempool entry was confirmed to be the
MnEHF transaction, e.g. `872ca79e...` created by `CEHFSignalsHandler` and
accepted on node0 at `poolsz 1 txn`.

Because the framework change affects every test that mines quorums, all 15 such
tests were run: `feature_dip4_coinbasemerkleroots`, `feature_llmq_connections`,
`feature_llmq_data_recovery`, `feature_llmq_dkg_intake`, `feature_llmq_dkgerrors`,
`feature_llmq_evo`, `feature_llmq_rotation`, `feature_llmq_signing`,
`feature_llmq_simplepose` (both variants), `feature_mnehf`,
`feature_notifications`, `feature_protx_version`, `p2p_instantsend`,
`p2p_platform_ban`, `p2p_quorum_data`. All passed except `feature_protx_version`,
which failed at `test_revoke_protx` waiting for `getconnectioncount() == 0`
(feature_protx_version.py:241). That is the pre-existing #6702 flake, not a
regression here: it reproduces identically on unmodified `develop` (1/8 failed
at `-j8` on a clean tree vs 3/8 with this PR, the same `line 241` signature in
every case), and it is unrelated to quorum commitments.

`test/lint/lint-python.py` passes.

## Breaking Changes

None. Test-only change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
