### PR TITLE
fix(wallet): report public-only descriptors in signing wallets as watch-only

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2220,7 +2220,16 @@ isminetype DescriptorScriptPubKeyMan::IsMine(const CScript& script) const
 {
     LOCK(cs_desc_man);
     if (m_map_script_pub_keys.count(script) > 0) {
-        return ISMINE_SPENDABLE;
+        // A descriptor containing only public keys can solve an input for fee
+        // estimation, but it cannot sign it. This distinction matters for
+        // private-key-enabled descriptor wallets which also track public-only
+        // descriptors (for example, a DashPay contact's receiving chain).
+        // Preserve descriptor watch-only/external-signer wallet semantics;
+        // those wallets deliberately operate without local private keys. The
+        // dangerous case is a public descriptor mixed into a signing wallet.
+        return HavePrivateKeys() || m_storage.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)
+                   ? ISMINE_SPENDABLE
+                   : ISMINE_WATCH_ONLY;
     }
     return ISMINE_NO;
 }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -102,6 +102,47 @@ static void AddKey(CWallet& wallet, const CKey& key)
     if (!wallet.AddWalletDescriptor(w_desc, provider, "", false)) assert(false);
 }
 
+BOOST_FIXTURE_TEST_CASE(public_descriptor_outputs_are_watch_only, TestChain100Setup)
+{
+    CWallet wallet(m_node.chain.get(), m_node.coinjoin_loader.get(), "", m_args, CreateDummyWalletDatabase());
+    CExtKey contact_key;
+    const std::array<std::byte, 32> seed{std::byte{1}};
+    contact_key.SetSeed(seed);
+    const CExtPubKey contact_xpub{contact_key.Neuter()};
+
+    FlatSigningProvider provider;
+    std::string error;
+    auto descriptor{Parse("pkh(" + EncodeExtPubKey(contact_xpub) + "/*)", provider, error,
+                          /*require_checksum=*/false)};
+    BOOST_REQUIRE_MESSAGE(descriptor, error);
+
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        WalletDescriptor wallet_descriptor(std::move(descriptor), /*creation_time=*/0,
+                                           /*range_start=*/0, /*range_end=*/10,
+                                           /*next_index=*/0);
+        BOOST_REQUIRE(wallet.AddWalletDescriptor(wallet_descriptor, provider, "DashPay contact",
+                                                 /*internal=*/false));
+
+        CExtPubKey child;
+        BOOST_REQUIRE(contact_xpub.Derive(child, 0));
+        const CScript contact_script{GetScriptForDestination(PKHash{child.pubkey})};
+        BOOST_CHECK_EQUAL(wallet.IsMine(contact_script), ISMINE_WATCH_ONLY);
+
+        CMutableTransaction payment;
+        payment.vin.emplace_back(g_insecure_rand_ctx.rand256(), 0);
+        payment.vout.emplace_back(COIN, contact_script);
+        wallet.AddToWallet(MakeTransactionRef(payment), TxStateInMempool{});
+
+        CCoinControl coin_control;
+        coin_control.m_include_unsafe_inputs = true;
+        BOOST_CHECK_EQUAL(AvailableCoins(wallet, &coin_control).size(), 0U);
+        coin_control.fAllowWatchOnly = true;
+        BOOST_CHECK_EQUAL(AvailableCoins(wallet, &coin_control).size(), 1U);
+    }
+}
+
 BOOST_FIXTURE_TEST_CASE(scan_for_wallet_transactions, TestChain100Setup)
 {
     // Cap last block file size, and mine new block in a new block file.


### PR DESCRIPTION
## Issue being fixed or feature implemented

`DescriptorScriptPubKeyMan::IsMine` returns `ISMINE_SPENDABLE` for any script tracked by one of the wallet's descriptors — including descriptors that contain only public keys. In a wallet that otherwise has private keys, outputs on such a descriptor are treated as spendable balance and can be selected by coin selection, producing transactions the wallet cannot sign. A public-only descriptor can *solve* a script (enough for fee estimation), but it cannot *sign* it.

Today this is hard to hit from the GUI/RPC because `importdescriptors` into a private-key-enabled wallet normally imports descriptors with private keys, but any current or future path that tracks a public-only descriptor in a signing wallet (e.g. address discovery for an external party's chain) silently corrupts the wallet's view of its spendable balance. This is a prerequisite correctness fix extracted from the Platform GUI work in PastaPastaPasta#49, where a DashPay contact's receiving chain is exactly such a descriptor.

## What was done?

Report scripts from public-only descriptors as `ISMINE_WATCH_ONLY` when the wallet is a signing wallet. Descriptor watch-only wallets and external-signer wallets (`WALLET_FLAG_DISABLE_PRIVATE_KEYS`) keep their existing `ISMINE_SPENDABLE` semantics — those wallets deliberately operate without local private keys and their spend paths handle signing elsewhere. The dangerous case is only a public descriptor mixed into a signing wallet.

## How Has This Been Tested?

New unit test `wallet_tests/public_descriptor_outputs_are_watch_only`: imports a public-only `pkh(xpub/*)` descriptor into a descriptor wallet with private keys enabled, and checks that a payment to a derived address is reported `ISMINE_WATCH_ONLY`, is excluded from `AvailableCoins` by default, and appears only when `fAllowWatchOnly` is set.

`wallet_tests`, `scriptpubkeyman_tests`, `ismine_tests`, and `coinselector_tests` suites pass locally (macOS, clang).

## Breaking Changes

None expected. Balances previously (mis)reported as spendable on such descriptors are now reported as watch-only.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
