### PR TITLE
fix: surface specific autobackup-failure tooltips in CoinJoin status

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -526,8 +526,14 @@ void OverviewPage::coinJoinStatus(bool fForce)
     // Disable any PS UI for masternode or when autobackup is disabled or failed for whatever reason
     if (clientModel->node().isMasternode() || nWalletBackups <= 0) {
         DisableCoinJoinCompletely();
-        if (nWalletBackups <= 0) {
+        if (nWalletBackups == 0) {
             ui->labelCoinJoinEnabled->setToolTip(tr("Automatic backups are disabled, no mixing available!"));
+        } else if (nWalletBackups == -1) {
+            ui->labelCoinJoinEnabled->setToolTip(tr("ERROR! Failed to create automatic backup") + ", " +
+                                                 tr("see debug.log for details.") + "<br><br>" +
+                                                 tr("Mixing is disabled, please close your wallet and fix the issue!"));
+        } else if (nWalletBackups == -2) {
+            ui->labelCoinJoinEnabled->setToolTip(tr("WARNING! Failed to replenish keypool, please unlock your wallet to do so."));
         }
         return;
     }
@@ -666,22 +672,11 @@ void OverviewPage::coinJoinStatus(bool fForce)
     if(fShowAdvancedCJUI && !strKeysLeftText.isEmpty()) strEnabled += ", " + strKeysLeftText;
     ui->labelCoinJoinEnabled->setText(strEnabled);
 
-    if (walletModel->wallet().isLegacy()) {
-        if(nWalletBackups == -1) {
-            // Automatic backup failed, nothing else we can do until user fixes the issue manually
-            DisableCoinJoinCompletely();
-
-            QString strError =  tr("ERROR! Failed to create automatic backup") + ", " +
-                                tr("see debug.log for details.") + "<br><br>" +
-                                tr("Mixing is disabled, please close your wallet and fix the issue!");
-            ui->labelCoinJoinEnabled->setToolTip(strError);
-
-            return;
-        } else if(nWalletBackups == -2) {
-            // We were able to create automatic backup but keypool was not replenished because wallet is locked.
-            QString strWarning = tr("WARNING! Failed to replenish keypool, please unlock your wallet to do so.");
-            ui->labelCoinJoinEnabled->setToolTip(strWarning);
-        }
+    if (walletModel->wallet().isLegacy() && nWalletBackups == -1) {
+        // Automatic backup failed, nothing else we can do until user fixes the issue manually.
+        // Stop mixing right away; the guard above sets the matching tooltip on the next timer tick.
+        DisableCoinJoinCompletely();
+        return;
     }
 
     // check coinjoin status and unlock if needed

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -19,6 +19,7 @@
 #include <qt/walletmodel.h>
 #include <key_io.h>
 #include <test/util/setup_common.h>
+#include <util/system.h>
 #include <validation.h>
 #include <wallet/wallet.h>
 #include <qt/overviewpage.h>
@@ -192,6 +193,30 @@ void TestGUI(interfaces::Node& node)
     CAmount balance = walletModel.wallet().getBalance();
     QString balanceComparison = BitcoinUnits::floorHtmlWithPrivacy(unit, balance, BitcoinUnits::SeparatorStyle::ALWAYS, false);
     QCOMPARE(balanceText, balanceComparison);
+
+    // Check that each autobackup failure state selects its specific tooltip on the CoinJoin status label
+    {
+        QLabel* coinJoinLabel = overviewPage.findChild<QLabel*>("labelCoinJoinEnabled");
+        QVERIFY(coinJoinLabel != nullptr);
+        const int nWalletBackupsOld = nWalletBackups;
+
+        nWalletBackups = 0;
+        overviewPage.coinJoinStatus(/*fForce=*/true);
+        QCOMPARE(coinJoinLabel->toolTip(), QString("Automatic backups are disabled, no mixing available!"));
+
+        nWalletBackups = -1;
+        overviewPage.coinJoinStatus(/*fForce=*/true);
+        QCOMPARE(coinJoinLabel->toolTip(),
+                 QString("ERROR! Failed to create automatic backup, see debug.log for details.<br><br>Mixing is "
+                         "disabled, please close your wallet and fix the issue!"));
+
+        nWalletBackups = -2;
+        overviewPage.coinJoinStatus(/*fForce=*/true);
+        QCOMPARE(coinJoinLabel->toolTip(),
+                 QString("WARNING! Failed to replenish keypool, please unlock your wallet to do so."));
+
+        nWalletBackups = nWalletBackupsOld;
+    }
 
     // Check Request Payment button
     ReceiveCoinsDialog receiveCoinsDialog;


### PR DESCRIPTION
## Issue being fixed or feature implemented
`OverviewPage::coinJoinStatus()` has an early guard that treats every non-positive `nWalletBackups` value the same: it disables CoinJoin and sets the generic "Automatic backups are disabled, no mixing available!" tooltip, then returns. But `nWalletBackups` distinguishes three states: `0` (backups disabled), `-1` (automatic backup failed) and `-2` (backup succeeded but keypool was not replenished because the wallet is locked).

The function has more specific handling for `-1` ("ERROR! Failed to create automatic backup") and `-2` ("WARNING! Failed to replenish keypool, please unlock your wallet") further down, but that code only takes effect within the single invocation where `autoBackupWallet()` freshly fails. On every subsequent timer tick the early `<= 0` guard runs first and overwrites the specific tooltip with the generic one, so users can't tell "I turned backups off" apart from "backups are failing" or "unlock your wallet to replenish the keypool".

This was noticed via a CodeRabbit review comment on #7005, but the bug predates that PR, so it is fixed here separately against `develop`.

## What was done?
The early guard now sets the status-specific tooltip directly: the generic "backups disabled" message only for `nWalletBackups == 0`, the backup-failure error for `-1`, and the unlock-your-wallet warning for `-2`. CoinJoin remains disabled in all three cases, preserving existing behavior.

The later per-status block is reduced to what still matters within the same invocation: stopping mixing immediately on `-1` (`CCoinJoinClientManager::CheckAutomaticBackup()` does not call `stopMixing()` for `-1`, and the modal at the failure site already tells the user mixing is disabled). Its tooltip assignments — including the whole `-2` branch, which only set a tooltip — are dropped, since the guard overwrote them within one timer tick anyway; the guard now shows the matching message persistently instead.

## How Has This Been Tested?
The change is a tooltip-selection change inside an existing GUI code path with no logic change to when CoinJoin is disabled; relying on CI for build verification. There is no existing GUI test coverage for this path.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
