### PR TITLE
fix: handle null pprev in IsQuorumTypeEnabled instead of terminating

### DIFF
--- a/src/llmq/commitment.cpp
+++ b/src/llmq/commitment.cpp
@@ -54,6 +54,14 @@ bool CFinalCommitment::VerifySignatureAsync(const llmq::UtilParameters& util_par
         LogPrint(BCLog::LLMQ, "CFinalCommitment::%s members[%s] quorumPublicKey[%s] commitmentHash[%s]\n", __func__,
                  ss3.str(), quorumPublicKey.ToString(), commitmentHash.ToString());
     }
+    // GetAllQuorumMembers() legitimately returns an empty set (disabled LLMQ type, out-of-range
+    // quorumIndex, parentless quorum base). A commitment can never be valid without members, and
+    // the single-member branch below indexes members[0] unconditionally, so reject here.
+    if (members.empty()) {
+        LogPrint(BCLog::LLMQ, "CFinalCommitment -- q[%s] no quorum members\n", quorumHash.ToString());
+        return false;
+    }
+
     if (llmq_params.is_single_member()) {
         LogPrintf("pubkey operator: %s\n", members[0]->pdmnState->pubKeyOperator.Get().ToString());
         if (!membersSig.VerifyInsecure(members[0]->pdmnState->pubKeyOperator.Get(), commitmentHash)) {

--- a/src/llmq/net_dkg.cpp
+++ b/src/llmq/net_dkg.cpp
@@ -435,6 +435,12 @@ void NetDKG::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStre
             m_peer_manager->PeerMisbehaving(pfrom.GetId(), 10);
             return;
         }
+        // Genesis (and any parentless index) is never a valid quorum base.
+        if (pQuorumBaseBlockIndex->pprev == nullptr) {
+            LogPrintf("NetDKG -- invalid genesis/parentless quorumHash %s\n", quorumHash.ToString());
+            m_peer_manager->PeerMisbehaving(pfrom.GetId(), 100);
+            return;
+        }
         if (!m_chainman.IsQuorumTypeEnabled(llmqType, pQuorumBaseBlockIndex->pprev)) {
             LogPrintf("NetDKG -- llmqType [%d] quorums aren't active\n", std23::to_underlying(llmqType));
             m_peer_manager->PeerMisbehaving(pfrom.GetId(), 100);

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -637,7 +637,9 @@ QuorumMembers GetAllQuorumMembers(Consensus::LLMQType llmqType, const UtilParame
     static RecursiveMutex cs_indexed_members;
     static std::map<Consensus::LLMQType, unordered_lru_cache<std::pair<uint256, int>, QuorumMembers, StaticSaltedHasher>> mapIndexedQuorumMembers GUARDED_BY(cs_indexed_members);
 
-    if (!util_params.m_chainman.IsQuorumTypeEnabled(llmqType, util_params.m_base_index->pprev)) {
+    // Genesis has pprev == nullptr and cannot host a quorum; treat as disabled.
+    if (util_params.m_base_index->pprev == nullptr ||
+        !util_params.m_chainman.IsQuorumTypeEnabled(llmqType, util_params.m_base_index->pprev)) {
         return {};
     }
 

--- a/src/test/evo_utils_tests.cpp
+++ b/src/test/evo_utils_tests.cpp
@@ -5,7 +5,9 @@
 #include <test/util/setup_common.h>
 
 #include <chainparams.h>
+#include <llmq/context.h>
 #include <llmq/options.h>
+#include <llmq/utils.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -66,6 +68,39 @@ BOOST_FIXTURE_TEST_CASE(utils_IsQuorumTypeEnabled_tests_regtest, RegTestingSetup
 BOOST_FIXTURE_TEST_CASE(utils_IsQuorumTypeEnabled_tests_mainnet, TestingSetup)
 {
     Test(m_node);
+}
+
+// Regression: a genesis quorum base has pprev == nullptr.
+// Pre-fix that pointer was fed to IsQuorumTypeEnabled's gsl::not_null parameter,
+// whose converting constructor calls Expects() and so std::terminate()s the
+// process. That is [[noreturn]] noexcept, not an exception, so no try/catch in
+// the validation or net-processing stack could contain it.
+//
+// Note the two guards below are not equivalent. Passing a literal nullptr was a
+// *compile* error pre-fix (not_null(std::nullptr_t) is deleted), so that line
+// only pins the relaxed signature. The GetAllQuorumMembers() call is the one
+// that reproduced the abort, since the null arrives through a runtime pointer.
+// The end-to-end consensus path is covered by
+// llmq_commitment_tests/commitment_genesis_quorum_hash_rejected_test.
+BOOST_FIXTURE_TEST_CASE(genesis_quorum_base_null_pprev_safe, RegTestingSetup)
+{
+    const CBlockIndex* genesis = WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip());
+    BOOST_REQUIRE(genesis != nullptr);
+    BOOST_REQUIRE_EQUAL(genesis->nHeight, 0);
+    BOOST_REQUIRE(genesis->pprev == nullptr);
+
+    const auto llmq_type = Params().GetConsensus().llmqTypeChainLocks;
+
+    // IsQuorumTypeEnabled sink pattern (NetDKG passes pQuorumBaseBlockIndex->pprev).
+    BOOST_CHECK(!m_node.chainman->IsQuorumTypeEnabled(llmq_type, nullptr));
+
+    // GetAllQuorumMembers with m_base_index == genesis.
+    const llmq::UtilParameters util_params{*Assert(m_node.dmnman),
+                                           *Assert(m_node.llmq_ctx)->qsnapman,
+                                           *Assert(m_node.chainman),
+                                           genesis};
+    const auto members = llmq::utils::GetAllQuorumMembers(llmq_type, util_params);
+    BOOST_CHECK(members.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/llmq_commitment_tests.cpp
+++ b/src/test/llmq_commitment_tests.cpp
@@ -17,6 +17,7 @@
 #include <streams.h>
 #include <util/check.h>
 #include <util/strencodings.h>
+#include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -190,6 +191,49 @@ BOOST_FIXTURE_TEST_CASE(commitment_check_undersized_bitset_debug_log_test, RegTe
                         "expected clamped 'validMembers[]', got: " + *it);
     BOOST_CHECK_MESSAGE(it->find("v[0]") == std::string::npos,
                         "unexpected v[0] in clamped log line: " + *it);
+}
+
+BOOST_FIXTURE_TEST_CASE(commitment_genesis_quorum_hash_rejected_test, RegTestingSetup)
+{
+    // End-to-end regression: a mined TRANSACTION_QUORUM_COMMITMENT whose
+    // quorumHash names the genesis block. Genesis has pprev == nullptr, and
+    // CFinalCommitment::Verify -> GetAllQuorumMembers used to hand that null to
+    // ChainstateManager::IsQuorumTypeEnabled's gsl::not_null parameter, which
+    // std::terminate()s the node. This drives the real consensus entry point
+    // (CheckLLMQCommitment), so the whole chain of guards is exercised: without
+    // them this test aborts the test binary (SIGABRT) rather than failing.
+    const CBlockIndex* genesis = WITH_LOCK(::cs_main, return m_node.chainman->ActiveTip());
+    BOOST_REQUIRE(genesis != nullptr);
+    BOOST_REQUIRE_EQUAL(genesis->nHeight, 0);
+    BOOST_REQUIRE(genesis->pprev == nullptr);
+
+    CFinalCommitmentTxPayload payload;
+    payload.nVersion = CFinalCommitmentTxPayload::CURRENT_VERSION;
+    // CheckLLMQCommitment requires nHeight == m_base_index->nHeight + 1.
+    payload.nHeight = 1;
+    payload.commitment = CreateValidCommitment(TEST_PARAMS, genesis->GetBlockHash());
+    // Genesis is past regtest's V19Height (1) and TEST_PARAMS does not rotate.
+    payload.commitment.nVersion = CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+    BOOST_REQUIRE(!payload.commitment.IsNull());
+
+    CMutableTransaction mtx;
+    mtx.nVersion = CTransaction::SPECIAL_VERSION;
+    mtx.nType = TRANSACTION_QUORUM_COMMITMENT;
+    SetTxPayload(mtx, payload);
+    const CTransaction tx{mtx};
+
+    const llmq::UtilParameters util_params{*Assert(m_node.dmnman),
+                                           *Assert(m_node.llmq_ctx)->qsnapman,
+                                           *Assert(m_node.chainman),
+                                           genesis};
+
+    TxValidationState state;
+    BOOST_CHECK(!llmq::CheckLLMQCommitment(util_params, tx, state));
+    BOOST_CHECK(state.IsInvalid());
+    // Reached Verify(), where the empty member set makes the validMembers bitset
+    // check reject. Any earlier reject reason would mean the test stopped short
+    // of the vulnerable code path.
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-qc-invalid");
 }
 
 BOOST_AUTO_TEST_CASE(commitment_serialization_test)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5723,10 +5723,15 @@ bool ChainstateManager::IsSnapshotActive() const
 }
 
 bool ChainstateManager::IsQuorumTypeEnabled(const Consensus::LLMQType llmqType,
-                                            gsl::not_null<const CBlockIndex*> pindexPrev,
+                                            const CBlockIndex* pindexPrev,
                                             std::optional<bool> optDIP0024IsActive,
                                             std::optional<bool> optHaveDIP0024Quorums) const
 {
+    // Null pindexPrev (genesis has no parent) means no prior height for an LLMQ type.
+    if (pindexPrev == nullptr) {
+        return false;
+    }
+
     constexpr int TESTNET_LLMQ_25_67_ACTIVATION_HEIGHT = 847000;
 
     const bool fDIP0024IsActive{optDIP0024IsActive.value_or(

--- a/src/validation.h
+++ b/src/validation.h
@@ -1091,7 +1091,8 @@ public:
     //! ResizeCoinsCaches() as needed.
     void MaybeRebalanceCaches() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    bool IsQuorumTypeEnabled(const Consensus::LLMQType llmqType, gsl::not_null<const CBlockIndex*> pindexPrev,
+    //! pindexPrev may be nullptr (e.g. genesis has no parent); null returns false.
+    bool IsQuorumTypeEnabled(const Consensus::LLMQType llmqType, const CBlockIndex* pindexPrev,
                              std::optional<bool> optDIP0024IsActive = std::nullopt,
                              std::optional<bool> optHaveDIP0024Quorums = std::nullopt) const;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`ChainstateManager::IsQuorumTypeEnabled` took `gsl::not_null<const CBlockIndex*>`. Three call sites pass a `pprev` that is null when the quorum base index is genesis: `llmq::utils::GetAllQuorumMembers`, `NetDKG::ProcessMessage`, and indirectly `CFinalCommitment::Verify`/`VerifySignatureAsync`.

The `not_null` converting constructor calls `Expects()`, which routes to `gsl::details::terminate()`. That function is `[[noreturn]] noexcept`, so this is a process abort and **not** an exception - the `try`/`catch(std::exception&)` in `CheckSpecialTx` cannot contain it. It is reached before any signature check, since `GetAllQuorumMembers` runs ahead of the `checkSigs` block in `Verify`.

Three entry points, with different gates:

- **`qfcommit` from an unauthenticated peer.** `CQuorumBlockProcessor::ProcessMessage` is dispatched with no MNAuth gate. An attacker sets `quorumHash` to the genesis hash. All pre-`Verify` gates pass except the "too old" height check, so this requires the victim's height to be at or below the DKG interval - i.e. any node in the first minutes of a fresh sync, and trivially on regtest/devnet.
- **DKG messages from any MNAuth-verified peer.** Gated only on a verified proRegTx, so any masternode operator can abort any node at any height. This is the more serious variant.
- **Block validation.** Mempool acceptance is closed to quorum commitments, so this needs a mined block.

## What was done?

- Change `IsQuorumTypeEnabled` to accept a raw pointer and return `false` on null, fixing the sink itself.
- Add defence-in-depth null checks at `GetAllQuorumMembers` and in the DKG message path, covering all three entry points including `ProcessSpecialTxsInBlock`.
- Reject quorum commitments with an empty member set. This also closes a genuine out-of-bounds read at `members[0]` in the single-member branch.

**On consensus safety of the empty-members check:** it has no consensus implication. An empty member set already fails `Verify`'s `validMembers`/`signers` bitset loop with `bad-qc-invalid`, and the aggregate BLS path with an empty pubkey vector can never verify true, so nothing currently accepted becomes rejected.

**Reviewer note:** relaxing the signature from `not_null` to a raw pointer weakens the contract for all other callers. If reviewers prefer, the alternative is to keep `not_null` and null-check at every call site instead; that was judged noisier for the same guarantee.

## How Has This Been Tested?

The first commit adds a regression test covering the genesis/null-pprev terminate path, ordered before the fix.

Full build and test validation is delegated to CI on this PR; the changes were not built locally.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
