### PR TITLE
fix(net): bound verified inbound connections per proRegTxHash

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -113,6 +113,7 @@ BITCOIN_TESTS =\
   test/evo_db_tests.cpp \
   test/evo_deterministicmns_tests.cpp \
   test/evo_islock_tests.cpp \
+  test/evo_mnauth_tests.cpp \
   test/evo_mnhf_tests.cpp \
   test/evo_netinfo_tests.cpp \
   test/evo_simplifiedmns_tests.cpp \

--- a/src/evo/mnauth.cpp
+++ b/src/evo/mnauth.cpp
@@ -155,8 +155,12 @@ MessageProcessingResult CMNAuth::ProcessMessage(CNode& peer, ServiceFlags node_s
         return {};
     }
 
-    peer.SetVerifiedProRegTxHash(mnauth.proRegTxHash);
-    peer.SetVerifiedPubKeyHash(dmn->pdmnState->pubKeyOperator.GetHash());
+    if (!connman.TryMarkVerified(peer.GetId(), mnauth.proRegTxHash, dmn->pdmnState->pubKeyOperator.GetHash())) {
+        // At the verified-inbound cap for this identity. Not a misbehavior: a legitimate
+        // reconnect racing not-yet-reaped stale legs must not be banned.
+        peer.fDisconnect = true;
+        return {};
+    }
 
     if (!peer.m_masternode_iqr_connection && connman.IsMasternodeQuorumRelayMember(peer.GetVerifiedProRegTxHash())) {
         // Tell our peer that we're interested in plain LLMQ recovered signatures.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1947,9 +1947,9 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
 
     // Evict connections until we are below nMaxInbound. In case eviction protection resulted in nodes to not be evicted
     // before, they might get evicted in batches now (after the protection timeout).
-    // We don't evict verified MN connections and also don't take them into account when checking limits. We can do this
-    // because we know that such connections are naturally limited by the total number of MNs, so this is not usable
-    // for attacks.
+    // We don't evict verified MN connections and also don't take them into account when checking limits. We can do
+    // this because such connections are limited by the total number of MNs times MAX_VERIFIED_INBOUND_PER_PROTX
+    // (enforced in TryMarkVerified), so this is not usable for attacks.
     while (nInbound - nVerifiedInboundMasternodes >= nMaxInbound)
     {
         if (!AttemptToEvictConnection()) {
@@ -4474,6 +4474,34 @@ void CConnman::AddPendingProbeConnections(const Uint256HashSet& proTxHashes)
 {
     LOCK(cs_vPendingMasternodes);
     masternodePendingProbes.insert(proTxHashes.begin(), proTxHashes.end());
+}
+
+bool CConnman::TryMarkVerified(NodeId id, const uint256& proregtx_hash, const uint256& pubkey_hash)
+{
+    // Exclusive, not shared: the count and the grant must be one atomic step or concurrent
+    // callers could each pass the check and jointly exceed the cap.
+    LOCK(m_nodes_mutex);
+    CNode* node = FindNodeMutable(id, /*fExcludeDisconnecting=*/false);
+    if (node == nullptr) {
+        return false;
+    }
+    if (node->IsInboundConn()) {
+        size_t verified_inbound{0};
+        for (const CNode* pnode : m_nodes) {
+            if (pnode != node && !pnode->fDisconnect && pnode->IsInboundConn() &&
+                pnode->GetVerifiedProRegTxHash() == proregtx_hash) {
+                ++verified_inbound;
+            }
+        }
+        if (verified_inbound >= MAX_VERIFIED_INBOUND_PER_PROTX) {
+            LogPrint(BCLog::NET_NETCONN, "CConnman::%s -- refusing to verify masternode %s: already %d verified inbound connections, peer=%d\n",
+                     __func__, proregtx_hash.ToString(), verified_inbound, id);
+            return false;
+        }
+    }
+    node->SetVerifiedProRegTxHash(proregtx_hash);
+    node->SetVerifiedPubKeyHash(pubkey_hash);
+    return true;
 }
 
 size_t CConnman::GetNodeCount(ConnectionDirection flags) const

--- a/src/net.h
+++ b/src/net.h
@@ -96,6 +96,26 @@ static const int MAX_BLOCK_RELAY_ONLY_CONNECTIONS = 2;
 static const int MAX_DESIRED_ONION_CONNECTIONS = 2;
 /** Maximum number of feeler connections */
 static const int MAX_FEELER_CONNECTIONS = 1;
+/**
+ * Upper bound on simultaneous verified *inbound* connections carrying the same proRegTxHash,
+ * enforced by CConnman::TryMarkVerified.
+ *
+ * A verified inbound masternode peer is exempt from the inbound connection limit
+ * (CreateNodeFromAcceptedSocket) and protected from eviction (GetEvictionCandidates), so without a
+ * bound a single operator key could stack such slots without end.
+ *
+ * The limit is not 1: a reconnect racing a socket we have not yet detected as dead legitimately
+ * produces a second verified inbound leg. Refusing it would strand the peer until InactivityCheck
+ * fires (TIMEOUT_INTERVAL, 20 minutes) — nothing in src/ sets SO_KEEPALIVE or TCP_USER_TIMEOUT, so
+ * that is the only reaper of half-open sockets, and where the peer is the deterministic outbound
+ * side we never dial it, leaving no other recovery path. A small allowance keeps that case working
+ * while making the exemption a bounded multiple of the masternode count. If a lower-level reaper
+ * is ever added, this value can likely be tightened.
+ *
+ * Consequently, up to this many verified legs per proRegTxHash may coexist: code that maps
+ * proRegTxHash -> node (e.g. sig-share routing) must tolerate duplicates.
+ */
+static constexpr size_t MAX_VERIFIED_INBOUND_PER_PROTX{3};
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** The maximum number of peer connections to maintain.
@@ -1481,6 +1501,16 @@ public:
     bool IsMasternodeQuorumNode(const CNode* pnode, const CDeterministicMNList& tip_mn_list) const;
     bool IsMasternodeQuorumRelayMember(const uint256& protxHash);
     void AddPendingProbeConnections(const Uint256HashSet& proTxHashes);
+
+    /**
+     * Mark a peer as a verified masternode connection, granting it the inbound-limit exemption and
+     * eviction protection tied to that status. Returns false, leaving the peer unmarked, if the
+     * peer no longer exists or — for inbound peers — once MAX_VERIFIED_INBOUND_PER_PROTX verified
+     * inbound connections already carry the same proRegTxHash; see that constant for the rationale.
+     * All paths that verify a masternode connection must go through this gate.
+     */
+    bool TryMarkVerified(NodeId id, const uint256& proregtx_hash, const uint256& pubkey_hash)
+        EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
 
     size_t GetNodeCount(ConnectionDirection) const EXCLUSIVE_LOCKS_REQUIRED(!m_nodes_mutex);
     std::map<CNetAddr, LocalServiceInfo> getNetLocalAddresses() const;

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -312,13 +312,7 @@ static RPCHelpMan mnauth()
     }
 
     const NodeContext& node = EnsureAnyNodeContext(request.context);
-    bool fSuccess = node.connman->ForNode(nodeId, CConnman::AllNodes, [&](CNode* pNode){
-        pNode->SetVerifiedProRegTxHash(proTxHash);
-        pNode->SetVerifiedPubKeyHash(publicKey.GetHash());
-        return true;
-    });
-
-    return fSuccess;
+    return node.connman->TryMarkVerified(nodeId, proTxHash, publicKey.GetHash());
 },
     };
 }

--- a/src/test/evo_mnauth_tests.cpp
+++ b/src/test/evo_mnauth_tests.cpp
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <net.h>
+#include <node/connection_types.h>
+#include <protocol.h>
+#include <test/util/net.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <memory>
+
+static_assert(MAX_VERIFIED_INBOUND_PER_PROTX >= 2,
+              "cap must tolerate a reconnect racing a not-yet-reaped socket");
+
+BOOST_FIXTURE_TEST_SUITE(evo_mnauth_tests, BasicTestingSetup)
+
+namespace {
+
+//! Ownership passes to ConnmanTestMsg, which deletes the nodes in ClearTestNodes().
+CNode& AddNode(ConnmanTestMsg& connman, NodeId id, ConnectionType conn_type)
+{
+    auto* node = new CNode{id,
+                           /*sock=*/nullptr,
+                           CAddress{},
+                           /*nKeyedNetGroupIn=*/0,
+                           /*nLocalHostNonceIn=*/0,
+                           CAddress{},
+                           /*addrNameIn=*/"",
+                           conn_type,
+                           /*inbound_onion=*/false};
+    connman.AddTestNode(*node);
+    return *node;
+}
+
+} // namespace
+
+/**
+ * CConnman::TryMarkVerified is the sole gate to verified-masternode status, which exempts an
+ * inbound peer from the inbound connection limit and protects it from eviction. It must refuse the
+ * grant once MAX_VERIFIED_INBOUND_PER_PROTX verified inbound connections already carry the same
+ * proRegTxHash, else one operator key could stack limit-exempt, eviction-immune slots without end.
+ */
+BOOST_AUTO_TEST_CASE(verified_inbound_capped_per_protx)
+{
+    auto connman = std::make_unique<ConnmanTestMsg>(0x1337, 0x1337, *m_node.addrman, *m_node.netgroupman);
+
+    const uint256 attacker{1};
+    const uint256 other{2};
+    const uint256 pubkey_hash{3};
+    NodeId id{0};
+
+    // An unknown peer id cannot be granted anything.
+    BOOST_CHECK(!connman->TryMarkVerified(/*id=*/1337, attacker, pubkey_hash));
+
+    // Inbound legs sharing one identity accumulate against that identity's budget; grants below
+    // the cap succeed, the first grant beyond it is refused and leaves the peer unmarked.
+    CNode* first_leg{nullptr};
+    for (size_t i = 0; i < MAX_VERIFIED_INBOUND_PER_PROTX; ++i) {
+        CNode& node = AddNode(*connman, id++, ConnectionType::INBOUND);
+        if (i == 0) first_leg = &node;
+        BOOST_CHECK(connman->TryMarkVerified(node.GetId(), attacker, pubkey_hash));
+        BOOST_CHECK_EQUAL(node.GetVerifiedProRegTxHash(), attacker);
+        BOOST_CHECK_EQUAL(node.GetVerifiedPubKeyHash(), pubkey_hash);
+    }
+    CNode& refused = AddNode(*connman, id++, ConnectionType::INBOUND);
+    BOOST_CHECK(!connman->TryMarkVerified(refused.GetId(), attacker, pubkey_hash));
+    BOOST_CHECK(refused.GetVerifiedProRegTxHash().IsNull());
+    BOOST_CHECK(refused.GetVerifiedPubKeyHash().IsNull());
+
+    // The budget is per identity, and unverified inbound legs such as `refused` do not consume it:
+    // they already count against nInbound and remain ordinary eviction candidates.
+    CNode& other_node = AddNode(*connman, id++, ConnectionType::INBOUND);
+    BOOST_CHECK(connman->TryMarkVerified(other_node.GetId(), other, pubkey_hash));
+
+    // Outbound legs are not part of the resource being bounded: neither the limit exemption nor
+    // eviction protection applies to them, so they are granted beyond the cap.
+    CNode& outbound = AddNode(*connman, id++, ConnectionType::OUTBOUND_FULL_RELAY);
+    BOOST_CHECK(connman->TryMarkVerified(outbound.GetId(), attacker, pubkey_hash));
+
+    // A verified leg already flagged for disconnect no longer holds its slot, so a reconnect
+    // racing a stale socket is accepted as soon as the stale leg is being torn down.
+    first_leg->fDisconnect = true;
+    BOOST_CHECK(connman->TryMarkVerified(refused.GetId(), attacker, pubkey_hash));
+    BOOST_CHECK_EQUAL(refused.GetVerifiedProRegTxHash(), attacker);
+
+    connman->ClearTestNodes();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/rpc_mnauth.py
+++ b/test/functional/rpc_mnauth.py
@@ -57,6 +57,30 @@ class FakeMNAUTHTest(DashTestFramework):
                                                          null_hash)
         assert not node.mnauth(-1, protx_hash, public_key)
 
+        # Bound on verified inbound connections per proRegTxHash; keep in sync with
+        # MAX_VERIFIED_INBOUND_PER_PROTX in src/net.h.
+        max_verified_inbound = 3
+
+        # The connection verified above already holds one slot; fill the remaining budget.
+        extra_peers = []
+        for _ in range(max_verified_inbound - 1):
+            extra_peers.append(node.add_p2p_connection(P2PInterface()))
+            peer_id = node.getpeerinfo()[-1]["id"]
+            assert node.mnauth(peer_id, protx_hash, public_key)
+
+        # The next inbound leg carrying the same identity is refused and stays unverified...
+        node.add_p2p_connection(P2PInterface())
+        refused_id = node.getpeerinfo()[-1]["id"]
+        assert not node.mnauth(refused_id, protx_hash, public_key)
+        assert "verified_proregtx_hash" not in node.getpeerinfo()[-1]
+
+        # ...until a verified leg goes away and frees its slot.
+        peer_count = len(node.getpeerinfo())
+        extra_peers[0].peer_disconnect()
+        self.wait_until(lambda: len(node.getpeerinfo()) == peer_count - 1)
+        assert node.mnauth(refused_id, protx_hash, public_key)
+        assert_equal(node.getpeerinfo()[-1]["verified_proregtx_hash"], protx_hash)
+
 
 if __name__ == '__main__':
     FakeMNAUTHTest().main()


### PR DESCRIPTION
## Issue being fixed or feature implemented

A verified inbound masternode peer gets two privileges:

- it is subtracted from the inbound limit in `CConnman::CreateNodeFromAcceptedSocket` (`nInbound - nVerifiedInboundMasternodes >= nMaxInbound`), so it costs nothing against the cap;
- it is unconditionally protected from eviction in `CConnman::GetEvictionCandidates`.

The in-tree comment justifies granting both with "we know that such connections are naturally limited by the total number of MNs, so this is not usable for attacks". That reasoning assumes the number of verified inbound connections per proRegTxHash is bounded. It was not.

`CMNAuth::ProcessMessage`'s duplicate handling does not converge when **both** legs are inbound:

- in the `deterministicOutbound == myProTxHash` branch it only sets `m_masternode_probe_connection` on the old leg — a deferred hint acted on by `CMasternodeUtils::DoMaintenance` only after `PROBE_WAIT_INTERVAL`, and only once outbound capacity is tight;
- in the other branch it tests `!IsInboundConn()` on both peers, which is false for both, so nothing happens at all.

Either way both sockets stay verified. An attacker holding a single masternode operator BLS key can therefore open connections to a masternode victim and accumulate limit-exempt, eviction-immune slots without end — exhausting connection slots and crowding honest peers out of the victim's inbound table, which also helps toward degrading a quorum member.

MNAUTH is signed over a per-connection random challenge, so it cannot be replayed: the attacker must genuinely hold an operator key, and the victim must itself be an active masternode.

## What was done?

Cap the number of simultaneous verified **inbound** connections per proRegTxHash at `MAX_VERIFIED_INBOUND_PER_PROTX`.

Enforcement lives in a new `CConnman::TryMarkVerified(NodeId, proRegTxHash, pubKeyHash)`, which is now the **single gate** through which a connection acquires verified-masternode status. It counts the verified inbound legs already carrying the identity and grants (or refuses) in one exclusive `m_nodes_mutex` scope — the count and the set are atomic, so the bound holds even if a future caller is not serialized the way today's message-handler thread is. Placing enforcement next to the state it guards and the privileges that state buys (both in `net.cpp`) means the cap is bounded by construction rather than by an invariant maintained at a distant call site.

Both callers route through the gate:

- `CMNAuth::ProcessMessage` calls it instead of setting the verified hash directly, and disconnects the new peer if the grant is refused;
- the regtest-only `mnauth` RPC calls it too, which additionally lets a functional test exercise the refusal path end to end.

The existing duplicate-resolution logic is deliberately left exactly as it is. The deterministic-outbound preference, the probe marking, and the drop-outbound branches are all unchanged; the gate simply refuses a new inbound leg once the identity is already at its limit.

**Why a cap rather than enforcing uniqueness.** The defect is that the count was *unbounded*, not that duplicates exist at all. Duplicates below the cap keep every privilege they have today, so ordinary churn is unaffected — in particular a reconnect that races a socket we have not yet detected as dead legitimately produces a second verified inbound leg. Refusing that leg would strand the peer until `InactivityCheck` fires at `TIMEOUT_INTERVAL` (20 minutes); there is no `SO_KEEPALIVE` or `TCP_USER_TIMEOUT` anywhere in `src/` to reap a half-open socket sooner, the peer retries every 60 s in the meantime, and where the peer is the deterministic outbound side this node never dials it, so there is no other recovery path. Leaving headroom avoids that class of problem entirely while still making the exemption a bounded multiple of the masternode count. A refused grant carries **no** misbehavior penalty, for the same reason.

Only inbound legs are counted, since neither the limit exemption nor the eviction protection applies to outbound ones. Legs already flagged `fDisconnect` do not count, so a reconnect racing a socket that is being torn down is accepted immediately.

The cap value is a named constant (currently 3: one live leg plus up to two not-yet-reaped stale ones) documented in `net.h` and trivial to tune.

## How Has This Been Tested?

`src/test/evo_mnauth_tests.cpp` builds a `ConnmanTestMsg` with fake peers and drives `TryMarkVerified` directly, asserting that grants succeed up to the cap and the next inbound leg for the same identity is refused and left unmarked; that the budget is per-identity (one peer cannot consume another's); that outbound legs are exempt from the cap; and that flagging a verified leg `fDisconnect` frees its slot for a reconnect. A `static_assert` pins that the cap can never be tightened to 1, so the reconnect-churn case cannot be regressed later.

`test/functional/rpc_mnauth.py` now drives the same path through the RPC: it fills the identity's budget, asserts the next inbound leg is refused and stays unverified, disconnects a verified leg, and asserts the refused peer can then be verified. Because the RPC now routes through the gate, this is real end-to-end coverage of the enforcement rather than of `SetVerifiedProRegTxHash` alone.

Built locally; `test_dash --run_test=evo_mnauth_tests` and `rpc_mnauth.py` pass. Full validation is delegated to CI.

## Breaking Changes

None for honest peers. A masternode that legitimately holds fewer than `MAX_VERIFIED_INBOUND_PER_PROTX` verified inbound connections to a single peer sees no change in behaviour.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
