### PR TITLE
fix: require a valid masternode signature before caching an orphan governance vote

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -826,9 +826,7 @@ bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceExc
 
     auto it = mapObjects.find(nHashGovobj);
     if (it == mapObjects.end()) {
-        // The parent object is unknown, so the vote signal cannot be mapped to a key type the way
-        // CGovernanceObject::ProcessVote does it (see onlyVotingKeyAllowed there). Accept either key.
-        if (!vote.IsValid(tip_mn_list, /*useVotingKey=*/true) && !vote.IsValid(tip_mn_list, /*useVotingKey=*/false)) {
+        if (!vote.IsValidForUnknownParent(tip_mn_list)) {
             std::string msg{strprintf("CGovernanceManager::%s -- Invalid vote for unknown parent object %s, MN outpoint = %s, vote hash = %s",
                 __func__, nHashGovobj.ToString(), vote.GetMasternodeOutpoint().ToStringShort(), nHashVote.ToString())};
             LogPrint(BCLog::GOBJECT, "%s\n", msg);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -804,6 +804,8 @@ bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceExc
     AssertLockNotHeld(cs_store);
     hashToRequest = uint256{};
 
+    const auto tip_mn_list{m_dmnman.GetListAtChainTip()};
+
     LOCK(cs_store);
     uint256 nHashVote = vote.GetHash();
     uint256 nHashGovobj = vote.GetParentHash();
@@ -824,8 +826,19 @@ bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceExc
 
     auto it = mapObjects.find(nHashGovobj);
     if (it == mapObjects.end()) {
+        // The parent object is unknown, so the vote signal cannot be mapped to a key type the way
+        // CGovernanceObject::ProcessVote does it (see onlyVotingKeyAllowed there). Accept either key.
+        if (!vote.IsValid(tip_mn_list, /*useVotingKey=*/true) && !vote.IsValid(tip_mn_list, /*useVotingKey=*/false)) {
+            std::string msg{strprintf("CGovernanceManager::%s -- Invalid vote for unknown parent object %s, MN outpoint = %s, vote hash = %s",
+                __func__, nHashGovobj.ToString(), vote.GetMasternodeOutpoint().ToStringShort(), nHashVote.ToString())};
+            LogPrint(BCLog::GOBJECT, "%s\n", msg);
+            exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
+            return false;
+        }
         std::string msg{strprintf("CGovernanceManager::%s -- Unknown parent object %s, MN outpoint = %s", __func__,
             nHashGovobj.ToString(), vote.GetMasternodeOutpoint().ToStringShort())};
+        // No penalty: the vote is signed by a masternode, it just arrived before its parent object,
+        // which routinely happens during governance sync. Misbehaviour scores never decay.
         exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_WARNING);
         if (cmmapOrphanVotes.Insert(nHashGovobj, governance::OrphanVote{vote, Now<NodeSeconds>() + GOVERNANCE_ORPHAN_EXPIRATION_TIME})) {
             hashToRequest = nHashGovobj; // Caller should request this object
@@ -842,7 +855,7 @@ bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceExc
         return false;
     }
 
-    bool fOk = govobj.ProcessVote(m_mn_metaman, fRateChecksEnabled, m_dmnman.GetListAtChainTip(), vote, exception);
+    bool fOk = govobj.ProcessVote(m_mn_metaman, fRateChecksEnabled, tip_mn_list, vote, exception);
     if (fOk) {
         fOk = cmapVoteToObject.Insert(nHashVote, it->second);
     } else if (exception.GetType() == GOVERNANCE_EXCEPTION_PERMANENT_ERROR && exception.GetNodePenalty() == 20) {

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -241,6 +241,14 @@ bool CGovernanceVote::IsValid(const CDeterministicMNList& tip_mn_list, bool useV
     }
 }
 
+bool CGovernanceVote::IsValidForUnknownParent(const CDeterministicMNList& tip_mn_list) const
+{
+    if (nVoteSignal == VOTE_SIGNAL_FUNDING && IsValid(tip_mn_list, /*useVotingKey=*/true)) {
+        return true;
+    }
+    return IsValid(tip_mn_list, /*useVotingKey=*/false);
+}
+
 
 bool operator==(const CGovernanceVote& vote1, const CGovernanceVote& vote2)
 {

--- a/src/governance/vote.h
+++ b/src/governance/vote.h
@@ -149,6 +149,15 @@ public:
     bool CheckSignature(const CKeyID& keyID) const;
     bool CheckSignature(const CBLSPublicKey& pubKey) const;
     bool IsValid(const CDeterministicMNList& tip_mn_list, bool useVotingKey) const;
+    /**
+     * Validation for a vote whose parent object is unknown, so the exact key
+     * requirement cannot be derived yet. Only a funding vote can ever be
+     * voting-key-signed (PROPOSAL + VOTE_SIGNAL_FUNDING -- see onlyVotingKeyAllowed
+     * in CGovernanceObject::ProcessVote); every other signal requires the operator
+     * key for every object type, and a funding vote on a non-proposal will be
+     * re-checked against the operator-key requirement when its parent arrives.
+     */
+    bool IsValidForUnknownParent(const CDeterministicMNList& tip_mn_list) const;
 
     /** The memoised verdict for this key, or nullopt if the next CheckSignature
      *  with it would have to run the cryptography. */

--- a/src/test/governance_inv_tests.cpp
+++ b/src/test/governance_inv_tests.cpp
@@ -7,6 +7,7 @@
 #include <governance/governance.h>
 #include <governance/net_governance.h>
 #include <governance/object.h>
+#include <masternode/meta.h>
 #include <masternode/sync.h>
 #include <net.h>
 #include <net_processing.h>
@@ -394,7 +395,12 @@ BOOST_AUTO_TEST_CASE(governance_votes_require_peer_announcement_or_request)
     m_node.peerman->InitializeNode(*second_announcing_peer, NODE_NETWORK);
     m_node.peerman->InitializeNode(*unsolicited_peer, NODE_NETWORK);
 
-    auto& connman = static_cast<ConnmanTestMsg&>(*m_node.connman);
+    // The vote below carries an unknown masternode outpoint, so CGovernanceManager::ProcessVote
+    // rejects it with a penalty of 20. Only a peer that passes the announce-then-request gate
+    // reaches ProcessVote at all, which makes the score the observable for the gate itself.
+    // Penalties are applied only once fully synced.
+    m_node.mn_sync->SwitchToNextAsset();
+    BOOST_REQUIRE(m_node.mn_sync->IsSynced());
 
     const CGovernanceVote vote{MakeGovernanceVote(uint256S("31"))};
     const CInv vote_inv{MSG_GOVERNANCE_OBJECT_VOTE, vote.GetHash()};
@@ -406,20 +412,17 @@ BOOST_AUTO_TEST_CASE(governance_votes_require_peer_announcement_or_request)
     ProcessInv(*m_node.peerman, *announcing_peer, vote_inv);
     ProcessInv(*m_node.peerman, *second_announcing_peer, vote_inv);
 
-    connman.FlushSendBuffer(*announcing_peer);
     ProcessGovernanceVote(net_gov, *announcing_peer, vote);
-    BOOST_CHECK_EQUAL(CountQueuedMessages(*announcing_peer, NetMsgType::MNGOVERNANCESYNC), 1U);
-    AssertMisbehaviorScore(*m_node.peerman, *announcing_peer, 0);
+    BOOST_CHECK(
+        !WITH_LOCK(::cs_main, return m_node.peerman->PeerConsumeObjectRequest(announcing_peer->GetId(), vote_inv)));
+    AssertMisbehaviorScore(*m_node.peerman, *announcing_peer, 20);
 
-    connman.FlushSendBuffer(*second_announcing_peer);
     ProcessGovernanceVote(net_gov, *second_announcing_peer, vote);
-    // Second announcer: the gate accepts (it independently announced the vote) and consumes
-    // its per-peer request entry. A rejected vote would return before the gate consumes and
-    // leave the entry intact, so this proves the accept path independently of the (deduped)
-    // orphan-request side effect.
+    // Consumption is per-peer: the second announcer's own entry is accepted and consumed,
+    // independent of the first peer's already-consumed entry.
     BOOST_CHECK(!WITH_LOCK(::cs_main,
                            return m_node.peerman->PeerConsumeObjectRequest(second_announcing_peer->GetId(), vote_inv)));
-    AssertMisbehaviorScore(*m_node.peerman, *second_announcing_peer, 0);
+    AssertMisbehaviorScore(*m_node.peerman, *second_announcing_peer, 20);
 
     m_node.peerman->FinalizeNode(*announcing_peer);
     m_node.peerman->FinalizeNode(*second_announcing_peer);
@@ -442,7 +445,6 @@ BOOST_AUTO_TEST_CASE(governance_vote_authorization_survives_unsynced_drop)
 
     auto peer{MakeGovernanceInvPeer(/*id=*/31)};
     m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
-    auto& connman = static_cast<ConnmanTestMsg&>(*m_node.connman);
 
     const CGovernanceVote vote{MakeGovernanceVote(uint256S("41"))};
     const CInv vote_inv{MSG_GOVERNANCE_OBJECT_VOTE, vote.GetHash()};
@@ -454,20 +456,97 @@ BOOST_AUTO_TEST_CASE(governance_vote_authorization_survives_unsynced_drop)
     // Not synced: delivering the vote is dropped at the sync gate and must NOT consume the request.
     m_node.mn_sync->Reset(/*fForce=*/true, /*fNotifyReset=*/false);
     BOOST_REQUIRE(!m_node.mn_sync->IsBlockchainSynced());
-    connman.FlushSendBuffer(*peer);
     ProcessGovernanceVote(net_gov, *peer, vote);
-    BOOST_CHECK_EQUAL(CountQueuedMessages(*peer, NetMsgType::MNGOVERNANCESYNC), 0U);
+    AssertMisbehaviorScore(*m_node.peerman, *peer, 0);
 
-    // Back in sync, the retransmit is still authorized: ProcessVote runs and (orphan parent)
-    // requests the missing object. Had the unsynced drop consumed the request, the gate would now
-    // reject the vote as unrequested and send no MNGOVERNANCESYNC.
-    m_node.mn_sync->SwitchToNextAsset();
-    BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
-    connman.FlushSendBuffer(*peer);
+    // Back in sync, the retransmit is still authorized and reaches ProcessVote, which rejects the
+    // unknown masternode outpoint with a penalty of 20. Had the unsynced drop consumed the request,
+    // the gate would now reject the vote as unrequested and return before ProcessVote, leaving the
+    // score at 0.
+    while (!m_node.mn_sync->IsSynced()) {
+        m_node.mn_sync->SwitchToNextAsset();
+    }
     ProcessGovernanceVote(net_gov, *peer, vote);
-    BOOST_CHECK_EQUAL(CountQueuedMessages(*peer, NetMsgType::MNGOVERNANCESYNC), 1U);
+    AssertMisbehaviorScore(*m_node.peerman, *peer, 20);
 
     m_node.peerman->FinalizeNode(*peer);
+    chainstate.ResetIbd();
+}
+
+// A vote whose parent object is unknown must prove masternode authorship before it is cached.
+BOOST_AUTO_TEST_CASE(orphan_votes_require_a_valid_masternode_signature)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    TestChainState& chainstate =
+        *static_cast<TestChainState*>(&m_node.chainman->ActiveChainstate());
+    chainstate.JumpOutOfIbd();
+
+    // Penalties are applied only once fully synced.
+    m_node.mn_sync->SwitchToNextAsset();
+    BOOST_REQUIRE(m_node.mn_sync->IsSynced());
+
+    NetGovernance net_gov(m_node.peerman.get(), *m_node.govman, *m_node.mn_sync,
+                          *m_node.netfulfilledman, *m_node.connman);
+
+    auto peer{MakeGovernanceInvPeer(/*id=*/41)};
+    m_node.peerman->InitializeNode(*peer, NODE_NETWORK);
+    auto& connman = static_cast<ConnmanTestMsg&>(*m_node.connman);
+
+    // The tip masternode list is empty in this setup, so no vote can name a known collateral.
+    const CGovernanceVote vote{MakeGovernanceVote(uint256S("51"))};
+    const CInv vote_inv{MSG_GOVERNANCE_OBJECT_VOTE, vote.GetHash()};
+
+    ProcessInv(*m_node.peerman, *peer, vote_inv);
+    connman.FlushSendBuffer(*peer);
+    ProcessGovernanceVote(net_gov, *peer, vote);
+
+    BOOST_CHECK(m_node.govman->GetOrphanVoteObjectHashes().empty());
+    BOOST_CHECK_EQUAL(CountQueuedMessages(*peer, NetMsgType::MNGOVERNANCESYNC), 0U);
+    AssertMisbehaviorScore(*m_node.peerman, *peer, 20);
+
+    m_node.peerman->FinalizeNode(*peer);
+    chainstate.ResetIbd();
+}
+
+// The same unauthenticated vote must cost the sender the same whether or not its parent object
+// happens to have arrived first.
+BOOST_AUTO_TEST_CASE(invalid_vote_is_scored_alike_with_and_without_a_parent_object)
+{
+    LOCK(NetEventsInterface::g_msgproc_mutex);
+
+    TestChainState& chainstate =
+        *static_cast<TestChainState*>(&m_node.chainman->ActiveChainstate());
+    chainstate.JumpOutOfIbd();
+
+    m_node.mn_sync->SwitchToNextAsset();
+    BOOST_REQUIRE(m_node.mn_sync->IsSynced());
+    // The known-object path runs CGovernanceObject::ProcessVote, which asserts metaman.IsValid().
+    BOOST_REQUIRE(m_node.mn_metaman->LoadCache(/*load_cache=*/false));
+
+    NetGovernance net_gov(m_node.peerman.get(), *m_node.govman, *m_node.mn_sync,
+                          *m_node.netfulfilledman, *m_node.connman);
+
+    auto orphan_peer{MakeGovernanceInvPeer(/*id=*/51)};
+    auto known_parent_peer{MakeGovernanceInvPeer(/*id=*/52)};
+    m_node.peerman->InitializeNode(*orphan_peer, NODE_NETWORK);
+    m_node.peerman->InitializeNode(*known_parent_peer, NODE_NETWORK);
+
+    const CGovernanceObject govobj{MakeGovernanceObject(GetTime<std::chrono::seconds>().count(), uint256S("61"))};
+    const CGovernanceVote orphan_vote{MakeGovernanceVote(uint256S("62"))};
+    const CGovernanceVote known_parent_vote{MakeGovernanceVote(govobj.GetHash())};
+
+    ProcessInv(*m_node.peerman, *orphan_peer, CInv{MSG_GOVERNANCE_OBJECT_VOTE, orphan_vote.GetHash()});
+    ProcessGovernanceVote(net_gov, *orphan_peer, orphan_vote);
+    AssertMisbehaviorScore(*m_node.peerman, *orphan_peer, 20);
+
+    m_node.govman->AddGovernanceObjectForTesting(govobj);
+    ProcessInv(*m_node.peerman, *known_parent_peer, CInv{MSG_GOVERNANCE_OBJECT_VOTE, known_parent_vote.GetHash()});
+    ProcessGovernanceVote(net_gov, *known_parent_peer, known_parent_vote);
+    AssertMisbehaviorScore(*m_node.peerman, *known_parent_peer, 20);
+
+    m_node.peerman->FinalizeNode(*orphan_peer);
+    m_node.peerman->FinalizeNode(*known_parent_peer);
     chainstate.ResetIbd();
 }
 

--- a/src/test/governance_inv_tests.cpp
+++ b/src/test/governance_inv_tests.cpp
@@ -44,9 +44,9 @@ struct GovernanceInvSetup : public TestingSetup {
         BOOST_REQUIRE(m_node.mn_sync->IsBlockchainSynced());
 
         BOOST_REQUIRE(m_node.mn_metaman);
-        // Note: mn_metaman is left unloaded. No test here reaches
-        // CGovernanceObject::ProcessVote, which asserts metaman.IsValid() -- a vote whose
-        // parent object exists would, and would need it loaded first.
+        // Note: mn_metaman is left unloaded. Reaching CGovernanceObject::ProcessVote asserts
+        // metaman.IsValid(), so a test that delivers a vote whose parent object exists must
+        // load it first (see invalid_vote_is_scored_alike_with_and_without_a_parent_object).
         m_node.govman = std::make_unique<CGovernanceManager>(*m_node.mn_metaman, *m_node.chainman, *m_node.chain_helper->superblocks, *m_node.dmnman, *m_node.mn_sync);
         // Match runtime preconditions: NetGovernance::AlreadyHave claims we
         // already have the inv when governance isn't loaded (e.g.


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CGovernanceManager::ProcessVote()` caches votes whose parent governance object is not yet
in `mapObjects` ("orphan votes") into `cmmapOrphanVotes`, keyed by the vote's `nParentHash`.
Today the insert happens **before any masternode-membership or signature check**, and the
exception raised carries a zero misbehaviour penalty. The only thing standing between a peer
and that cache is the announce-then-request tracker in `src/governance/net_governance.cpp`
(the peer has to INV the vote hash first). Nothing about the vote's contents is verified.

So a peer can put arbitrary unvalidated attacker-chosen data into a node's governance cache
and pay nothing for it, and the node will additionally emit an `MNGOVERNANCESYNC` request for
the invented parent hash. Caching unverified peer data is the wrong default regardless of how
much of it fits.

Note also that the same garbage vote is scored differently depending on whether its parent
object happens to have arrived: with a parent present, `CGovernanceObject::ProcessVote`
rejects an unknown masternode with `GOVERNANCE_EXCEPTION_PERMANENT_ERROR` / penalty 20;
without a parent, the identical vote is silently cached with penalty 0.

## What was done?

In the orphan branch of `CGovernanceManager::ProcessVote`, require the vote to carry a valid
signature from a masternode present in the tip list before it may enter `cmmapOrphanVotes`:

```cpp
if (!vote.IsValidForUnknownParent(tip_mn_list)) {
    // GOVERNANCE_EXCEPTION_PERMANENT_ERROR, penalty 20
}
```

Notes on the specifics:

* **The existing validator is called rather than re-implementing its checks inline.**
  `CGovernanceVote::IsValid` already performs the future-time check, the signal/outcome bounds
  checks, the `GetMNByCollateral` lookup and the signature verification. Duplicating those
  inline would guarantee they drift apart from the known-object path over time.
* **Key selection is signal-aware** (`CGovernanceVote::IsValidForUnknownParent`). Which key is
  correct depends on the parent object's type and the vote signal (`onlyVotingKeyAllowed` in
  `CGovernanceObject::ProcessVote`): only `PROPOSAL` + `VOTE_SIGNAL_FUNDING` may ever use the
  voting key; every other signal requires the operator BLS key for every object type. So for a
  funding vote — whose parent type is by definition unknown on this path — either key is
  accepted, while all other signals are checked against the operator key only. This matters
  because the voting key is the lower-trust credential (routinely delegated to third-party
  voting services): without the signal check, a voting-key holder could cache non-funding votes
  that can never validate once their parent arrives. A funding vote on a non-proposal object
  still gets re-checked against the operator-key requirement at replay time.
* **Penalty 20 / `GOVERNANCE_EXCEPTION_PERMANENT_ERROR`** matches exactly what
  `CGovernanceObject::ProcessVote` already applies for an unknown masternode or a failed
  `IsValid` on the known-object path, so the same bad vote now costs the sender the same
  either way.
* **The orphan branch itself stays at penalty 0.** Once the gate passes, reaching that branch
  means the vote is signed by a masternode and the only reason it cannot be applied is that
  its parent has not arrived — a benign relay race that happens routinely during governance
  sync. Misbehaviour scores never decay, so scoring there would eventually disconnect honest
  relays.
* **Gate rejections are deliberately not inserted into `cmapInvalidVotes`.** That would make
  replays cheaper to reject, but `cmapInvalidVotes` is sized `MAX_CACHE_SIZE = 1'000'000` and
  caching gate rejections would create a *new* unauthenticated path for filling it with
  attacker-chosen entries — i.e. exactly the class of problem this change is meant to reduce.
* `m_dmnman.GetListAtChainTip()` is hoisted to the top of `ProcessVote` so both the orphan gate
  and the known-object path share a single call; previously it was fetched inline at the
  `govobj.ProcessVote` call site.

**On verifying signatures under `cs_store`:** this is not a new class of work under that lock.
The known-object path already does exactly this — `CGovernanceManager::ProcessVote` holds
`cs_store` across `govobj.ProcessVote(...)`, which calls `vote.IsValid(...)` at
`src/governance/object.cpp:458`. This change applies the established pattern to the orphan
branch. It does add up to two verifications for a vote that fails both, but only on the orphan
path and only for peers that already passed the announce-then-request gate.

### What this does and does not fix

This is a validation change. It does **not** close the underlying resource-exhaustion issue on
`cmmapOrphanVotes`, for four reasons worth stating plainly:

1. **A valid masternode signature is not scarce.** `nParentHash` *is* covered by the signature
   (see `GetSignatureString()` and the `SER_GETHASH` serialization in `src/governance/vote.h`),
   but nothing ties the signed parent hash to an object that actually exists. Any one of the
   ~4000 masternode keys can sign an unbounded number of votes naming invented parent hashes,
   and each one lands in a distinct cache slot.
2. **That path is penalty-0 by design** (see above), so a flood of well-signed orphan votes is
   unscored on purpose.
3. **Misbehaviour scoring is suppressed while `!IsSynced()`** — see the `m_node_sync.IsSynced()`
   condition guarding `PeerMisbehaving` in `net_governance.cpp` — which is precisely the window
   in which orphan votes are most common.
4. **Per-masternode vote rate limiting is unreachable here.** `GOVERNANCE_UPDATE_MIN` is
   enforced inside `CGovernanceObject::ProcessVote`, i.e. after the parent lookup, and it is
   explicitly disabled on replay (`ScopedLockBool guard(cs_store, fRateChecksEnabled, false)`
   in `CheckOrphanVotes`).

What it does buy: the cost of entry into the orphan cache goes from *free for any
unauthenticated peer* to *requires a masternode key*, and garbage votes that previously
vanished into the cache unscored are now scoreable — consistently with the known-object path.
That is correct hygiene, but the bound on the data structure is what actually caps the damage.
Bounding/expiring the cache is complementary work and is being handled separately in #7517 and
#7526; this PR is intentionally independent of both and will conflict with them textually.

One known side effect is deliberately left out of scope here.
`CGovernanceVote::CheckSignature(const CBLSPublicKey&)` logs its failure with an unconditional
`LogPrintf`, unlike its `CKeyID` sibling and unlike the rest of `IsValid`, which use
`LogPrint(BCLog::GOBJECT, ...)`. Reaching it previously required a vote naming a governance object
we actually have; after the gate, a vote naming an invented parent hash reaches it too, so a peer
holding a real masternode outpoint (public data) plus a garbage signature can write a line to
debug.log per message without `-debug` being set. Putting that log behind the `gobject` category
is a one-word fix but touches an unrelated file, so it is not bundled here.

## How Has This Been Tested?

Built with `--enable-debug --enable-suppress-external-warnings --without-gui` on
aarch64-apple-darwin (clang).

New unit tests in `src/test/governance_inv_tests.cpp`:

* `orphan_votes_require_a_valid_masternode_signature` — a vote naming an outpoint that is not in
  the tip masternode list, delivered by a peer that legitimately announced it, does not enter
  the orphan cache (`GetOrphanVoteObjectHashes()` stays empty), triggers no `MNGOVERNANCESYNC`
  request for the invented parent, and scores the sender 20.
* `invalid_vote_is_scored_alike_with_and_without_a_parent_object` — the same unauthenticated
  vote costs 20 whether or not its parent object is present, i.e. the orphan gate and
  `CGovernanceObject::ProcessVote` agree.

Two existing tests were updated. `governance_votes_require_peer_announcement_or_request` and
`governance_vote_authorization_survives_unsynced_drop` previously used "an `MNGOVERNANCESYNC`
was emitted" as the observable proving that a vote reached `ProcessVote`; the votes they build
carry a placeholder signature, so under this change they no longer reach the orphan branch and
no such message is sent. They now use the misbehaviour score as the observable instead: a peer
that passes the announce-then-request gate reaches `ProcessVote` and is scored 20, while a peer
that fails the gate returns before `ProcessVote` and stays at 0. That is a stricter test of the
authorization gate than the old one — it distinguishes "reached `ProcessVote`" from "did not"
rather than relying on an incidental side effect. Both now advance `mn_sync` to
`MASTERNODE_SYNC_FINISHED`, since penalties are only applied once `IsSynced()`.

Coverage limit, stated plainly: `GovernanceInvSetup` is a `TestingSetup{MAIN}` fixture with no
chain and therefore an empty deterministic masternode list, so `CGovernanceVote::IsValid`
short-circuits on the `GetMNByCollateral` lookup before reaching `CheckSignature`. These tests
therefore prove that the gate exists, runs on the orphan path, rejects a vote no masternode
could have authored, and scores it identically to the known-object path — but they do not
exercise `CheckSignature` itself, in either direction. Covering that (a registered masternode
with a forged signature rejected, and one with a valid signature still accepted into the orphan
cache) needs a chain-backed fixture with a real ProRegTx, which would mean rebuilding this
fixture on `TestChainSetup` and is deliberately not attempted here. The positive path is
covered end-to-end by `feature_governance.py`, which votes with real masternodes.

The new assertions were verified to fail against unmodified code: with the change to
`governance.cpp` reverted and the tests kept, the suite reports 7 failures, including
`check m_node.govman->GetOrphanVoteObjectHashes().empty() has failed` and
`check CountQueuedMessages(*peer, NetMsgType::MNGOVERNANCESYNC) == 0U has failed [1 != 0]`.

Ran:

* `./src/test/test_dash --run_test=governance_inv_tests` — passes (6 cases)
* `./src/test/test_dash` — passes (794 cases)
* `test/functional/test_runner.py feature_governance.py feature_governance_cl.py` — passes
* `test/lint/lint-whitespace.py`, `test/lint/lint-circular-dependencies.py` — clean

## Breaking Changes

None to consensus, RPC or the P2P wire format. Behavioural change on the P2P vote path: a
governance vote whose parent object is unknown is now dropped instead of cached unless it
carries a valid masternode signature, and a peer that sends such a vote is assigned a
misbehaviour score of 20 (only while fully synced). A node that legitimately relays orphan
votes ahead of their parent objects is unaffected, since those votes are validly signed.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_



