### PR TITLE
test: reach the governance vote signature path with a chain-backed fixture

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -124,6 +124,7 @@ BITCOIN_TESTS =\
   test/governance_inv_tests.cpp \
   test/governance_superblock_tests.cpp \
   test/governance_validators_tests.cpp \
+  test/governance_vote_processing_tests.cpp \
   test/governance_vote_sync_tests.cpp \
   test/governance_vote_wire_tests.cpp \
   test/coinjoin_inouts_tests.cpp \

--- a/src/test/governance_vote_processing_tests.cpp
+++ b/src/test/governance_vote_processing_tests.cpp
@@ -1,0 +1,384 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/amount.h>
+#include <evo/chainhelper.h>
+#include <evo/deterministicmns.h>
+#include <governance/governance.h>
+#include <governance/object.h>
+#include <governance/vote.h>
+#include <index/txindex.h>
+#include <interfaces/chain.h>
+#include <key.h>
+#include <key_io.h>
+#include <masternode/meta.h>
+#include <masternode/sync.h>
+#include <messagesigner.h>
+#include <netfulfilledman.h>
+#include <primitives/transaction.h>
+#include <script/standard.h>
+#include <timedata.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+#include <util/time.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <test/util/index.h>
+#include <test/util/masternode.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+// TestChainSetup only accepts checkpointed chain lengths, so 107 blocks plus
+// -dip3params=109:500 is the shortest chain a ProRegTx can be mined on. Same setup as
+// TestChainDIP3Setup in evo_deterministicmns_tests.cpp.
+constexpr int DIP3_ACTIVATION_HEIGHT{109};
+
+void SignWithVotingKey(CGovernanceVote& vote, const CKey& key)
+{
+    std::vector<unsigned char> sig;
+    BOOST_REQUIRE(CMessageSigner::SignMessage(vote.GetSignatureString(), sig, key));
+    vote.SetSignature(sig);
+}
+
+void SignWithOperatorKey(CGovernanceVote& vote, const CBLSSecretKey& key)
+{
+    // Vote signatures are always basic-scheme, regardless of the currently active BLS scheme:
+    // CGovernanceVote::CheckSignature() deserializes and verifies with legacy=false.
+    vote.SetSignature(
+        key.Sign(vote.GetSignatureHash(), /*specificLegacyScheme=*/false).ToByteVector(/*specificLegacyScheme=*/false));
+}
+
+// A chain with one registered masternode whose voting (ECDSA) and operator (BLS) keys are known
+// to the test, so votes can be signed for real and CGovernanceVote::CheckSignature is actually
+// reached. Without a populated masternode list every CGovernanceVote::IsValid() call would
+// short-circuit at GetMNByCollateral and no signature would ever be verified.
+struct GovernanceVoteSetup : public TestChainSetup {
+    CKey mn_voting_key;
+    CBLSSecretKey mn_operator_key;
+    COutPoint mn_collateral;
+    SimpleUTXOMap utxos;
+    //! Fixed so a proposal can be rebuilt bit-for-bit (and keep its hash) once its fee tx is known.
+    int64_t proposal_time{0};
+    std::string proposal_payment_address;
+
+    GovernanceVoteSetup() :
+        TestChainSetup(DIP3_ACTIVATION_HEIGHT - 2, CBaseChainParams::REGTEST, {"-dip3params=109:500"})
+    {
+        // A failed BOOST_REQUIRE below throws, and a throwing constructor means no destructor runs.
+        // Tear the globals down by hand so one broken invariant here doesn't leave a live tx index
+        // (and a dangling m_node reference in it) for every later test in the binary.
+        try {
+            SetUp();
+        } catch (...) {
+            TearDown();
+            throw;
+        }
+    }
+
+    ~GovernanceVoteSetup() { TearDown(); }
+
+    void SetUp()
+    {
+        // CGovernanceObject::IsCollateralValid() reads the proposal fee tx out of the tx index;
+        // without it no proposal can ever be accepted, orphan votes included.
+        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(m_node), /*n_cache_size=*/1 << 20,
+                                              /*f_memory=*/true);
+        BOOST_REQUIRE(g_txindex->Start());
+        IndexWaitSynced(*g_txindex);
+
+        utxos = BuildSimpleUtxoMap(m_coinbase_txns);
+
+        // Activate DIP3, then register the masternode that votes in these tests.
+        MineBlocks(1);
+        auto protx = CreateProRegTx(*m_node.chainman, utxos, /*port=*/1, payout_script(), coinbaseKey, mn_voting_key,
+                                    mn_operator_key);
+        mn_collateral = COutPoint(protx.GetHash(), 0);
+        MineBlock({protx});
+        BOOST_REQUIRE(tip_mn_list().GetMNByCollateral(mn_collateral) != nullptr);
+
+        BOOST_REQUIRE(m_node.mn_metaman->LoadCache(/*load_cache=*/false));
+        BOOST_REQUIRE(m_node.netfulfilledman->LoadCache(/*load_cache=*/false));
+        // Governance relay and CheckAndRemove() are no-ops until the node considers itself synced.
+        // Two SwitchToNextAsset() calls get there from BLOCKCHAIN; the bound is just a loop guard.
+        for (int i = 0; i < 5 && !m_node.mn_sync->IsSynced(); ++i) {
+            m_node.mn_sync->SwitchToNextAsset();
+        }
+        BOOST_REQUIRE(m_node.mn_sync->IsSynced());
+
+        m_node.govman = std::make_unique<CGovernanceManager>(*m_node.mn_metaman, *m_node.chainman,
+                                                             *m_node.chain_helper->superblocks, *m_node.dmnman,
+                                                             *m_node.mn_sync);
+        BOOST_REQUIRE(m_node.govman->LoadCache(/*load_cache=*/false));
+
+        proposal_time = TicksSinceEpoch<std::chrono::seconds>(GetAdjustedTime());
+        CKey payment_key;
+        payment_key.MakeNewKey(true);
+        proposal_payment_address = EncodeDestination(PKHash(payment_key.GetPubKey()));
+    }
+
+    void TearDown()
+    {
+        // govman holds a reference into chain_helper, so it must go first (matches PrepareShutdown
+        // ordering in init.cpp).
+        m_node.govman.reset();
+        if (g_txindex) {
+            SyncWithValidationInterfaceQueue();
+            g_txindex->Stop();
+            g_txindex.reset();
+        }
+    }
+
+    CScript coinbase_script() const { return GetScriptForRawPubKey(coinbaseKey.GetPubKey()); }
+
+    //! Masternode payouts and the proposal fee change must go to a P2PKH script (bad-protx-payee
+    //! rejects the raw-pubkey coinbase script, IsCollateralValid() rejects anything else).
+    CScript payout_script() const { return GetScriptForDestination(PKHash(coinbaseKey.GetPubKey())); }
+
+    CDeterministicMNList tip_mn_list() const { return m_node.dmnman->GetListAtChainTip(); }
+
+    void MineBlock(const std::vector<CMutableTransaction>& txns)
+    {
+        const CBlock block = CreateAndProcessBlock(txns, coinbase_script());
+        const CBlockIndex* tip{WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain().Tip())};
+        BOOST_REQUIRE_EQUAL(tip->GetBlockHash(), block.GetHash());
+        m_node.dmnman->UpdatedBlockTip(tip);
+        SetMockTime(GetTime() + 1);
+        IndexWaitSynced(*g_txindex);
+    }
+
+    void MineBlocks(int num_blocks)
+    {
+        for (int i = 0; i < num_blocks; ++i) {
+            MineBlock({});
+        }
+    }
+
+    //! The proposal both the orphan vote and the fee tx below commit to. The object hash
+    //! deliberately excludes the collateral hash, so the same proposal can be built first with an
+    //! empty collateral (to learn its hash) and again once the fee tx paying to that hash exists.
+    CGovernanceObject MakeProposal(const uint256& collateral_hash) const
+    {
+        const std::string data{
+            strprintf("{\"type\":1,\"name\":\"test-proposal\",\"start_epoch\":%d,\"end_epoch\":%d,\"payment_amount\":1.0,\"payment_address\":\"%s\",\"url\":\"https://dash.org\"}",
+                      proposal_time, proposal_time + 100000, proposal_payment_address)};
+        return CGovernanceObject{uint256{}, /*revision=*/1, proposal_time, collateral_hash, HexStr(data)};
+    }
+
+    //! Burns the proposal fee to an OP_RETURN committing to the object hash, the way
+    //! `gobject prepare` does, and buries it under the confirmations the collateral check needs.
+    uint256 ConfirmProposalCollateral(const uint256& govobj_hash)
+    {
+        CMutableTransaction tx;
+        // IsCollateralValid() rejects the fee tx unless every output is P2PKH or unspendable, so
+        // the change cannot go back to the burn script.
+        const auto spent = FundTransaction(*m_node.chainman, tx, utxos,
+                                           CScript() << OP_RETURN << ToByteVector(govobj_hash),
+                                           GOVERNANCE_PROPOSAL_FEE_TX, /*script_change=*/payout_script());
+        SignTransaction(tx, spent, coinbaseKey);
+
+        MineBlock({tx});
+        MineBlocks(GOVERNANCE_FEE_CONFIRMATIONS - 1);
+        return tx.GetHash();
+    }
+
+    //! A vote's hash covers everything but its signature, so votes that should be distinguishable
+    //! (e.g. a re-signed vote) need distinct timestamps.
+    CGovernanceVote MakeVote(const uint256& parent_hash, vote_signal_enum_t signal, vote_outcome_enum_t outcome,
+                             std::chrono::seconds time_offset = 0s) const
+    {
+        CGovernanceVote vote{mn_collateral, parent_hash, signal, outcome};
+        vote.SetTime(GetAdjustedTime() + time_offset);
+        return vote;
+    }
+};
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(governance_vote_processing_tests, GovernanceVoteSetup)
+
+// A vote that arrives before its parent object must be kept and replayed once the object shows up,
+// otherwise every vote that races ahead of its proposal is lost for good.
+BOOST_AUTO_TEST_CASE(orphan_vote_is_cached_and_applied_when_parent_arrives)
+{
+    auto& govman = *m_node.govman;
+
+    // Build the proposal but keep it out of the manager: the vote arrives first.
+    const uint256 parent_hash{MakeProposal(uint256{}).GetHash()};
+    BOOST_REQUIRE(!govman.HaveObjectForHash(parent_hash));
+
+    CGovernanceVote vote{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+    SignWithVotingKey(vote, mn_voting_key);
+    // Guard: the orphan gate rejects a vote it cannot verify against the masternode list, so if
+    // the masternode or its signature were not recognized every check below would fail at once.
+    // Requiring validity up front turns that diffuse failure into one pointed at the setup.
+    BOOST_REQUIRE(vote.IsValid(tip_mn_list(), /*useVotingKey=*/true));
+
+    CGovernanceException exception;
+    uint256 hash_to_request;
+    BOOST_CHECK(!govman.ProcessVote(vote, exception, hash_to_request));
+    BOOST_CHECK_EQUAL(exception.GetType(), GOVERNANCE_EXCEPTION_WARNING);
+    BOOST_CHECK_EQUAL(exception.GetNodePenalty(), 0);
+    // The caller uses this to ask the sending peer for the missing object.
+    BOOST_CHECK_EQUAL(hash_to_request, parent_hash);
+    BOOST_CHECK(govman.GetOrphanVoteObjectHashes() == std::vector<uint256>{parent_hash});
+
+    const uint256 collateral_hash{ConfirmProposalCollateral(parent_hash)};
+    CGovernanceObject proposal{MakeProposal(collateral_hash)};
+    BOOST_REQUIRE_EQUAL(proposal.GetHash(), parent_hash);
+    govman.AddGovernanceObject(proposal, /*peer_str=*/"");
+    BOOST_REQUIRE(govman.HaveObjectForHash(parent_hash));
+
+    // The orphan vote is now applied to the object it was waiting for and is no longer pending.
+    auto stored = govman.FindConstGovernanceObject(parent_hash);
+    BOOST_REQUIRE(stored != nullptr);
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 1);
+    BOOST_CHECK_EQUAL(govman.GetCurrentVotes(parent_hash, mn_collateral).size(), 1U);
+    BOOST_CHECK(govman.GetOrphanVoteObjectHashes().empty());
+    // Known gap, pinned here so a fix has to update this test: CheckOrphanVotes() applies the
+    // vote to the object but never indexes it in cmapVoteToObject, so the vote inv it relays
+    // during the replay cannot be served to a peer that requests it.
+    BOOST_CHECK(!govman.HaveVoteForHash(vote.GetHash()));
+
+    // A peer re-sending the same vote must not be punished for it.
+    CGovernanceException replay_exception;
+    uint256 replay_hash_to_request;
+    BOOST_CHECK(!govman.ProcessVote(vote, replay_exception, replay_hash_to_request));
+    BOOST_CHECK_EQUAL(replay_exception.GetNodePenalty(), 0);
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 1);
+}
+
+// Votes are only counted if they carry a signature from a registered masternode.
+BOOST_AUTO_TEST_CASE(unsigned_and_unknown_masternode_votes_are_rejected)
+{
+    auto& govman = *m_node.govman;
+
+    const CGovernanceObject proposal{MakeProposal(uint256::ONE)};
+    const uint256 parent_hash{proposal.GetHash()};
+    govman.AddGovernanceObjectForTesting(proposal);
+    BOOST_REQUIRE(govman.HaveObjectForHash(parent_hash));
+
+    // Forged signature: right masternode, wrong key.
+    CKey attacker_key;
+    attacker_key.MakeNewKey(true);
+    CGovernanceVote forged{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+    SignWithVotingKey(forged, attacker_key);
+
+    CGovernanceException exception;
+    uint256 hash_to_request;
+    BOOST_CHECK(!govman.ProcessVote(forged, exception, hash_to_request));
+    BOOST_CHECK_EQUAL(exception.GetType(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR);
+    BOOST_CHECK_EQUAL(exception.GetNodePenalty(), 20);
+    BOOST_CHECK(!govman.HaveVoteForHash(forged.GetHash()));
+
+    // Re-sending a vote already known to be invalid is still punished, without re-verifying it.
+    CGovernanceException repeat_exception;
+    BOOST_CHECK(!govman.ProcessVote(forged, repeat_exception, hash_to_request));
+    BOOST_CHECK_EQUAL(repeat_exception.GetType(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR);
+    BOOST_CHECK_EQUAL(repeat_exception.GetNodePenalty(), 20);
+
+    // Forged operator signature: right masternode, wrong BLS key. A non-funding signal, so the
+    // operator-key (BLS) verification path is the one that must reject it.
+    CBLSSecretKey attacker_operator_key;
+    attacker_operator_key.MakeNewKey();
+    CGovernanceVote forged_bls{MakeVote(parent_hash, VOTE_SIGNAL_VALID, VOTE_OUTCOME_YES)};
+    SignWithOperatorKey(forged_bls, attacker_operator_key);
+
+    CGovernanceException forged_bls_exception;
+    BOOST_CHECK(!govman.ProcessVote(forged_bls, forged_bls_exception, hash_to_request));
+    BOOST_CHECK_EQUAL(forged_bls_exception.GetType(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR);
+    BOOST_CHECK_EQUAL(forged_bls_exception.GetNodePenalty(), 20);
+    BOOST_CHECK(!govman.HaveVoteForHash(forged_bls.GetHash()));
+
+    // Correctly signed, but the outpoint belongs to no masternode.
+    CKey stranger_key;
+    stranger_key.MakeNewKey(true);
+    CGovernanceVote stranger{COutPoint{uint256S("42"), 0}, parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES};
+    stranger.SetTime(GetAdjustedTime());
+    SignWithVotingKey(stranger, stranger_key);
+
+    CGovernanceException stranger_exception;
+    BOOST_CHECK(!govman.ProcessVote(stranger, stranger_exception, hash_to_request));
+    BOOST_CHECK_EQUAL(stranger_exception.GetType(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR);
+    BOOST_CHECK_EQUAL(stranger_exception.GetNodePenalty(), 20);
+
+    // A vote dated too far in the future is rejected even with a valid signature.
+    CGovernanceVote from_the_future{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES, 2h)};
+    SignWithVotingKey(from_the_future, mn_voting_key);
+
+    CGovernanceException future_exception;
+    BOOST_CHECK(!govman.ProcessVote(from_the_future, future_exception, hash_to_request));
+    BOOST_CHECK_EQUAL(future_exception.GetType(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR);
+    BOOST_CHECK_EQUAL(future_exception.GetNodePenalty(), 20);
+
+    auto stored = govman.FindConstGovernanceObject(parent_hash);
+    BOOST_REQUIRE(stored != nullptr);
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 0);
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_VALID), 0);
+}
+
+// Funding a proposal is the one decision reserved for the voting key; every other signal may be
+// signed by the operator (BLS) key. Mixing the two up must not be accepted either way around.
+//
+// Rate checks are live on this path (unlike the orphan replay above, which disables them), so each
+// vote below has to be the first *accepted* one for its (masternode, signal) pair: a rejected vote
+// leaves last_update at epoch 0, but a second accepted vote for the same signal would be turned
+// away by the 1h GOVERNANCE_UPDATE_MIN limit instead of the rule under test.
+BOOST_AUTO_TEST_CASE(proposal_funding_votes_require_the_voting_key)
+{
+    auto& govman = *m_node.govman;
+
+    const CGovernanceObject proposal{MakeProposal(uint256::ONE)};
+    const uint256 parent_hash{proposal.GetHash()};
+    govman.AddGovernanceObjectForTesting(proposal);
+    auto stored = govman.FindConstGovernanceObject(parent_hash);
+    BOOST_REQUIRE(stored != nullptr);
+
+    // Operator key on a funding vote: valid BLS signature, wrong key for this signal.
+    CGovernanceVote funding_by_operator{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+    SignWithOperatorKey(funding_by_operator, mn_operator_key);
+    BOOST_REQUIRE(funding_by_operator.IsValid(tip_mn_list(), /*useVotingKey=*/false));
+
+    CGovernanceException exception;
+    uint256 hash_to_request;
+    BOOST_CHECK(!govman.ProcessVote(funding_by_operator, exception, hash_to_request));
+    BOOST_CHECK_EQUAL(exception.GetType(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR);
+    BOOST_CHECK_EQUAL(exception.GetNodePenalty(), 20);
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 0);
+
+    // Voting key on a funding vote: accepted and counted. Dated a second later so it is a vote in
+    // its own right rather than the rejected one above with a different signature glued on.
+    CGovernanceVote funding_by_voting_key{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES, 1s)};
+    SignWithVotingKey(funding_by_voting_key, mn_voting_key);
+
+    CGovernanceException funding_exception;
+    BOOST_CHECK(govman.ProcessVote(funding_by_voting_key, funding_exception, hash_to_request));
+    BOOST_CHECK(govman.HaveVoteForHash(funding_by_voting_key.GetHash()));
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 1);
+
+    // Operator key on a non-funding signal: accepted and counted.
+    CGovernanceVote valid_by_operator{MakeVote(parent_hash, VOTE_SIGNAL_VALID, VOTE_OUTCOME_YES)};
+    SignWithOperatorKey(valid_by_operator, mn_operator_key);
+
+    CGovernanceException valid_exception;
+    BOOST_CHECK(govman.ProcessVote(valid_by_operator, valid_exception, hash_to_request));
+    BOOST_CHECK(govman.HaveVoteForHash(valid_by_operator.GetHash()));
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_VALID), 1);
+
+    // A known good vote received twice is dropped quietly, not punished.
+    CGovernanceException duplicate_exception;
+    BOOST_CHECK(!govman.ProcessVote(funding_by_voting_key, duplicate_exception, hash_to_request));
+    BOOST_CHECK_EQUAL(duplicate_exception.GetNodePenalty(), 0);
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/masternode.cpp
+++ b/src/test/util/masternode.cpp
@@ -67,6 +67,12 @@ SimpleUTXOMap BuildSimpleUtxoMap(const std::vector<CTransactionRef>& txs)
 SimpleUTXOMap FundTransaction(const ChainstateManager& chainman, CMutableTransaction& tx, SimpleUTXOMap& utxos,
                               const CScript& script_payout, CAmount amount)
 {
+    return FundTransaction(chainman, tx, utxos, script_payout, amount, /*script_change=*/script_payout);
+}
+
+SimpleUTXOMap FundTransaction(const ChainstateManager& chainman, CMutableTransaction& tx, SimpleUTXOMap& utxos,
+                              const CScript& script_payout, CAmount amount, const CScript& script_change)
+{
     CAmount change;
     auto inputs = WITH_LOCK(::cs_main, return SelectUTXOs(chainman.ActiveChain(), utxos, amount, change));
     for (const auto& input : inputs) {
@@ -74,7 +80,7 @@ SimpleUTXOMap FundTransaction(const ChainstateManager& chainman, CMutableTransac
     }
     tx.vout.emplace_back(amount, script_payout);
     if (change != 0) {
-        tx.vout.emplace_back(change, script_payout);
+        tx.vout.emplace_back(change, script_change);
     }
     return inputs;
 }

--- a/src/test/util/masternode.h
+++ b/src/test/util/masternode.h
@@ -20,6 +20,9 @@ using SimpleUTXOMap = std::map<COutPoint, Coin>;
 SimpleUTXOMap BuildSimpleUtxoMap(const std::vector<CTransactionRef>& txs);
 SimpleUTXOMap FundTransaction(const ChainstateManager& chainman, CMutableTransaction& tx, SimpleUTXOMap& utxos,
                               const CScript& script_payout, CAmount amount);
+//! Overload for payout scripts that cannot receive the change, e.g. an OP_RETURN burn.
+SimpleUTXOMap FundTransaction(const ChainstateManager& chainman, CMutableTransaction& tx, SimpleUTXOMap& utxos,
+                              const CScript& script_payout, CAmount amount, const CScript& script_change);
 void SignTransaction(CMutableTransaction& tx, const SimpleUTXOMap& coins, const CKey& coinbase_key);
 CMutableTransaction CreateProRegTx(const ChainstateManager& chainman, SimpleUTXOMap& utxos, int port,
                                    const CScript& script_payout, const CKey& coinbase_key, CKey& owner_key_ret,


### PR DESCRIPTION
## Issue being fixed or feature implemented

No governance unit test ever reaches `CGovernanceVote::CheckSignature`.

The existing governance fixtures (e.g. `governance_inv_tests.cpp`) are built on
`TestingSetup` with no chain, so `m_dmnman.GetListAtChainTip()` returns an empty
masternode list and every `CGovernanceVote::IsValid()` call short-circuits at
`GetMNByCollateral()` before any signature is verified. Consequently:

* nothing proves a correctly signed vote from a registered masternode is
  accepted at all;
* nothing proves a forged signature is rejected;
* nothing proves the orphan-vote path (a vote that arrives before its parent
  object) actually recovers once the object shows up.

That last one is the dangerous gap: a change that made vote acceptance stricter
in the wrong place would silently break governance orphan-vote recovery
entirely, and the unit tests would stay green. `feature_governance.py` does not
deterministically produce a vote that arrives before its parent object, so it is
not reliable coverage for that path either.

## What was done?

Added `src/test/governance_vote_processing_tests.cpp`: a chain-backed fixture
plus three test cases. No production code is touched.

The fixture mines a regtest chain, activates DIP3, registers one masternode with
a real `ProRegTx` and keeps its voting (ECDSA) and operator (BLS) keys, so votes
can be signed for real and the signature checks are genuinely exercised. It also
enables the tx index, which `CGovernanceObject::IsCollateralValid()` reads the
proposal fee transaction from — without it no proposal can ever be accepted.

Test cases:

* `orphan_vote_is_cached_and_applied_when_parent_arrives` — a properly signed
  vote whose parent object is unknown is cached as an orphan, reported back as
  the object hash to request from the peer, and raises no peer penalty. The
  proposal fee is then burned to an `OP_RETURN` committing to the object hash and
  buried under the required confirmations, the proposal is accepted for real, and
  the orphan vote is replayed onto it (yes-count 1, orphan list empty). A peer
  re-sending the vote afterwards is not punished.
* `unsigned_and_unknown_masternode_votes_are_rejected` — a forged signature, a
  vote from an outpoint belonging to no masternode, and a vote dated too far in
  the future are each rejected with a permanent error and a penalty of 20; a
  repeat of a vote already known to be invalid is still penalised; the object's
  vote count stays at zero.
* `proposal_funding_votes_require_the_voting_key` — an operator-key-signed
  funding vote on a proposal is rejected (valid BLS signature, wrong key for that
  signal), a voting-key-signed funding vote is accepted and counted, an
  operator-key-signed `VALID` vote is accepted and counted, and a duplicate of an
  accepted vote is dropped without a penalty.

The chain/ProRegTx plumbing comes from `src/test/util/masternode.h`, the shared
module added in #7536, so nothing is duplicated here.

One preparatory commit is needed for that: `FundTransaction()` always paid the
change back to the payout script, which does not work for the proposal fee
transaction — its payout is an `OP_RETURN` burn, and `IsCollateralValid()`
rejects the transaction unless the change lands on a P2PKH output. An overload
taking a separate change script covers that; the existing five-argument form
keeps its behaviour and no existing call site changes.

## How Has This Been Tested?

* `./src/test/test_dash --run_test=governance_vote_processing_tests` — passes,
  roughly 0.6s for all three cases.
* `./src/test/test_dash --run_test=block_reward_reallocation_tests` and
  `--run_test=evo_dip3_activation_tests` — pass, covering the other users of the
  shared `FundTransaction()` helper.
* Full `./src/test/test_dash` run — 793 cases, no errors. The pre-existing
  governance suites (`governance_inv_tests`, `governance_validators_tests`,
  `governance_superblock_tests`, `governance_vote_wire_tests`) and
  `evo_dip3_activation_tests` are unaffected.
* `test/lint/all-lint.py` — clean apart from cppcheck warnings that already
  exist on develop in unrelated files; `clang-format` reports no differences on
  the new file.

The tests were checked to actually bite, by mutation:

* Adding a masternode/signature gate in front of the orphan cache in
  `CGovernanceManager::ProcessVote` with its condition inverted (so that
  legitimate votes are rejected) fails
  `orphan_vote_is_cached_and_applied_when_parent_arrives` on 7 assertions.
* Making both `CGovernanceVote::CheckSignature` overloads return `true`
  unconditionally fails the other two cases on 15 assertions.
* Forcing a fixture-constructor invariant to fail leaves the tx index torn down
  correctly and the failure contained to this suite: the three cases fail and
  `evo_dip3_activation_tests` / `txindex_tests` still pass in the same binary run.

Environment: macOS (arm64), depends build, `--enable-debug`.

## Breaking Changes

None. Test-only change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

