### PR TITLE
fix: score peers requesting an unregistered LLMQType via QGETDATA

### DIFF
--- a/src/llmq/net_quorum.cpp
+++ b/src/llmq/net_quorum.cpp
@@ -108,9 +108,11 @@ void NetQuorum::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataS
         const bool request_limit_exceeded = !m_qman.RegisterDataRequest(key, request, /*add_expiry_bias=*/false);
 
         if (!Params().GetLLMQ(request.GetLLMQType()).has_value()) {
-            if (sendQDATA(CQuorumDataRequest::Errors::QUORUM_TYPE_INVALID, request_limit_exceeded)) {
-                m_peer_manager->PeerMisbehaving(pfrom.GetId(), 25, "request limit exceeded");
-            }
+            // Unlike the misses below, this one cannot be explained by the peer being ahead of
+            // us: no quorum of an unregistered type can exist on this chain, so there is
+            // nothing to ask about. Answer with the error anyway, then score in full.
+            sendQDATA(CQuorumDataRequest::Errors::QUORUM_TYPE_INVALID, request_limit_exceeded);
+            m_peer_manager->PeerMisbehaving(pfrom.GetId(), 100, "invalid llmqType in QGETDATA");
             return;
         }
 

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -326,10 +326,14 @@ class QuorumDataMessagesTest(DashTestFramework):
             qgetdata_invalid_block = msg_qgetdata(protx_hash_int, 100, 0x01, protx_hash_int)
             qgetdata_invalid_quorum = msg_qgetdata(int(mn2.get_node(self).getblockhash(0), 16), 100, 0x01, protx_hash_int)
             qgetdata_invalid_no_member = msg_qgetdata(quorum_hash_int, 100, 0x02, quorum_hash_int)
-            p2p_mn2.test_qgetdata(qgetdata_invalid_type, QUORUM_TYPE_INVALID)
             p2p_mn2.test_qgetdata(qgetdata_invalid_block, QUORUM_BLOCK_NOT_FOUND)
             p2p_mn2.test_qgetdata(qgetdata_invalid_quorum, QUORUM_NOT_FOUND)
             p2p_mn2.test_qgetdata(qgetdata_invalid_no_member, MASTERNODE_IS_NO_MEMBER)
+            # An unregistered LLMQ type is answered like the misses above, but unlike them it
+            # cannot be explained by the peer being ahead of us, so it is scored in full too.
+            # Kept last: the peer is dropped once it is.
+            p2p_mn2.test_qgetdata(qgetdata_invalid_type, QUORUM_TYPE_INVALID)
+            self.wait_until(lambda: not p2p_mn2.is_connected, timeout=10)
             # The last two error case require the node to miss its DKG data so we just reindex the node.
             mn2.get_node(self).disconnect_p2ps()
             self.restart_mn(mn1, reindex=True)


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `QGETDATA` handler validates the requested `Consensus::LLMQType`, but treats an unregistered one as a routine miss. `sendQDATA` groups `QUORUM_TYPE_INVALID` with `QUORUM_BLOCK_NOT_FOUND`, `QUORUM_NOT_FOUND` and `MASTERNODE_IS_NO_MEMBER`, all of which are scored only when the request limiter is also exceeded:

```cpp
case (CQuorumDataRequest::Errors::QUORUM_TYPE_INVALID):
case (CQuorumDataRequest::Errors::QUORUM_BLOCK_NOT_FOUND):
case (CQuorumDataRequest::Errors::QUORUM_NOT_FOUND):
case (CQuorumDataRequest::Errors::MASTERNODE_IS_NO_MEMBER):
    misbehave = request_limit_exceeded;
```

That grouping is right for the others: a peer hits them innocently when it is ahead of us, or when we lack data it reasonably expected us to have. An unregistered LLMQ type is not in that category. No quorum of a type this chain does not register can exist, so there is nothing for a well-behaved peer to ask about, and every sibling handler already treats one as a protocol violation -- QSIGREC, the DKG messages and QFCOMMITMENT all score 100.

The practical exposure is small: `QGETDATA` already requires a ProRegTx-verified masternode or a qwatch connection, and each request passes through `RegisterDataRequest`, so the traffic is rate-limited even when unscored. This is a consistency fix, not a fix for a live attack.

## What was done?

Send the `QUORUM_TYPE_INVALID` reply exactly as before, so a confused peer still learns why its request failed, then score the sender 100.

`p2p_quorum_data.py` exercises every error code on one connection. Its invalid-type case moves to the end of that block, because the peer is now dropped once it sends one; the test asserts the disconnect.

Spotted while reviewing dashpay/dash#7516, which fixes an abort reachable through the same class of unvalidated `LLMQType`. This change is independent of it -- it does not depend on that PR and can land in either order.

## How Has This Been Tested?

Built and run on macOS/arm64 against develop:

- Full build clean.
- `p2p_quorum_data.py`: passes.

## Breaking Changes

A peer that requests quorum data for an LLMQ type this chain does not register is now scored to the ban threshold instead of being answered indefinitely. Only requests that were already answered with `QUORUM_TYPE_INVALID` are affected.

A new LLMQ type is introduced with a deployment, and no quorum of that type exists on chain before activation, so an honest peer has nothing to request until every node recognises the type. This should not misfire across a version boundary.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
