### PR TITLE
perf: check quorum activity before materializing the quorum on QSIGREC

### DIFF
--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -366,20 +366,34 @@ bool CSigningManager::GetRecoveredSigForGetData(const uint256& hash, CRecoveredS
 void CSigningManager::VerifyAndProcessRecoveredSig(NodeId from, std::shared_ptr<CRecoveredSig> recoveredSig)
 {
     auto llmq_type = recoveredSig->getLlmqType();
-    auto quorum = qman.GetQuorum(llmq_type, recoveredSig->getQuorumHash());
+    const uint256& quorum_hash = recoveredSig->getQuorumHash();
 
-    if (!quorum) {
-        LogPrint(BCLog::LLMQ, "CSigningManager::%s -- quorum %s not found\n", __func__,
-                 recoveredSig->getQuorumHash().ToString());
-        return;
-    }
-    if (!IsQuorumActive(llmq_type, qman, quorum->qc->quorumHash)) {
+    // Cheap gate first. IsQuorumActive is bounded to the keepOldConnections most recent
+    // quorums at the tip, and that set is shared and cached across callers. GetQuorum, by
+    // contrast, takes the peer-supplied hash and can rebuild an arbitrary historical mined
+    // commitment (DMN list replay + member selection) on a cache miss — do not let an
+    // unsolicited QSIGREC force that work for inactive hashes.
+    // Caller (NetSigning) has already rejected unknown llmq types.
+    if (!IsQuorumActive(llmq_type, qman, quorum_hash)) {
         return;
     }
 
     // It's important to only skip seen *valid* sig shares here. See comment for CBatchedSigShare
     // We don't receive recovered sigs in batches, but we do batched verification per node on these
     if (db.HasRecoveredSigForHash(recoveredSig->GetHash())) {
+        return;
+    }
+
+    // Once IsQuorumActive has passed, quorum_hash is one of the recent quorums ScanQuorums
+    // covers, so this is usually served from cache. ScanQuorums and GetQuorum keep separate
+    // LRUs, so a rebuild is still possible here, but only of a recent quorum — never of the
+    // arbitrary historical one a peer could otherwise name.
+    auto quorum = qman.GetQuorum(llmq_type, quorum_hash);
+    if (!quorum) {
+        // Reported active by ScanQuorums but no longer materializable (e.g. reorg).
+        // Not peer-controlled once the hash is restricted to the active set, so no score.
+        LogPrint(BCLog::LLMQ, "CSigningManager::%s -- quorum %s not found\n", __func__,
+                 quorum_hash.ToString());
         return;
     }
 

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -368,12 +368,8 @@ void CSigningManager::VerifyAndProcessRecoveredSig(NodeId from, std::shared_ptr<
     auto llmq_type = recoveredSig->getLlmqType();
     const uint256& quorum_hash = recoveredSig->getQuorumHash();
 
-    // Cheap gate first. IsQuorumActive is bounded to the keepOldConnections most recent
-    // quorums at the tip, and that set is shared and cached across callers. GetQuorum, by
-    // contrast, takes the peer-supplied hash and can rebuild an arbitrary historical mined
-    // commitment (DMN list replay + member selection) on a cache miss — do not let an
-    // unsolicited QSIGREC force that work for inactive hashes.
-    // Caller (NetSigning) has already rejected unknown llmq types.
+    // Cheap gate first: GetQuorum can rebuild an arbitrary historical quorum on a cache miss,
+    // so don't let an unsolicited QSIGREC force that work for an inactive hash.
     if (!IsQuorumActive(llmq_type, qman, quorum_hash)) {
         return;
     }
@@ -384,14 +380,9 @@ void CSigningManager::VerifyAndProcessRecoveredSig(NodeId from, std::shared_ptr<
         return;
     }
 
-    // Once IsQuorumActive has passed, quorum_hash is one of the recent quorums ScanQuorums
-    // covers, so this is usually served from cache. ScanQuorums and GetQuorum keep separate
-    // LRUs, so a rebuild is still possible here, but only of a recent quorum — never of the
-    // arbitrary historical one a peer could otherwise name.
     auto quorum = qman.GetQuorum(llmq_type, quorum_hash);
     if (!quorum) {
-        // Reported active by ScanQuorums but no longer materializable (e.g. reorg).
-        // Not peer-controlled once the hash is restricted to the active set, so no score.
+        // Active per ScanQuorums but no longer materializable (e.g. reorg); not peer-controlled, so no score.
         LogPrint(BCLog::LLMQ, "CSigningManager::%s -- quorum %s not found\n", __func__,
                  quorum_hash.ToString());
         return;


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CSigningManager::VerifyAndProcessRecoveredSig` called `qman.GetQuorum(...)` before `IsQuorumActive(...)`.

Those two have very different costs. `IsQuorumActive` is bounded to the `keepOldConnections` most recent quorums at the tip, and that set is shared and cached across callers. `GetQuorum` takes the peer-supplied hash and can rebuild an arbitrary historical mined commitment on a cache miss — a deterministic masternode list replay plus member selection. An unsolicited `QSIGREC` naming an inactive quorum hash therefore forced the expensive path before the cheap gate had a chance to reject it.

This was split out of [#7519](https://github.com/dashpay/dash/pull/7519), where it had been bundled with unrelated QGETDATA work.

## What was done?

Swap the order so the cheap gate runs first. Once `IsQuorumActive` passes, the hash is one of the recent quorums `ScanQuorums` covers, so the subsequent `GetQuorum` is usually served from cache. `ScanQuorums` and `GetQuorum` keep separate LRUs, so a rebuild there is still possible, but only of a recent quorum — never of the arbitrary historical one a peer could otherwise name.

A null quorum after that point is no longer peer-controlled — it means the quorum was reported active but is no longer materializable, e.g. after a reorg — so it is logged without a misbehaviour score.

The caller (`NetSigning`) has already rejected unknown LLMQ types before this point, so the reordering does not widen what reaches `IsQuorumActive`.

## How Has This Been Tested?

Compiles cleanly. This is a reordering of two existing checks with no behavioural change for valid input, so it is covered by the existing QSIGREC paths in the functional suite. Full validation is delegated to CI.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
