### PR TITLE
fix: bound DYNBITSET allocation against remaining stream size

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -435,7 +435,16 @@ void WriteFixedBitSet(Stream& s, const std::vector<bool>& vec, size_t size)
     s.write(AsBytes(Span{vBytes}));
 }
 
-template<typename Stream>
+/** A stream that can report how many bytes are still available to read.
+ *
+ * size() must mean bytes *remaining*, not the total the stream ever held. ReadFixedBitSet
+ * relies on that to bound a wire-declared bit count before allocating, so a stream whose
+ * size() means anything else would silently weaken the bound rather than fail to compile.
+ */
+template<typename S>
+concept SizedStream = requires(const S& s) { { s.size() } -> std::convertible_to<size_t>; };
+
+template<SizedStream Stream>
 void ReadFixedBitSet(Stream& s, std::vector<bool>& vec, size_t size)
 {
     const size_t nbytes = (size + 7) / 8;
@@ -444,10 +453,8 @@ void ReadFixedBitSet(Stream& s, std::vector<bool>& vec, size_t size)
     // multi-megabyte resize and zero-fill that is only abandoned when the short read throws.
     // A well-formed message always carries exactly the required bytes, so this rejects only
     // claims that could never have been satisfied.
-    if constexpr (requires(const Stream& cs) { cs.size(); }) {
-        if (nbytes > s.size()) {
-            throw std::ios_base::failure("ReadFixedBitSet(): declared size exceeds remaining bytes");
-        }
+    if (nbytes > s.size()) {
+        throw std::ios_base::failure("ReadFixedBitSet(): declared size exceeds remaining bytes");
     }
 
     vec.resize(size);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -438,9 +438,21 @@ void WriteFixedBitSet(Stream& s, const std::vector<bool>& vec, size_t size)
 template<typename Stream>
 void ReadFixedBitSet(Stream& s, std::vector<bool>& vec, size_t size)
 {
+    const size_t nbytes = (size + 7) / 8;
+    // Bound the wire-declared length against the bytes actually left in the stream before
+    // allocating anything. Otherwise a handful of bytes declaring millions of bits forces a
+    // multi-megabyte resize and zero-fill that is only abandoned when the short read throws.
+    // A well-formed message always carries exactly the required bytes, so this rejects only
+    // claims that could never have been satisfied.
+    if constexpr (requires(const Stream& cs) { cs.size(); }) {
+        if (nbytes > s.size()) {
+            throw std::ios_base::failure("ReadFixedBitSet(): declared size exceeds remaining bytes");
+        }
+    }
+
     vec.resize(size);
 
-    std::vector<uint8_t> vBytes((size + 7) / 8);
+    std::vector<uint8_t> vBytes(nbytes);
     s.read(AsWritableBytes(Span{vBytes}));
     for (size_t p = 0; p < size; p++)
         vec[p] = (vBytes[p / 8] & (1 << (p % 8))) != 0;

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -3,15 +3,20 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <hash.h>
+#include <llmq/commitment.h>
+#include <llmq/params.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
+#include <uint256.h>
 #include <util/strencodings.h>
 
 #include <stdint.h>
 
+#include <ios>
 #include <limits>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -181,6 +186,89 @@ BOOST_AUTO_TEST_CASE(vector_bool)
 
     BOOST_CHECK(vec1 == std::vector<uint8_t>(vec2.begin(), vec2.end()));
     BOOST_CHECK(SerializeHash(vec1) == SerializeHash(vec2));
+}
+
+
+//! The message the bound throws. Matching it exactly keeps these tests from passing on an
+//! unrelated short read, which is the very failure mode the bound replaces.
+static constexpr std::string_view BOUND_REJECTION{"declared size exceeds remaining bytes"};
+
+/**
+ * DYNBITSET must not allocate from an attacker-declared CompactSize when the remaining stream
+ * is far too small to hold the claimed bit payload. A handful of bytes claiming ~1e6 bits is
+ * the amplification primitive: ReadCompactSize permits up to 33,554,432, which would resize a
+ * std::vector<bool> to ~4 MiB and allocate another ~4 MiB byte buffer before the short read
+ * throws. The claim below is deliberately modest so the pre-fix path also stays safe on CI.
+ */
+BOOST_AUTO_TEST_CASE(dynbitset_rejects_oversized_declared_length)
+{
+    constexpr uint64_t kClaimedBits = 1'000'000;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    WriteCompactSize(s, kClaimedBits);
+    // No bit payload follows, so the remaining size is zero.
+
+    std::vector<bool> bits;
+    std::string what;
+    bool threw = false;
+    try {
+        s >> DYNBITSET(bits);
+    } catch (const std::ios_base::failure& e) {
+        threw = true;
+        what = e.what();
+    }
+    BOOST_CHECK_MESSAGE(threw, "DYNBITSET must reject a declared length that exceeds remaining bytes");
+    // Rejection has to precede the resize, so the destination must still hold its exact
+    // pre-deserialization state. Merely falling short of the declared size would also be
+    // satisfied by an allocation that happened and was then abandoned.
+    BOOST_CHECK(bits.empty());
+    BOOST_CHECK_MESSAGE(what.find(BOUND_REJECTION) != std::string::npos,
+                        "Expected a pre-allocation rejection, got: " + what);
+}
+
+/** A legitimately sized DYNBITSET (LLMQ max 400) must still round-trip unchanged. */
+BOOST_AUTO_TEST_CASE(dynbitset_accepts_legitimate_llmq_size)
+{
+    constexpr size_t kSize = Consensus::MAX_LLMQ_SIZE;
+    std::vector<bool> original(kSize, false);
+    for (size_t i = 0; i < kSize; i += 3) {
+        original[i] = true;
+    }
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << DYNBITSET(original);
+
+    std::vector<bool> decoded;
+    s >> DYNBITSET(decoded);
+    BOOST_CHECK(decoded == original);
+}
+
+/**
+ * The same primitive is reachable from an unauthenticated QFCOMMITMENT via CFinalCommitment's
+ * signers bitset, so cover the real message type too.
+ */
+BOOST_AUTO_TEST_CASE(qfinalcommitment_rejects_oversized_signers_bitset)
+{
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    // nVersion (u16) | llmqType (u8) | quorumHash (32) | signers DYNBITSET | ...
+    s << static_cast<uint16_t>(llmq::CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION);
+    s << Consensus::LLMQType::LLMQ_400_85;
+    s << uint256::ONE;
+    WriteCompactSize(s, 1'000'000);
+
+    llmq::CFinalCommitment qc;
+    std::string what;
+    bool threw = false;
+    try {
+        s >> qc;
+    } catch (const std::ios_base::failure& e) {
+        threw = true;
+        what = e.what();
+    }
+    BOOST_CHECK(threw);
+    BOOST_CHECK(qc.signers.empty());
+    BOOST_CHECK_MESSAGE(what.find(BOUND_REJECTION) != std::string::npos,
+                        "Expected a pre-allocation rejection for CFinalCommitment, got: " + what);
 }
 
 BOOST_AUTO_TEST_CASE(noncanonical)

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -3,12 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <hash.h>
-#include <llmq/commitment.h>
-#include <llmq/params.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
-#include <uint256.h>
 #include <util/strencodings.h>
 
 #include <stdint.h>
@@ -209,27 +206,18 @@ BOOST_AUTO_TEST_CASE(dynbitset_rejects_oversized_declared_length)
     // No bit payload follows, so the remaining size is zero.
 
     std::vector<bool> bits;
-    std::string what;
-    bool threw = false;
-    try {
-        s >> DYNBITSET(bits);
-    } catch (const std::ios_base::failure& e) {
-        threw = true;
-        what = e.what();
-    }
-    BOOST_CHECK_MESSAGE(threw, "DYNBITSET must reject a declared length that exceeds remaining bytes");
+    BOOST_CHECK_EXCEPTION(s >> DYNBITSET(bits), std::ios_base::failure,
+                          HasReason(std::string{BOUND_REJECTION}));
     // Rejection has to precede the resize, so the destination must still hold its exact
     // pre-deserialization state. Merely falling short of the declared size would also be
     // satisfied by an allocation that happened and was then abandoned.
     BOOST_CHECK(bits.empty());
-    BOOST_CHECK_MESSAGE(what.find(BOUND_REJECTION) != std::string::npos,
-                        "Expected a pre-allocation rejection, got: " + what);
 }
 
-/** A legitimately sized DYNBITSET (LLMQ max 400) must still round-trip unchanged. */
-BOOST_AUTO_TEST_CASE(dynbitset_accepts_legitimate_llmq_size)
+/** The largest bit count accepted by ReadCompactSize must still round-trip unchanged. */
+BOOST_AUTO_TEST_CASE(dynbitset_accepts_maximum_size)
 {
-    constexpr size_t kSize = Consensus::MAX_LLMQ_SIZE;
+    constexpr size_t kSize = MAX_SIZE;
     std::vector<bool> original(kSize, false);
     for (size_t i = 0; i < kSize; i += 3) {
         original[i] = true;
@@ -241,34 +229,6 @@ BOOST_AUTO_TEST_CASE(dynbitset_accepts_legitimate_llmq_size)
     std::vector<bool> decoded;
     s >> DYNBITSET(decoded);
     BOOST_CHECK(decoded == original);
-}
-
-/**
- * The same primitive is reachable from an unauthenticated QFCOMMITMENT via CFinalCommitment's
- * signers bitset, so cover the real message type too.
- */
-BOOST_AUTO_TEST_CASE(qfinalcommitment_rejects_oversized_signers_bitset)
-{
-    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
-    // nVersion (u16) | llmqType (u8) | quorumHash (32) | signers DYNBITSET | ...
-    s << static_cast<uint16_t>(llmq::CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION);
-    s << Consensus::LLMQType::LLMQ_400_85;
-    s << uint256::ONE;
-    WriteCompactSize(s, 1'000'000);
-
-    llmq::CFinalCommitment qc;
-    std::string what;
-    bool threw = false;
-    try {
-        s >> qc;
-    } catch (const std::ios_base::failure& e) {
-        threw = true;
-        what = e.what();
-    }
-    BOOST_CHECK(threw);
-    BOOST_CHECK(qc.signers.empty());
-    BOOST_CHECK_MESSAGE(what.find(BOUND_REJECTION) != std::string::npos,
-                        "Expected a pre-allocation rejection for CFinalCommitment, got: " + what);
 }
 
 BOOST_AUTO_TEST_CASE(noncanonical)


### PR DESCRIPTION
## Issue being fixed or feature implemented

`ReadFixedBitSet` allocated from a wire-declared `CompactSize` with no bound beyond `ReadCompactSize`'s 33,554,432 cap. Roughly five bytes on the wire — a `CompactSize` claiming millions of bits, with no payload following — therefore forced a `std::vector<bool>` resize plus a byte buffer totalling several MiB, all of which was only abandoned when the subsequent short read threw.

`MAX_PROTOCOL_MESSAGE_LENGTH` does not help here, because the attack uses an *undersized* message.

The primitive is reachable from an unauthenticated `QFCOMMITMENT` via `CFinalCommitment`'s `signers` and `validMembers` bitsets, and applies to every other `DYNBITSET` caller as well.

This was split out of [#7523](https://github.com/dashpay/dash/pull/7523), where it was bundled with a much larger and more contentious DKG-intake change. The bound stands on its own, so it is offered separately for independent review.

## What was done?

Bound the declared length against the bytes actually remaining in the stream, before allocating anything. A well-formed message always carries exactly the required bytes, so this rejects only claims that could never have been satisfied.

The guard needs the stream to report how many bytes are still available, so `ReadFixedBitSet` is constrained on a `SizedStream` concept. That constraint is deliberately a hard requirement rather than a fallback: a stream without `size()` — `CHashVerifier`, for instance — now fails to compile here instead of silently deserializing an unbounded bitset. An earlier revision duck-typed the check with `if constexpr`, which would have let a future caller quietly lose the bound with no diagnostic.

Nothing in tree is affected, because every stream that reaches this path already reports bytes *remaining*: `DataStream` (`vch.size() - m_read_pos`), `SpanReader`, and `OverrideStream`, which forwards to its wrapped stream. That "remaining, not total" requirement is what the bound rests on, so it is documented on the concept itself — a stream whose `size()` meant something else would weaken the bound silently rather than fail to compile.

Note on what is deliberately *not* included: an earlier revision also checked `nbytes > MAX_SIZE`. That check is dead code — `size` comes from `ReadCompactSize`, which already caps at 33,554,432, so `(size + 7) / 8` can never exceed 4 MiB and the condition is always false.

## How Has This Been Tested?

`src/test/serialize_tests.cpp` covers the amplification case (a declared length far exceeding the remaining stream must be rejected *before* allocating, not by a short read afterwards) and a maximum-size bitset (`MAX_SIZE`, 33,554,432 bits) round-tripping unchanged.

Built locally and `test_dash --run_test=serialize_tests` passes. Full validation is delegated to CI.

## Breaking Changes

None. Only messages declaring a bit count that the message could not possibly contain are affected, and those were never valid.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone