### PR TITLE
fix(scripts): make lint-cppcheck-dash actually report warnings

### DIFF
--- a/contrib/containers/ci/ci-slim.Dockerfile
+++ b/contrib/containers/ci/ci-slim.Dockerfile
@@ -1,6 +1,6 @@
 # Builder for cppcheck
 FROM debian:bookworm-slim AS cppcheck-builder
-ARG CPPCHECK_VERSION=2.17.1
+ARG CPPCHECK_VERSION=2.21.0
 RUN set -ex; \
     apt-get update && apt-get install -y --no-install-recommends \
         curl \

--- a/src/active/context.cpp
+++ b/src/active/context.cpp
@@ -42,7 +42,7 @@ ActiveContext::ActiveContext(CBLSWorker& bls_worker, ChainstateManager& chainman
     dkgdbgman{std::make_unique<llmq::CDKGDebugManager>(dmnman, qsnapman, chainman)},
     qdkgsman{std::make_unique<llmq::CDKGSessionManager>(dmnman, qsnapman, chainman, sporkman, db_params)},
     shareman{std::make_unique<llmq::CSigSharesManager>(connman, chainman, sigman, *nodeman, qman, sporkman)},
-    gov_signer{std::make_unique<GovernanceSigner>(connman, dmnman, govman, superblocks, *nodeman, chainman, mn_sync)},
+    gov_signer{std::make_unique<GovernanceSigner>(dmnman, govman, superblocks, *nodeman, chainman, mn_sync)},
     ehf_sighandler{std::make_unique<llmq::CEHFSignalsHandler>(chainman, sigman, *shareman, qman)},
     cl_signer{std::make_unique<chainlock::ChainLockSigner>(chainman, chainlocks, clhandler, isman,
                                                            qman, sigman, *shareman, mn_sync)},

--- a/src/active/context.h
+++ b/src/active/context.h
@@ -66,7 +66,7 @@ public:
                            llmq::CQuorumManager& qman, llmq::CQuorumSnapshotManager& qsnapman,
                            llmq::CSigningManager& sigman, const CMasternodeSync& mn_sync,
                            const CBLSSecretKey& operator_sk, const util::DbWrapperParams& db_params, bool quorums_watch);
-    ~ActiveContext();
+    ~ActiveContext() override;
 
     void Start();
     void Stop();

--- a/src/active/dkgsession.cpp
+++ b/src/active/dkgsession.cpp
@@ -673,9 +673,6 @@ CFinalCommitment ActiveDKGSession::FinalizeSingleCommitment()
 
     CDKGLogger logger(*this, __func__, __LINE__);
 
-    std::vector<CBLSId> signerIds;
-    std::vector<CBLSSignature> thresholdSigs;
-
     CFinalCommitment fqc(params, m_quorum_base_block_index->GetBlockHash());
 
 

--- a/src/active/dkgsession.h
+++ b/src/active/dkgsession.h
@@ -31,7 +31,7 @@ public:
                      const CActiveMasternodeManager& mn_activeman, const ChainstateManager& chainman,
                      const CSporkManager& sporkman, const CBlockIndex* base_block_index,
                      const Consensus::LLMQParams& params);
-    ~ActiveDKGSession();
+    ~ActiveDKGSession() override;
 
 public:
     // Phase 1: contribution

--- a/src/active/dkgsessionhandler.h
+++ b/src/active/dkgsessionhandler.h
@@ -77,7 +77,7 @@ public:
                             const CActiveMasternodeManager& mn_activeman, const ChainstateManager& chainman,
                             const CSporkManager& sporkman, const Consensus::LLMQParams& llmq_params, bool quorums_watch,
                             int quorums_idx);
-    ~ActiveDKGSessionHandler();
+    ~ActiveDKGSessionHandler() override;
 
 public:
     //! CDKGSessionHandler

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -234,6 +234,7 @@ public:
 struct CBLSIdImplicit : public uint256
 {
     CBLSIdImplicit() = default;
+    // cppcheck-suppress noExplicitConstructor
     CBLSIdImplicit(const uint256& id)
     {
         memcpy(begin(), id.begin(), sizeof(uint256));

--- a/src/bls/bls.h
+++ b/src/bls/bls.h
@@ -161,6 +161,7 @@ public:
         return IsValid();
     }
 
+    // cppcheck-suppress functionStatic
     inline void Serialize(CSizeComputer& s) const
     {
         s.seek(SerSize);
@@ -435,6 +436,7 @@ public:
         return *this;
     }
 
+    // cppcheck-suppress functionStatic
     inline void Serialize(CSizeComputer& s) const
     {
         s.seek(BLSObject::SerSize);

--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -382,8 +382,8 @@ struct VectorAggregator : public std::enable_shared_from_this<VectorAggregator<T
 // Same rules as in Aggregator apply for the inputs
 struct ContributionVerifier : public std::enable_shared_from_this<ContributionVerifier> {
     struct BatchState {
-        size_t start;
-        size_t count;
+        size_t start{0};
+        size_t count{0};
 
         BLSVerificationVectorPtr vvec;
         CBLSSecretKey skShare;

--- a/src/bls/bls_worker.cpp
+++ b/src/bls/bls_worker.cpp
@@ -155,8 +155,8 @@ struct Aggregator : public std::enable_shared_from_this<Aggregator<T>> {
         }
     }
 
-    const T* pointer(const T& v) { return &v; }
-    const T* pointer(const T* v) { return v; }
+    static const T* pointer(const T& v) { return &v; }
+    static const T* pointer(const T* v) { return v; }
 
     // Starts aggregation.
     // If parallel=true, then this will return fast, otherwise this will block until aggregation is done
@@ -297,7 +297,7 @@ struct Aggregator : public std::enable_shared_from_this<Aggregator<T>> {
     }
 
     template <typename TP>
-    T SyncAggregate(Span<TP> vec, size_t start, size_t count)
+    static T SyncAggregate(Span<TP> vec, size_t start, size_t count)
     {
         T result = *vec[start];
         for (size_t j = 1; j < count; j++) {

--- a/src/chainlock/chainlock.h
+++ b/src/chainlock/chainlock.h
@@ -58,7 +58,7 @@ private:
     chainlock::ChainLockSig bestChainLockWithKnownBlock GUARDED_BY(cs);
 
 public:
-    Chainlocks(const CSporkManager& sporkman);
+    explicit Chainlocks(const CSporkManager& sporkman);
 
     [[nodiscard]] bool IsEnabled() const;
     [[nodiscard]] bool IsSigningEnabled() const;

--- a/src/chainlock/signing.h
+++ b/src/chainlock/signing.h
@@ -63,7 +63,7 @@ public:
                              ChainlockHandler& clhandler, const llmq::CInstantSendManager& isman,
                              const llmq::CQuorumManager& qman, llmq::CSigningManager& sigman,
                              llmq::CSigSharesManager& shareman, const CMasternodeSync& mn_sync);
-    ~ChainLockSigner();
+    ~ChainLockSigner() override;
 
     void Start();
     void Stop();

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -214,7 +214,7 @@ public:
     explicit CCoinJoinClientManager(const std::shared_ptr<wallet::CWallet>& wallet, CDeterministicMNManager& dmnman,
                                     CMasternodeMetaMan& mn_metaman, const CMasternodeSync& mn_sync,
                                     const llmq::CInstantSendManager& isman, CoinJoinQueueManager* queueman);
-    ~CCoinJoinClientManager();
+    ~CCoinJoinClientManager() override;
 
     void ProcessMessage(CNode& peer, Chainstate& active_chainstate, CConnman& connman, const CTxMemPool& mempool, std::string_view msg_type, CDataStream& vRecv) EXCLUSIVE_LOCKS_REQUIRED(!cs_deqsessions);
 

--- a/src/coinjoin/client.h
+++ b/src/coinjoin/client.h
@@ -52,7 +52,7 @@ public:
     }
 
     [[nodiscard]] uint256 GetProTxHash() const { return proTxHash; }
-    [[nodiscard]] CCoinJoinAccept GetDSA() const { return dsa; }
+    [[nodiscard]] const CCoinJoinAccept& GetDSA() const { return dsa; }
     [[nodiscard]] bool IsExpired() const { return GetTime() - nTimeCreated > TIMEOUT; }
 
     friend bool operator==(const CPendingDsaRequest& a, const CPendingDsaRequest& b)

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -429,7 +429,7 @@ class CDSTXManager
 public:
     CDSTXManager(const CDSTXManager&) = delete;
     CDSTXManager& operator=(const CDSTXManager&) = delete;
-    CDSTXManager(const chainlock::Chainlocks& chainlocks);
+    explicit CDSTXManager(const chainlock::Chainlocks& chainlocks);
     ~CDSTXManager();
 
     void AddDSTX(const CCoinJoinBroadcastTx& dstx) EXCLUSIVE_LOCKS_REQUIRED(!cs_mapdstx);

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -108,7 +108,7 @@ public:
                              CDeterministicMNManager& dmnman, CDSTXManager& dstxman, CMasternodeMetaMan& mn_metaman,
                              CTxMemPool& mempool, const CActiveMasternodeManager& mn_activeman,
                              const CMasternodeSync& mn_sync, const llmq::CInstantSendManager& isman);
-    ~CCoinJoinServer();
+    ~CCoinJoinServer() override;
 
     void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv) override;
     bool ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker) override;

--- a/src/coinjoin/util.h
+++ b/src/coinjoin/util.h
@@ -59,7 +59,7 @@ public:
     CTransactionBuilderOutput(CTransactionBuilderOutput&&) = delete;
     CTransactionBuilderOutput& operator=(CTransactionBuilderOutput&&) = delete;
     /// Get the scriptPubKey of this output
-    [[nodiscard]] CScript GetScript() const { return script; }
+    [[nodiscard]] const CScript& GetScript() const { return script; }
     /// Get the amount of this output
     [[nodiscard]] CAmount GetAmount() const { return nAmount; }
     /// Try update the amount of this output. Returns true if it was successful and false if not (e.g. insufficient amount left).

--- a/src/coinjoin/walletman.cpp
+++ b/src/coinjoin/walletman.cpp
@@ -321,7 +321,7 @@ MessageProcessingResult CJWalletManagerImpl::ProcessDSQueue(NodeId from, CConnma
                      dmn->proTxHash.ToString(), dsq.ToString());
 
             ForAnyCJClientMan(
-                [&dsq](CCoinJoinClientManager& clientman) { return clientman.MarkAlreadyJoinedQueueAsTried(dsq); });
+                [&dsq](const CCoinJoinClientManager& clientman) { return clientman.MarkAlreadyJoinedQueueAsTried(dsq); });
 
             m_queueman->AddQueue(dsq);
         }

--- a/src/evo/deterministicmns.cpp
+++ b/src/evo/deterministicmns.cpp
@@ -1135,8 +1135,7 @@ bool CDeterministicMNManager::MigrateLegacyDiffs(const CBlockIndex* const tip_in
 }
 
 CDeterministicMNManager::RecalcDiffsResult CDeterministicMNManager::RecalculateAndRepairDiffs(
-    const CBlockIndex* start_index, const CBlockIndex* stop_index, ChainstateManager& chainman,
-    BuildListFromBlockFunc build_list_func, bool repair)
+    const CBlockIndex* start_index, const CBlockIndex* stop_index, BuildListFromBlockFunc build_list_func, bool repair)
 {
     RecalcDiffsResult result;
     result.start_height = start_index->nHeight;
@@ -1237,7 +1236,7 @@ CDeterministicMNManager::RecalcDiffsResult CDeterministicMNManager::RecalculateA
 
     // Write repaired diffs to database
     if (repair) {
-        WriteRepairedDiffs(recalculated_diffs, result);
+        WriteRepairedDiffs(recalculated_diffs);
     }
 
     return result;
@@ -1426,7 +1425,7 @@ std::vector<std::pair<uint256, CDeterministicMNListDiff>> CDeterministicMNManage
 }
 
 void CDeterministicMNManager::WriteRepairedDiffs(
-    const std::vector<std::pair<uint256, CDeterministicMNListDiff>>& recalculated_diffs, RecalcDiffsResult& result)
+    const std::vector<std::pair<uint256, CDeterministicMNListDiff>>& recalculated_diffs)
 {
     AssertLockNotHeld(cs);
 

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -805,7 +805,7 @@ public:
         CDeterministicMNList& mnListRet)>;
 
     [[nodiscard]] RecalcDiffsResult RecalculateAndRepairDiffs(const CBlockIndex* start_index,
-                                                              const CBlockIndex* stop_index, ChainstateManager& chainman,
+                                                              const CBlockIndex* stop_index,
                                                               BuildListFromBlockFunc build_list_func, bool repair)
         EXCLUSIVE_LOCKS_REQUIRED(!cs);
     [[nodiscard]] bool IsRepaired() const;
@@ -828,7 +828,7 @@ private:
     std::vector<std::pair<uint256, CDeterministicMNListDiff>> RepairSnapshotPair(
         const CBlockIndex* from_index, const CBlockIndex* to_index, const CDeterministicMNList& from_snapshot,
         const CDeterministicMNList& to_snapshot, BuildListFromBlockFunc build_list_func, RecalcDiffsResult& result);
-    void WriteRepairedDiffs(const std::vector<std::pair<uint256, CDeterministicMNListDiff>>& recalculated_diffs,
-                            RecalcDiffsResult& result) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    void WriteRepairedDiffs(const std::vector<std::pair<uint256, CDeterministicMNListDiff>>& recalculated_diffs)
+        EXCLUSIVE_LOCKS_REQUIRED(!cs);
 };
 #endif // BITCOIN_EVO_DETERMINISTICMNS_H

--- a/src/evo/deterministicmns.h
+++ b/src/evo/deterministicmns.h
@@ -517,7 +517,7 @@ public:
 
 private:
     template <typename T>
-    [[nodiscard]] uint256 GetUniquePropertyHash(const T& v) const
+    [[nodiscard]] static uint256 GetUniquePropertyHash(const T& v)
     {
 #define DMNL_NO_TEMPLATE(name) \
     static_assert(!std::is_same_v<std::decay_t<T>, name>, "GetUniquePropertyHash cannot be templated against " #name)
@@ -820,12 +820,13 @@ private:
     CDeterministicMNList GetListForBlockInternal(gsl::not_null<const CBlockIndex*> pindex) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     // Helper methods for RecalculateAndRepairDiffs
-    std::vector<const CBlockIndex*> CollectSnapshotBlocks(const CBlockIndex* start_index, const CBlockIndex* stop_index,
-                                                          const Consensus::Params& consensus_params);
+    static std::vector<const CBlockIndex*> CollectSnapshotBlocks(const CBlockIndex* start_index,
+                                                                 const CBlockIndex* stop_index,
+                                                                 const Consensus::Params& consensus_params);
     bool VerifySnapshotPair(const CBlockIndex* from_index, const CBlockIndex* to_index,
                             const CDeterministicMNList& from_snapshot, const CDeterministicMNList& to_snapshot,
                             RecalcDiffsResult& result);
-    std::vector<std::pair<uint256, CDeterministicMNListDiff>> RepairSnapshotPair(
+    static std::vector<std::pair<uint256, CDeterministicMNListDiff>> RepairSnapshotPair(
         const CBlockIndex* from_index, const CBlockIndex* to_index, const CDeterministicMNList& from_snapshot,
         const CDeterministicMNList& to_snapshot, BuildListFromBlockFunc build_list_func, RecalcDiffsResult& result);
     void WriteRepairedDiffs(const std::vector<std::pair<uint256, CDeterministicMNListDiff>>& recalculated_diffs)

--- a/src/evo/dmn_types.h
+++ b/src/evo/dmn_types.h
@@ -24,8 +24,8 @@ namespace dmn_types {
 
 struct mntype_struct
 {
-    const int32_t voting_weight;
-    const CAmount collat_amount;
+    const int32_t voting_weight{0};
+    const CAmount collat_amount{0};
     const std::string_view description;
 };
 

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -111,7 +111,7 @@ public:
     CMNHFManager(const CMNHFManager&) = delete;
     CMNHFManager& operator=(const CMNHFManager&) = delete;
     explicit CMNHFManager(CEvoDB& evoDb, const ChainstateManager& chainman);
-    ~CMNHFManager();
+    ~CMNHFManager() override;
 
     /**
      * Every new block should be processed when Tip() is updated by calling of CMNHFManager::ProcessBlock.

--- a/src/evo/netinfo.cpp
+++ b/src/evo/netinfo.cpp
@@ -400,7 +400,7 @@ bool ExtNetInfo::IsAddrPortDuplicate(const NetInfoEntry& candidate) const
                        [&candidate](const auto& entry) { return candidate == entry; });
 }
 
-bool ExtNetInfo::HasAddrDuplicates(const NetInfoList& entries) const
+bool ExtNetInfo::HasAddrDuplicates(const NetInfoList& entries)
 {
     std::unordered_set<std::string> known{};
     for (const auto& entry : entries) {
@@ -412,7 +412,7 @@ bool ExtNetInfo::HasAddrDuplicates(const NetInfoList& entries) const
     return false;
 }
 
-bool ExtNetInfo::IsAddrDuplicate(const NetInfoEntry& candidate, const NetInfoList& entries) const
+bool ExtNetInfo::IsAddrDuplicate(const NetInfoEntry& candidate, const NetInfoList& entries)
 {
     const std::string& candidate_str{candidate.ToStringAddr()};
     return std::any_of(entries.begin(), entries.end(),

--- a/src/evo/netinfo.h
+++ b/src/evo/netinfo.h
@@ -325,6 +325,7 @@ public:
         }
     }
 
+    // cppcheck-suppress functionStatic
     void Serialize(CSizeComputer& s) const
     {
         s.seek(::GetSerializeSize(CService{}, s.GetVersion()));
@@ -375,10 +376,10 @@ private:
     bool IsAddrPortDuplicate(const NetInfoEntry& candidate) const;
 
     /** Returns true if there are addr duplicates within a given address list */
-    bool HasAddrDuplicates(const NetInfoList& entries) const;
+    static bool HasAddrDuplicates(const NetInfoList& entries);
 
     /** Returns true if candidate is an addr duplicate within a given address list */
-    bool IsAddrDuplicate(const NetInfoEntry& candidate, const NetInfoList& entries) const;
+    static bool IsAddrDuplicate(const NetInfoEntry& candidate, const NetInfoList& entries);
 
     /** Validate uniqueness requirements and add to object if passed */
     NetInfoStatus ProcessCandidate(const NetInfoPurpose purpose, const NetInfoEntry& candidate);

--- a/src/evo/simplifiedmns.cpp
+++ b/src/evo/simplifiedmns.cpp
@@ -69,10 +69,9 @@ std::string CSimplifiedMNListEntry::ToString() const
                      (nVersion >= ProTxVersion::ExtAddr ? "" : strprintf(", platformHTTPPort=%d", platformHTTPPort)));
 }
 
-CSimplifiedMNList::CSimplifiedMNList(std::vector<std::unique_ptr<CSimplifiedMNListEntry>>&& smlEntries)
+CSimplifiedMNList::CSimplifiedMNList(std::vector<std::unique_ptr<CSimplifiedMNListEntry>>&& smlEntries) :
+    mnList{std::move(smlEntries)}
 {
-    mnList = std::move(smlEntries);
-
     std::sort(mnList.begin(), mnList.end(), [&](const std::unique_ptr<CSimplifiedMNListEntry>& a, const std::unique_ptr<CSimplifiedMNListEntry>& b) {
         return a->proRegTxHash.Compare(b->proRegTxHash) < 0;
     });

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -293,6 +293,7 @@ bool CSpecialTxProcessor::RebuildListFromBlock(const CBlock& block, gsl::not_nul
 {
     // Verify that prevList either represents an empty/initial state (default-constructed),
     // or it matches the previous block's hash.
+    // cppcheck-suppress assertWithSideEffect
     assert(prevList == CDeterministicMNList() || prevList.GetBlockHash() == pindexPrev->GetBlockHash());
 
     int nHeight = pindexPrev->nHeight + 1;

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -884,7 +884,7 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(Chainstate& chainstate, const
     return true;
 }
 
-bool CSpecialTxProcessor::UndoSpecialTxsInBlock(Chainstate& chainstate, const CBlock& block, const CBlockIndex* pindex, std::optional<MNListUpdates>& updatesRet)
+bool CSpecialTxProcessor::UndoSpecialTxsInBlock(const Chainstate& chainstate, const CBlock& block, const CBlockIndex* pindex, std::optional<MNListUpdates>& updatesRet)
 {
     AssertLockHeld(::cs_main);
 

--- a/src/evo/specialtxman.cpp
+++ b/src/evo/specialtxman.cpp
@@ -699,9 +699,6 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(Chainstate& chainstate, const
         static int64_t nTimeLoop = 0;
         static int64_t nTimeQuorum = 0;
         static int64_t nTimeDMN = 0;
-        static int64_t nTimeMerkleMNL = 0;
-        static int64_t nTimeMerkleQuorums = 0;
-        static int64_t nTimeCbTxCL = 0;
         static int64_t nTimeMnehf = 0;
         static int64_t nTimePayload = 0;
         static int64_t nTimeCreditPool = 0;
@@ -809,6 +806,10 @@ bool CSpecialTxProcessor::ProcessSpecialTxsInBlock(Chainstate& chainstate, const
                  nTimeDMN * 0.000001);
 
         if (opt_cbTx.has_value()) {
+            static int64_t nTimeMerkleMNL = 0;
+            static int64_t nTimeMerkleQuorums = 0;
+            static int64_t nTimeCbTxCL = 0;
+
             uint256 calculatedMerkleRootMNL;
             if (!CalcCbTxMerkleRootMNList(calculatedMerkleRootMNL, mn_list.to_sml(), state)) {
                 // pass the state returned by the function above

--- a/src/evo/specialtxman.h
+++ b/src/evo/specialtxman.h
@@ -74,7 +74,7 @@ public:
     bool ProcessSpecialTxsInBlock(Chainstate& chainstate, const CBlock& block, const CBlockIndex* pindex, const CCoinsViewCache& view, bool fJustCheck,
                                   bool fCheckCbTxMerkleRoots, BlockValidationState& state, std::optional<MNListUpdates>& updatesRet)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-    bool UndoSpecialTxsInBlock(Chainstate& chainstate, const CBlock& block, const CBlockIndex* pindex, std::optional<MNListUpdates>& updatesRet)
+    bool UndoSpecialTxsInBlock(const Chainstate& chainstate, const CBlock& block, const CBlockIndex* pindex, std::optional<MNListUpdates>& updatesRet)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -786,7 +786,7 @@ bool CGovernanceManager::MasternodeRateCheck(const CGovernanceObject& govobj, bo
     return false;
 }
 
-bool CGovernanceManager::ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception, CConnman& connman)
+bool CGovernanceManager::ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception)
 {
     AssertLockNotHeld(cs_store);
     AssertLockNotHeld(cs_relay);

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -1156,7 +1156,7 @@ void CGovernanceManager::RemoveInvalidVotes()
             if (removed.empty()) {
                 continue;
             }
-            for (auto& voteHash : removed) {
+            for (const auto& voteHash : removed) {
                 cmapVoteToObject.Erase(voteHash);
                 cmapInvalidVotes.Erase(voteHash);
                 cmmapOrphanVotes.Erase(voteHash);

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -21,7 +21,6 @@
 
 class CBloomFilter;
 class CBlockIndex;
-class CConnman;
 class CDataStream;
 class CDeterministicMNList;
 class CDeterministicMNManager;
@@ -313,7 +312,7 @@ public:
      */
     bool ConfirmInventoryRequest(const CInv& inv)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store);
-    bool ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception, CConnman& connman)
+    bool ProcessVoteAndRelay(const CGovernanceVote& vote, CGovernanceException& exception)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_store, !cs_relay);
     void RelayObject(const CGovernanceObject& obj)
         EXCLUSIVE_LOCKS_REQUIRED(!cs_relay);

--- a/src/governance/net_governance.cpp
+++ b/src/governance/net_governance.cpp
@@ -175,11 +175,6 @@ void NetGovernance::ProcessMessage(CNode& peer, const std::string& msg_type, CDa
 
         uint256 nHash = govobj.GetHash();
 
-        if (!m_node_sync.IsBlockchainSynced()) {
-            LogPrint(BCLog::GOBJECT, "MNGOVERNANCEOBJECT -- masternode list not synced\n");
-            return;
-        }
-
         std::string strHash = nHash.ToString();
 
         LogPrint(BCLog::GOBJECT, "MNGOVERNANCEOBJECT -- Received object: %s\n", strHash);

--- a/src/governance/signing.cpp
+++ b/src/governance/signing.cpp
@@ -23,10 +23,9 @@ namespace {
 constexpr std::chrono::seconds GOVERNANCE_FUDGE_WINDOW{2h};
 } // anonymous namespace
 
-GovernanceSigner::GovernanceSigner(CConnman& connman, CDeterministicMNManager& dmnman, CGovernanceManager& govman,
+GovernanceSigner::GovernanceSigner(CDeterministicMNManager& dmnman, CGovernanceManager& govman,
                                    governance::SuperblockManager& superblocks, const CActiveMasternodeManager& mn_activeman,
                                    const ChainstateManager& chainman, const CMasternodeSync& mn_sync) :
-    m_connman{connman},
     m_dmnman{dmnman},
     m_govman{govman},
     m_superblocks{superblocks},
@@ -280,7 +279,7 @@ bool GovernanceSigner::VoteFundingTrigger(const uint256& nHash, const vote_outco
     vote.SetSignature(m_mn_activeman.SignBasic(vote.GetSignatureHash()));
 
     CGovernanceException exception;
-    if (!m_govman.ProcessVoteAndRelay(vote, exception, m_connman)) {
+    if (!m_govman.ProcessVoteAndRelay(vote, exception)) {
         LogPrint(BCLog::GOBJECT, "%s -- Vote FUNDING %d for trigger:%s failed:%s\n", __func__, outcome,
                  nHash.ToString(), exception.what());
         return false;

--- a/src/governance/signing.h
+++ b/src/governance/signing.h
@@ -16,7 +16,6 @@
 
 class CActiveMasternodeManager;
 class CBlockIndex;
-class CConnman;
 class CDeterministicMNManager;
 class CGovernanceManager;
 class ChainstateManager;
@@ -29,7 +28,6 @@ class SuperblockManager;
 class GovernanceSigner
 {
 private:
-    CConnman& m_connman;
     CDeterministicMNManager& m_dmnman;
     CGovernanceManager& m_govman;
     governance::SuperblockManager& m_superblocks;
@@ -44,7 +42,7 @@ public:
     GovernanceSigner() = delete;
     GovernanceSigner(const GovernanceSigner&) = delete;
     GovernanceSigner& operator=(const GovernanceSigner&) = delete;
-    explicit GovernanceSigner(CConnman& connman, CDeterministicMNManager& dmnman, CGovernanceManager& govman,
+    explicit GovernanceSigner(CDeterministicMNManager& dmnman, CGovernanceManager& govman,
                               governance::SuperblockManager& superblocks, const CActiveMasternodeManager& mn_activeman,
                               const ChainstateManager& chainman, const CMasternodeSync& mn_sync);
     ~GovernanceSigner();

--- a/src/governance/superblock.cpp
+++ b/src/governance/superblock.cpp
@@ -245,14 +245,14 @@ CAmount CSuperblock::GetPaymentsTotalAmount()
 *   - Does this transaction match the superblock?
 */
 
-bool CSuperblock::IsValid(const CChain& active_chain, const CTransaction& txNew, int nBlockHeight, CAmount blockReward, bool is_v24)
+bool CSuperblock::IsValid(const CChain& active_chain, const CTransaction& txNew, int block_height, CAmount blockReward, bool is_v24)
 {
     // TODO : LOCK(cs);
     // No reason for a lock here now since this method only accesses data
     // internal to *this and since CSuperblock's are accessed only through
     // shared pointers there's no way our object can get deleted while this
     // code is running.
-    if (!IsValidBlockHeight(nBlockHeight)) {
+    if (!IsValidBlockHeight(block_height)) {
         LogPrintf("CSuperblock::IsValid -- ERROR: Block invalid, incorrect block height\n");
         return false;
     }
@@ -279,7 +279,7 @@ bool CSuperblock::IsValid(const CChain& active_chain, const CTransaction& txNew,
 
     // payments should not exceed limit
     CAmount nPaymentsTotalAmount = GetPaymentsTotalAmount();
-    CAmount nPaymentsLimit = GetPaymentsLimit(active_chain, nBlockHeight);
+    CAmount nPaymentsLimit = GetPaymentsLimit(active_chain, block_height);
     if (nPaymentsTotalAmount > nPaymentsLimit) {
         LogPrintf("CSuperblock::IsValid -- ERROR: Block invalid, payments limit exceeded: payments %lld, limit %lld\n", nPaymentsTotalAmount, nPaymentsLimit);
         return false;

--- a/src/governance/superblock.h
+++ b/src/governance/superblock.h
@@ -107,7 +107,7 @@ public:
     bool GetPayment(int nPaymentIndex, CGovernancePayment& paymentRet);
     CAmount GetPaymentsTotalAmount();
 
-    bool IsValid(const CChain& active_chain, const CTransaction& txNew, int nBlockHeight, CAmount blockReward, bool is_v24);
+    bool IsValid(const CChain& active_chain, const CTransaction& txNew, int block_height, CAmount blockReward, bool is_v24);
     bool IsExpired(int heightToTest) const;
 
     std::vector<uint256> GetProposalHashes() const;

--- a/src/index/addressindex.cpp
+++ b/src/index/addressindex.cpp
@@ -47,12 +47,13 @@ bool AddressIndex::DB::WriteBatch(const std::vector<CAddressIndexEntry>& address
 }
 
 bool AddressIndex::DB::ReadAddressIndex(const uint160& address_hash, const AddressType type,
-                                        std::vector<CAddressIndexEntry>& entries, const int32_t start, const int32_t end)
+                                        std::vector<CAddressIndexEntry>& entries, const int32_t start_height,
+                                        const int32_t end_height)
 {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
-    if (start > 0 && end > 0) {
-        pcursor->Seek(std::make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorHeightKey(type, address_hash, start)));
+    if (start_height > 0 && end_height > 0) {
+        pcursor->Seek(std::make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorHeightKey(type, address_hash, start_height)));
     } else {
         pcursor->Seek(std::make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorKey(type, address_hash)));
     }
@@ -61,7 +62,7 @@ bool AddressIndex::DB::ReadAddressIndex(const uint160& address_hash, const Addre
         std::pair<uint8_t, CAddressIndexKey> key;
         if (pcursor->GetKey(key) && key.first == DB_ADDRESSINDEX && key.second.m_address_type == type &&
             key.second.m_address_bytes == address_hash) {
-            if (end > 0 && key.second.m_block_height > end) {
+            if (end_height > 0 && key.second.m_block_height > end_height) {
                 break;
             }
             CAmount value;
@@ -399,9 +400,10 @@ bool AddressIndex::CustomRewind(const interfaces::BlockKey& current_tip, const i
 BaseIndex::DB& AddressIndex::GetDB() const { return *m_db; }
 
 bool AddressIndex::GetAddressIndex(const uint160& address_hash, const AddressType type,
-                                   std::vector<CAddressIndexEntry>& entries, const int32_t start, const int32_t end) const
+                                   std::vector<CAddressIndexEntry>& entries, const int32_t start_height,
+                                   const int32_t end_height) const
 {
-    return m_db->ReadAddressIndex(address_hash, type, entries, start, end);
+    return m_db->ReadAddressIndex(address_hash, type, entries, start_height, end_height);
 }
 
 bool AddressIndex::GetAddressUnspentIndex(const uint160& address_hash, const AddressType type,

--- a/src/index/addressindex.h
+++ b/src/index/addressindex.h
@@ -41,7 +41,8 @@ protected:
 
         /// Read address transaction history
         bool ReadAddressIndex(const uint160& address_hash, const AddressType type,
-                              std::vector<CAddressIndexEntry>& entries, const int32_t start = 0, const int32_t end = 0);
+                              std::vector<CAddressIndexEntry>& entries, const int32_t start_height = 0,
+                              const int32_t end_height = 0);
 
         /// Read address unspent outputs
         bool ReadAddressUnspentIndex(const uint160& address_hash, const AddressType type,
@@ -78,7 +79,7 @@ public:
 
     /// Query address transaction history
     bool GetAddressIndex(const uint160& address_hash, const AddressType type, std::vector<CAddressIndexEntry>& entries,
-                         const int32_t start = 0, const int32_t end = 0) const;
+                         const int32_t start_height = 0, const int32_t end_height = 0) const;
 
     /// Query address unspent outputs
     bool GetAddressUnspentIndex(const uint160& address_hash, const AddressType type,

--- a/src/index/addressindex_types.h
+++ b/src/index/addressindex_types.h
@@ -127,7 +127,7 @@ public:
     }
 
 public:
-    size_t GetSerializeSize(int nType, int nVersion) const { return 66; }
+    static size_t GetSerializeSize(int, int) { return 66; }
 
     template <typename Stream>
     void Serialize(Stream& s) const
@@ -174,7 +174,7 @@ public:
     }
 
 public:
-    size_t GetSerializeSize(int nType, int nVersion) const { return 21; }
+    static size_t GetSerializeSize(int, int) { return 21; }
 
     template <typename Stream>
     void Serialize(Stream& s) const
@@ -213,7 +213,7 @@ public:
     }
 
 public:
-    size_t GetSerializeSize(int nType, int nVersion) const { return 25; }
+    static size_t GetSerializeSize(int, int) { return 25; }
 
     template <typename Stream>
     void Serialize(Stream& s) const
@@ -257,7 +257,7 @@ public:
     }
 
 public:
-    size_t GetSerializeSize(int nType, int nVersion) const { return 57; }
+    static size_t GetSerializeSize(int, int) { return 57; }
 
     template <typename Stream>
     void Serialize(Stream& s) const

--- a/src/index/timestampindex.cpp
+++ b/src/index/timestampindex.cpp
@@ -22,7 +22,7 @@ bool TimestampIndex::DB::Write(const CTimestampIndexKey& key)
     return CDBWrapper::Write(std::make_pair(DB_TIMESTAMPINDEX, key), true);
 }
 
-bool TimestampIndex::DB::ReadRange(uint32_t high, uint32_t low, std::vector<uint256>& hashes)
+void TimestampIndex::DB::ReadRange(uint32_t high, uint32_t low, std::vector<uint256>& hashes)
 {
     std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
@@ -39,8 +39,6 @@ bool TimestampIndex::DB::ReadRange(uint32_t high, uint32_t low, std::vector<uint
             break;
         }
     }
-
-    return true;
 }
 
 bool TimestampIndex::DB::EraseTimestampIndex(const CTimestampIndexKey& key)
@@ -91,7 +89,7 @@ bool TimestampIndex::CustomRewind(const interfaces::BlockKey& current_tip, const
 
 BaseIndex::DB& TimestampIndex::GetDB() const { return *m_db; }
 
-bool TimestampIndex::GetBlockHashes(uint32_t high, uint32_t low, std::vector<uint256>& hashes) const
+void TimestampIndex::GetBlockHashes(uint32_t high, uint32_t low, std::vector<uint256>& hashes) const
 {
-    return m_db->ReadRange(high, low, hashes);
+    m_db->ReadRange(high, low, hashes);
 }

--- a/src/index/timestampindex.h
+++ b/src/index/timestampindex.h
@@ -34,7 +34,7 @@ protected:
         bool Write(const CTimestampIndexKey& key);
 
         /// Read timestamp index entries within the given range
-        bool ReadRange(uint32_t high, uint32_t low, std::vector<uint256>& hashes);
+        void ReadRange(uint32_t high, uint32_t low, std::vector<uint256>& hashes);
 
         /// Erase timestamp index entry
         bool EraseTimestampIndex(const CTimestampIndexKey& key);
@@ -58,7 +58,7 @@ public:
     virtual ~TimestampIndex() override;
 
     /// Retrieve block hashes within the given timestamp range [low, high]
-    bool GetBlockHashes(uint32_t high, uint32_t low, std::vector<uint256>& hashes) const;
+    void GetBlockHashes(uint32_t high, uint32_t low, std::vector<uint256>& hashes) const;
 };
 
 #endif // BITCOIN_INDEX_TIMESTAMPINDEX_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2427,7 +2427,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                                                        CDeterministicMNList& mnListRet) -> bool {
                     return node.chain_helper->special_tx->RebuildListFromBlock(block, pindexPrev, prevList, view, debugLogs, state, mnListRet);
                 };
-                auto result = node.dmnman->RecalculateAndRepairDiffs(start_index, stop_index, chainman, build_list_func, true);
+                auto result = node.dmnman->RecalculateAndRepairDiffs(start_index, stop_index, build_list_func, true);
 
                 if (!result.verification_errors.empty()) {
                     LogPrintf("WARNING: Verification errors:\n%s\n", Join(result.verification_errors, "\n"));

--- a/src/instantsend/instantsend.h
+++ b/src/instantsend/instantsend.h
@@ -32,7 +32,7 @@ typedef std::shared_ptr<const CTransaction> CTransactionRef;
 namespace instantsend {
 
 struct PendingISLockFromPeer {
-    NodeId node_id;
+    NodeId node_id{0};
     InstantSendLockPtr islock;
 };
 
@@ -71,7 +71,7 @@ private:
     // TXs which are neither IS locked nor ChainLocked. We use this to determine for which TXs we need to retry IS
     // locking of child TXs
     struct NonLockedTxInfo {
-        const CBlockIndex* pindexMined;
+        const CBlockIndex* pindexMined{nullptr};
         CTransactionRef tx;
         Uint256HashSet children;
     };

--- a/src/instantsend/signing.h
+++ b/src/instantsend/signing.h
@@ -71,7 +71,7 @@ public:
                                llmq::CInstantSendManager& isman, llmq::CSigningManager& sigman,
                                llmq::CSigSharesManager& shareman, llmq::CQuorumManager& qman, CSporkManager& sporkman,
                                CTxMemPool& mempool, const CMasternodeSync& mn_sync);
-    ~InstantSendSigner();
+    ~InstantSendSigner() override;
 
     void RegisterRecoveryInterface();
     void UnregisterRecoveryInterface();

--- a/src/llmq/blockprocessor.cpp
+++ b/src/llmq/blockprocessor.cpp
@@ -500,7 +500,7 @@ std::optional<std::pair<QcHashMap, QcIndexedHashMap>> CQuorumBlockProcessor::Get
     return std::make_pair(m_qc_hashes_cached, m_qc_indexed_hashes_cached);
 }
 
-bool CQuorumBlockProcessor::UndoBlock(Chainstate& chainstate, const CBlock& block, gsl::not_null<const CBlockIndex*> pindex)
+bool CQuorumBlockProcessor::UndoBlock(const Chainstate& chainstate, const CBlock& block, gsl::not_null<const CBlockIndex*> pindex)
 {
     AssertLockHeld(::cs_main);
 

--- a/src/llmq/blockprocessor.h
+++ b/src/llmq/blockprocessor.h
@@ -108,7 +108,7 @@ public:
 
     bool ProcessBlock(Chainstate& chainstate, const CBlock& block, gsl::not_null<const CBlockIndex*> pindex, BlockValidationState& state,
                       bool fJustCheck, bool fBLSChecks) EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs, !m_qc_hashes_cache_mutex);
-    bool UndoBlock(Chainstate& chainstate, const CBlock& block, gsl::not_null<const CBlockIndex*> pindex)
+    bool UndoBlock(const Chainstate& chainstate, const CBlock& block, gsl::not_null<const CBlockIndex*> pindex)
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main, !minableCommitmentsCs, !m_qc_hashes_cache_mutex);
 
     //! it returns hash of commitment if it should be relay, otherwise nullopt

--- a/src/llmq/dkgmessages.h
+++ b/src/llmq/dkgmessages.h
@@ -20,7 +20,7 @@ namespace llmq {
 class CDKGContribution
 {
 public:
-    Consensus::LLMQType llmqType;
+    Consensus::LLMQType llmqType{Consensus::LLMQType::LLMQ_NONE};
     uint256 quorumHash;
     uint256 proTxHash;
     BLSVerificationVectorPtr vvec;
@@ -107,11 +107,11 @@ public:
 class CDKGJustification
 {
 public:
-    Consensus::LLMQType llmqType;
+    Consensus::LLMQType llmqType{Consensus::LLMQType::LLMQ_NONE};
     uint256 quorumHash;
     uint256 proTxHash;
     struct Contribution {
-        uint32_t index;
+        uint32_t index{0};
         CBLSSecretKey key;
         SERIALIZE_METHODS(Contribution, obj)
         {

--- a/src/llmq/dkgsessionmgr.h
+++ b/src/llmq/dkgsessionmgr.h
@@ -65,7 +65,7 @@ private:
 
     mutable Mutex contributionsCacheCs;
     struct ContributionsCacheKey {
-        Consensus::LLMQType llmqType;
+        Consensus::LLMQType llmqType{Consensus::LLMQType::LLMQ_NONE};
         uint256 quorumHash;
         uint256 proTxHash;
         bool operator<(const ContributionsCacheKey& r) const

--- a/src/llmq/ehf_signals.h
+++ b/src/llmq/ehf_signals.h
@@ -36,7 +36,7 @@ public:
     explicit CEHFSignalsHandler(ChainstateManager& chainman, CSigningManager& sigman, CSigSharesManager& shareman,
                                 const CQuorumManager& qman);
 
-    ~CEHFSignalsHandler();
+    ~CEHFSignalsHandler() override;
 
     /**
      * Since Tip is updated it could be a time to generate EHF Signal

--- a/src/llmq/net_dkg.cpp
+++ b/src/llmq/net_dkg.cpp
@@ -544,7 +544,7 @@ bool NetDKG::AlreadyHave(const CInv& inv)
     case MSG_QUORUM_PREMATURE_COMMITMENT: {
         if (!IsQuorumDKGEnabled(m_sporkman)) return false;
         bool seen = false;
-        m_qdkgsman.ForEachHandler([&](CDKGSessionHandler& h) {
+        m_qdkgsman.ForEachHandler([&](const CDKGSessionHandler& h) {
             if (seen) return;
             if (h.pendingContributions.HasSeen(inv.hash) || h.pendingComplaints.HasSeen(inv.hash) ||
                 h.pendingJustifications.HasSeen(inv.hash) || h.pendingPrematureCommitments.HasSeen(inv.hash)) {
@@ -652,7 +652,7 @@ void NetDKG::PhaseHandlerThread(ActiveDKGSessionHandler& handler)
 }
 
 static void AddQuorumProbeConnections(const Consensus::LLMQParams& llmqParams, CConnman& connman,
-                                      CMasternodeMetaMan& mn_metaman, const CSporkManager& sporkman,
+                                      const CMasternodeMetaMan& mn_metaman, const CSporkManager& sporkman,
                                       const UtilParameters& util_params, const CDeterministicMNList& tip_mn_list,
                                       const uint256& myProTxHash)
 {

--- a/src/llmq/net_dkg.h
+++ b/src/llmq/net_dkg.h
@@ -63,7 +63,7 @@ public:
            CDKGDebugManager& dkgdbgman, CQuorumBlockProcessor& qblockman, CQuorumSnapshotManager& qsnapman,
            const CActiveMasternodeManager& mn_activeman, CConnman& connman);
 
-    ~NetDKG();
+    ~NetDKG() override;
 
     // NetHandler
     void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv) override

--- a/src/llmq/net_quorum.cpp
+++ b/src/llmq/net_quorum.cpp
@@ -263,8 +263,8 @@ bool NetQuorum::ProcessContribQGETDATA(CDataStream& ssResponseData, const CQuoru
     return false;
 }
 
-bool NetQuorum::ProcessContribQDATA(CNode& pfrom, CDataStream& vRecv,
-                                    CQuorum& quorum, CQuorumDataRequest& request)
+bool NetQuorum::ProcessContribQDATA(const CNode& pfrom, CDataStream& vRecv,
+                                    CQuorum& quorum, const CQuorumDataRequest& request)
 {
     if (!(request.GetDataMask() & CQuorumDataRequest::ENCRYPTED_CONTRIBUTIONS)) {
         return true;

--- a/src/llmq/net_quorum.h
+++ b/src/llmq/net_quorum.h
@@ -95,8 +95,8 @@ private:
     bool ProcessContribQGETDATA(CDataStream& ssResponseData, const CQuorum& quorum,
                                 CQuorumDataRequest& request,
                                 gsl::not_null<const CBlockIndex*> block_index) const;
-    bool ProcessContribQDATA(CNode& pfrom, CDataStream& vRecv,
-                             CQuorum& quorum, CQuorumDataRequest& request);
+    bool ProcessContribQDATA(const CNode& pfrom, CDataStream& vRecv,
+                             CQuorum& quorum, const CQuorumDataRequest& request);
 
 private:
     CBLSWorker& m_bls_worker;

--- a/src/llmq/net_signing.cpp
+++ b/src/llmq/net_signing.cpp
@@ -454,7 +454,7 @@ void NetSigning::ProcessPendingSigShares(
         }
 
         auto rec_sigs = m_shares_manager->ProcessPendingSigShares(v, quorums);
-        for (auto& rs : rec_sigs) {
+        for (const auto& rs : rec_sigs) {
             ProcessRecoveredSig(rs, true);
         }
     }

--- a/src/llmq/observer.h
+++ b/src/llmq/observer.h
@@ -35,7 +35,7 @@ public:
     ObserverContext(CDeterministicMNManager& dmnman, llmq::CQuorumManager& qman, llmq::CQuorumSnapshotManager& qsnapman,
                     const ChainstateManager& chainman, const CSporkManager& sporkman,
                     const util::DbWrapperParams& db_params);
-    ~ObserverContext();
+    ~ObserverContext() override;
 
     // QuorumRole
     // Watch-only nodes are not masternodes

--- a/src/llmq/params.h
+++ b/src/llmq/params.h
@@ -48,44 +48,44 @@ enum class LLMQType : uint8_t {
 // Configures a LLMQ and its DKG
 // See https://github.com/dashpay/dips/blob/master/dip-0006.md for more details
 struct LLMQParams {
-    LLMQType type;
+    LLMQType type{LLMQType::LLMQ_NONE};
 
     // not consensus critical, only used in logging, RPC and UI
     std::string_view name;
 
     // Whether this is a DIP0024 quorum or not
-    bool useRotation;
+    bool useRotation{false};
 
     // the size of the quorum, e.g. 50 or 400
-    int size;
+    int size{0};
 
     // The minimum number of valid members after the DKG. If less members are determined valid, no commitment can be
     // created. Should be higher then the threshold to allow some room for failing nodes, otherwise quorum might end up
     // not being able to ever created a recovered signature if more nodes fail after the DKG
-    int minSize;
+    int minSize{0};
 
     // The threshold required to recover a final signature. Should be at least 50%+1 of the quorum size. This value
     // also controls the size of the public key verification vector and has a large influence on the performance of
     // recovery. It also influences the amount of minimum messages that need to be exchanged for a single signing session.
     // This value has the most influence on the security of the quorum. The number of total malicious masternodes
     // required to negatively influence signing sessions highly correlates to the threshold percentage.
-    int threshold;
+    int threshold{0};
 
     // The interval in number blocks for DKGs and the creation of LLMQs. If set to 24 for example, a DKG will start
     // every 24 blocks, which is approximately once every hour.
-    int dkgInterval;
+    int dkgInterval{0};
 
     // The number of blocks per phase in a DKG session. There are 6 phases plus the mining phase that need to be processed
     // per DKG. Set this value to a number of blocks so that each phase has enough time to propagate all required
     // messages to all members before the next phase starts. If blocks are produced too fast, whole DKG sessions will
     // fail.
-    int dkgPhaseBlocks;
+    int dkgPhaseBlocks{0};
 
     // The starting block inside the DKG interval for when mining of commitments starts. The value is inclusive.
     // Starting from this block, the inclusion of (possibly null) commitments is enforced until the first non-null
     // commitment is mined. The chosen value should be at least 5 * dkgPhaseBlocks so that it starts right after the
     // finalization phase.
-    int dkgMiningWindowStart;
+    int dkgMiningWindowStart{0};
 
     // The ending block inside the DKG interval for when mining of commitments ends. The value is inclusive.
     // Choose a value so that miners have enough time to receive the commitment and mine it. Also take into consideration
@@ -93,31 +93,31 @@ struct LLMQParams {
     // be large enough so that other miners have a chance to produce a block containing a non-null commitment. The window
     // should at the same time not be too large so that not too much space is wasted with null commitments in case a DKG
     // session failed.
-    int dkgMiningWindowEnd;
+    int dkgMiningWindowEnd{0};
 
     // In the complaint phase, members will vote on other members being bad (missing valid contribution). If at least
     // dkgBadVotesThreshold have voted for another member to be bad, it will considered to be bad by all other members
     // as well. This serves as a protection against late-comers who send their contribution on the bring of
     // phase-transition, which would otherwise result in inconsistent views of the valid members set
-    int dkgBadVotesThreshold;
+    int dkgBadVotesThreshold{0};
 
     // Number of quorums to consider "active" for signing sessions
-    int signingActiveQuorumCount;
+    int signingActiveQuorumCount{0};
 
     // Used for intra-quorum communication. This is the number of quorums for which we should keep old connections.
     // For non-rotated quorums it should be at least one more than the active quorums set.
     // For rotated quorums it should be equal to 2 x active quorums set.
-    int keepOldConnections;
+    int keepOldConnections{0};
 
     // The number of quorums for which we should keep keys. Usually it's equal to signingActiveQuorumCount * 2.
     // Unlike for other quorum types we want to keep data (secret key shares and vvec)
     // for Platform quorums for much longer because Platform can be restarted and
     // it must be able to re-sign stuff.
 
-    int keepOldKeys;
+    int keepOldKeys{0};
 
     // How many members should we try to send all sigShares to before we give up.
-    int recoveryMembers;
+    int recoveryMembers{0};
 public:
     [[nodiscard]] constexpr int max_cycles(int quorums_count) const
     {

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -117,6 +117,7 @@ public:
     SERIALIZE_METHODS(CQuorumDataRequest, obj)
     {
         bool fRead{false};
+        // cppcheck-suppress constParameterReference
         SER_READ(obj, fRead = true);
         READWRITE(obj.llmqType, obj.quorumHash, obj.nDataMask, obj.proTxHash);
         if (fRead) {

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -114,7 +114,7 @@ std::string CBatchedSigShares::ToInvString() const
     return inv.ToString();
 }
 
-static void InitSession(CSigSharesNodeState::Session& s, const llmq::SignHash& signHash, CSigBase from)
+static void InitSession(CSigSharesNodeState::Session& s, const llmq::SignHash& signHash, const CSigBase& from)
 {
     const auto& llmq_params_opt = Params().GetLLMQ(from.getLlmqType());
     assert(llmq_params_opt.has_value());

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -382,7 +382,7 @@ public:
         uint32_t recvSessionId{UNINITIALIZED_SESSION_ID};
         uint32_t sendSessionId{UNINITIALIZED_SESSION_ID};
 
-        Consensus::LLMQType llmqType;
+        Consensus::LLMQType llmqType{Consensus::LLMQType::LLMQ_NONE};
         uint256 quorumHash;
         uint256 id;
         uint256 msgHash;

--- a/src/llmq/snapshot.h
+++ b/src/llmq/snapshot.h
@@ -94,7 +94,7 @@ class CGetQuorumRotationInfo
 public:
     std::vector<uint256> baseBlockHashes;
     uint256 blockRequestHash;
-    bool extraShare;
+    bool extraShare{false};
 
     SERIALIZE_METHODS(CGetQuorumRotationInfo, obj)
     {

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -305,8 +305,8 @@ QuorumMembers ComputeQuorumMembers(Consensus::LLMQType llmqType, const CChainPar
 
 void BuildQuorumSnapshot(const Consensus::LLMQParams& llmqParams, const Consensus::Params& consensus_params,
                          const CDeterministicMNList& allMns, const CDeterministicMNList& mnUsedAtH,
-                         std::vector<CDeterministicMNCPtr>& sortedCombinedMns, llmq::CQuorumSnapshot& quorumSnapshot,
-                         std::vector<int>& skipList, const CBlockIndex* pCycleQuorumBaseBlockIndex)
+                         llmq::CQuorumSnapshot& quorumSnapshot, std::vector<int>& skipList,
+                         const CBlockIndex* pCycleQuorumBaseBlockIndex)
 {
     if (!llmqParams.useRotation || pCycleQuorumBaseBlockIndex->nHeight % llmqParams.dkgInterval != 0) {
         ASSERT_IF_DEBUG(false);
@@ -456,8 +456,8 @@ std::vector<QuorumMembers> BuildNewQuorumQuarterMembers(const Consensus::LLMQPar
 
     if (storeSnapshot) {
         llmq::CQuorumSnapshot quorumSnapshot{};
-        BuildQuorumSnapshot(llmqParams, util_params.m_chainman.GetConsensus(), allMns, MnsUsedAtH, sortedCombinedMnsList,
-                            quorumSnapshot, skipList, util_params.m_base_index);
+        BuildQuorumSnapshot(llmqParams, util_params.m_chainman.GetConsensus(), allMns, MnsUsedAtH, quorumSnapshot,
+                            skipList, util_params.m_base_index);
         util_params.m_qsnapman.StoreSnapshotForBlock(llmqParams.type, util_params.m_base_index, quorumSnapshot);
     }
 

--- a/src/llmq/utils.cpp
+++ b/src/llmq/utils.cpp
@@ -549,9 +549,9 @@ BlsCheck::BlsCheck() = default;
 
 BlsCheck::BlsCheck(CBLSSignature sig, std::vector<CBLSPublicKey> pubkeys, uint256 msg_hash, std::string id_string) :
     m_sig(sig),
-    m_pubkeys(pubkeys),
+    m_pubkeys(std::move(pubkeys)),
     m_msg_hash(msg_hash),
-    m_id_string(id_string)
+    m_id_string(std::move(id_string))
 {
 }
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -292,9 +292,9 @@ public:
     }
     bool processVoteAndRelay(const CGovernanceVote& vote, std::string& error) override
     {
-        if (context().govman != nullptr && context().connman != nullptr) {
+        if (context().govman != nullptr) {
             CGovernanceException exception;
-            bool result = context().govman->ProcessVoteAndRelay(vote, exception, *context().connman);
+            bool result = context().govman->ProcessVoteAndRelay(vote, exception);
             if (!result) {
                 error = exception.GetMessage();
             }

--- a/src/qt/clientfeeds.h
+++ b/src/qt/clientfeeds.h
@@ -83,10 +83,10 @@ public:
     void fetch() override EXCLUSIVE_LOCKS_REQUIRED(!m_cs) = 0;
 
 protected:
-    void setData(std::shared_ptr<const Data> data) EXCLUSIVE_LOCKS_REQUIRED(!m_cs)
+    void setData(std::shared_ptr<const Data> feed_data) EXCLUSIVE_LOCKS_REQUIRED(!m_cs)
     {
         LOCK(m_cs);
-        m_data = std::move(data);
+        m_data = std::move(feed_data);
     }
 
 private:

--- a/src/qt/clientfeeds.h
+++ b/src/qt/clientfeeds.h
@@ -105,7 +105,7 @@ class ChainLockFeed : public Feed<ChainLockData> {
 
 public:
     explicit ChainLockFeed(QObject* parent, ClientModel& client_model);
-    ~ChainLockFeed();
+    ~ChainLockFeed() override;
 
     void fetch() override;
 
@@ -123,7 +123,7 @@ class CreditPoolFeed : public Feed<CreditPoolData> {
 
 public:
     explicit CreditPoolFeed(QObject* parent, ClientModel& client_model);
-    ~CreditPoolFeed();
+    ~CreditPoolFeed() override;
 
     void fetch() override;
 
@@ -140,7 +140,7 @@ class InstantSendFeed : public Feed<InstantSendData> {
 
 public:
     explicit InstantSendFeed(QObject* parent, ClientModel& client_model);
-    ~InstantSendFeed();
+    ~InstantSendFeed() override;
 
     void fetch() override;
 
@@ -160,7 +160,7 @@ class MasternodeFeed : public Feed<MasternodeData> {
 
 public:
     explicit MasternodeFeed(QObject* parent, ClientModel& client_model);
-    ~MasternodeFeed();
+    ~MasternodeFeed() override;
 
     void fetch() override;
 
@@ -177,7 +177,7 @@ class QuorumFeed : public Feed<QuorumData> {
 
 public:
     explicit QuorumFeed(QObject* parent, ClientModel& client_model);
-    ~QuorumFeed();
+    ~QuorumFeed() override;
 
     void fetch() override;
 
@@ -202,7 +202,7 @@ class ProposalFeed : public Feed<ProposalData> {
 
 public:
     explicit ProposalFeed(QObject* parent, ClientModel& client_model, MasternodeFeed& feed_masternode);
-    ~ProposalFeed();
+    ~ProposalFeed() override;
 
     void fetch() override;
 

--- a/src/qt/donutchart.h
+++ b/src/qt/donutchart.h
@@ -44,8 +44,8 @@ protected:
 
 private:
     struct Geometry {
-        int m_inner_radius;
-        int m_outer_radius;
+        int m_inner_radius{0};
+        int m_outer_radius{0};
         QPoint m_center;
     };
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -567,9 +567,7 @@ static RPCHelpMan getblockhashes()
     unsigned int low = request.params[1].getInt<int>();
     std::vector<uint256> blockHashes;
 
-    if (!node.timestamp_index->GetBlockHashes(high, low, blockHashes)) {
-        throw JSONRPCError(RPC_MISC_ERROR, "Failed to read timestamp index.");
-    }
+    node.timestamp_index->GetBlockHashes(high, low, blockHashes);
 
     UniValue result(UniValue::VARR);
     for (const auto& hash : blockHashes) {

--- a/src/rpc/coinjoin.cpp
+++ b/src/rpc/coinjoin.cpp
@@ -542,7 +542,7 @@ void RegisterCoinJoinRPCCommands(CRPCTable& t)
 #endif // ENABLE_WALLET
     ) {
         for (const auto& command : commands_wallet) {
-            tableRPC.appendCommand(command.name, &command);
+            t.appendCommand(command.name, &command);
         }
     }
 }

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1911,8 +1911,8 @@ static UniValue evodb_verify_or_repair_impl(const JSONRPCRequest& request, bool 
     UniValue result(UniValue::VOBJ);
     UniValue verification_errors(UniValue::VARR);
 
-    for (const auto& error : recalc_result.verification_errors) {
-        verification_errors.push_back(error);
+    for (const auto& verification_error : recalc_result.verification_errors) {
+        verification_errors.push_back(verification_error);
     }
 
     result.pushKV("startHeight", recalc_result.start_height);
@@ -1924,8 +1924,8 @@ static UniValue evodb_verify_or_repair_impl(const JSONRPCRequest& request, bool 
     // Only include repair errors if we're in repair mode
     if (repair) {
         UniValue repair_errors(UniValue::VARR);
-        for (const auto& error : recalc_result.repair_errors) {
-            repair_errors.push_back(error);
+        for (const auto& repair_error : recalc_result.repair_errors) {
+            repair_errors.push_back(repair_error);
         }
         result.pushKV("repairErrors", repair_errors);
     }

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1804,14 +1804,6 @@ static RPCHelpMan protx_listdiff()
     const CBlockIndex* pBaseBlockIndex = ParseBlockIndex(request.params[0], chainman, "baseBlock");
     const CBlockIndex* pTargetBlockIndex = ParseBlockIndex(request.params[1], chainman, "block");
 
-    if (pBaseBlockIndex == nullptr) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Base block not found");
-    }
-
-    if (pTargetBlockIndex == nullptr) {
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
-    }
-
     ret.pushKV("baseHeight", pBaseBlockIndex->nHeight);
     ret.pushKV("blockHeight", pTargetBlockIndex->nHeight);
 

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -1449,7 +1449,7 @@ static bool CheckWalletOwnsKey(const CWallet* const pwallet, const CKeyID& keyID
 }
 #endif
 
-static UniValue BuildDMNListEntry(const CWallet* const pwallet, const CDeterministicMN& dmn, CMasternodeMetaMan& mn_metaman, bool detailed, const ChainstateManager& chainman, const CBlockIndex* pindex = nullptr)
+static UniValue BuildDMNListEntry(const CWallet* const pwallet, const CDeterministicMN& dmn, const CMasternodeMetaMan& mn_metaman, bool detailed, const ChainstateManager& chainman, const CBlockIndex* pindex = nullptr)
 {
     if (!detailed) {
         return dmn.proTxHash.ToString();
@@ -1538,7 +1538,7 @@ static RPCHelpMan protx_list()
     const ChainstateManager& chainman = EnsureChainman(node);
 
     CDeterministicMNManager& dmnman = *CHECK_NONFATAL(node.dmnman);
-    CMasternodeMetaMan& mn_metaman = *CHECK_NONFATAL(node.mn_metaman);
+    const CMasternodeMetaMan& mn_metaman = *CHECK_NONFATAL(node.mn_metaman);
 
     std::shared_ptr<CWallet> wallet{nullptr};
 #ifdef ENABLE_WALLET
@@ -1650,7 +1650,7 @@ static RPCHelpMan protx_info()
     const ChainstateManager& chainman = EnsureChainman(node);
 
     CDeterministicMNManager& dmnman = *CHECK_NONFATAL(node.dmnman);
-    CMasternodeMetaMan& mn_metaman = *CHECK_NONFATAL(node.mn_metaman);
+    const CMasternodeMetaMan& mn_metaman = *CHECK_NONFATAL(node.mn_metaman);
 
     std::shared_ptr<CWallet> wallet{nullptr};
 #ifdef ENABLE_WALLET
@@ -1913,7 +1913,7 @@ static UniValue evodb_verify_or_repair_impl(const JSONRPCRequest& request, bool 
     };
 
     // Call the dmnman method to do the work
-    auto recalc_result = dmnman.RecalculateAndRepairDiffs(start_index, stop_index, chainman, build_list_func, repair);
+    auto recalc_result = dmnman.RecalculateAndRepairDiffs(start_index, stop_index, build_list_func, repair);
 
     // Convert result to UniValue
     UniValue result(UniValue::VOBJ);

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -2180,7 +2180,7 @@ Span<const CRPCCommand> GetWalletEvoRPCCommands()
 }
 #endif // ENABLE_WALLET
 
-void RegisterEvoRPCCommands(CRPCTable& tableRPC)
+void RegisterEvoRPCCommands(CRPCTable& t)
 {
     static const CRPCCommand commands[]{
         {"evo", &bls_help},
@@ -2197,7 +2197,7 @@ void RegisterEvoRPCCommands(CRPCTable& tableRPC)
         {"evo", &protx_info},
     };
     for (const auto& command : commands) {
-        tableRPC.appendCommand(command.name, &command);
+        t.appendCommand(command.name, &command);
     }
     // If we aren't compiling with wallet support, we still need to register RPCs that are
     // capable of working without wallet support. We have to do this even if wallet support
@@ -2211,7 +2211,7 @@ void RegisterEvoRPCCommands(CRPCTable& tableRPC)
 #endif // ENABLE_WALLET
     ) {
         for (const auto& command : commands_wallet) {
-            tableRPC.appendCommand(command.name, &command);
+            t.appendCommand(command.name, &command);
         }
     }
 }

--- a/src/rpc/evo.cpp
+++ b/src/rpc/evo.cpp
@@ -934,7 +934,6 @@ static UniValue protx_register_common_wrapper(const JSONRPCRequest& request,
                     LOCK(pwallet->cs_wallet);
                     // lets prove we own the collateral
                     CScript scriptPubKey = GetScriptForDestination(txDest);
-                    std::unique_ptr<SigningProvider> provider = pwallet->GetSolvingProvider(scriptPubKey);
 
                     std::string signed_payload;
                     SigningResult err = pwallet->SignMessage(ptx.MakeSignString(), *pkhash, signed_payload);

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -660,6 +660,8 @@ static RPCResult ListObjectsHelp()
     auto ret = CGovernanceObject::GetStateJsonHelp(/*key=*/"", /*optional=*/false, /*local_valid_key=*/"fBlockchainValidity");
     auto mod_inner = ret.m_inner;
     for (const auto& result : CGovernanceObject::GetVotesJsonHelp(/*key=*/"", /*optional=*/false).m_inner) {
+        // The range expression's temporary is lifetime-extended for the whole loop
+        // cppcheck-suppress danglingTempReference
         mod_inner.push_back(result);
     }
     return RPCResult{ret.m_type, ret.m_key_name, ret.m_description, mod_inner};

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -466,8 +466,7 @@ static UniValue VoteWithMasternodes(const JSONRPCRequest& request, const CWallet
         }
 
         CGovernanceException exception;
-        CConnman& connman = EnsureConnman(node);
-        if (node.govman->ProcessVoteAndRelay(vote, exception, connman)) {
+        if (node.govman->ProcessVoteAndRelay(vote, exception)) {
             nSuccessful++;
             statusObj.pushKV("result", "success");
         } else {
@@ -932,10 +931,8 @@ static RPCHelpMan voteraw()
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Failure to verify vote.");
     }
 
-    CConnman& connman = EnsureConnman(node);
-
     CGovernanceException exception;
-    if (node.govman->ProcessVoteAndRelay(vote, exception, connman)) {
+    if (node.govman->ProcessVoteAndRelay(vote, exception)) {
         return "Voted successfully";
     } else {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Error voting : " + exception.GetMessage());

--- a/src/rpc/governance.cpp
+++ b/src/rpc/governance.cpp
@@ -658,9 +658,8 @@ static RPCResult ListObjectsHelp()
 {
     auto ret = CGovernanceObject::GetStateJsonHelp(/*key=*/"", /*optional=*/false, /*local_valid_key=*/"fBlockchainValidity");
     auto mod_inner = ret.m_inner;
-    for (const auto& result : CGovernanceObject::GetVotesJsonHelp(/*key=*/"", /*optional=*/false).m_inner) {
-        // The range expression's temporary is lifetime-extended for the whole loop
-        // cppcheck-suppress danglingTempReference
+    const auto votes_help = CGovernanceObject::GetVotesJsonHelp(/*key=*/"", /*optional=*/false);
+    for (const auto& result : votes_help.m_inner) {
         mod_inner.push_back(result);
     }
     return RPCResult{ret.m_type, ret.m_key_name, ret.m_description, mod_inner};

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -677,7 +677,7 @@ static RPCHelpMan getaddressbalance()
         LOCK(::cs_main);
         for (const auto& address : addresses) {
             if (!node.address_index->GetAddressIndex(address.first, address.second, addressIndex,
-                                                 /*start=*/0, /*end=*/0)) {
+                                                 /*start_height=*/0, /*end_height=*/0)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
             }
         }

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -1304,7 +1304,7 @@ static RPCHelpMan verifyislock()
         signHeight = pindexMined->nHeight;
     }
 
-    CBlockIndex* pBlockIndex{nullptr};
+    const CBlockIndex* pBlockIndex{nullptr};
     {
         LOCK(cs_main);
         if (signHeight == -1) {

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -1388,7 +1388,7 @@ static RPCHelpMan submitchainlock()
 }
 
 
-void RegisterQuorumsRPCCommands(CRPCTable &tableRPC)
+void RegisterQuorumsRPCCommands(CRPCTable& t)
 {
     static const CRPCCommand commands[]{
         {"evo", &quorum_help},
@@ -1413,6 +1413,6 @@ void RegisterQuorumsRPCCommands(CRPCTable &tableRPC)
         {"evo", &verifyislock},
     };
     for (const auto& command : commands) {
-        tableRPC.appendCommand(command.name, &command);
+        t.appendCommand(command.name, &command);
     }
 }

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -160,6 +160,7 @@ util::Result<std::unique_ptr<StatsdClient>> StatsdClient::make(const ArgsManager
             return util::Error{_("No text before the scheme delimiter, malformed URL")};
         }
         std::string scheme{ToLower(host.substr(/*pos=*/0, scheme_idx))};
+        // cppcheck-suppress knownConditionTrueFalse
         if (scheme != "udp") {
             return util::Error{_("Unsupported URL scheme, must begin with udp://")};
         }

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -217,12 +217,12 @@ util::Result<std::unique_ptr<StatsdClient>> StatsdClient::make(const ArgsManager
 StatsdClientImpl::StatsdClientImpl(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
                                    const std::string& prefix, const std::string& suffix,
                                    std::optional<bilingual_str>& error) :
+    m_sender{std::make_unique<RawSender>(host, port,
+                                         std::make_pair(batch_size, static_cast<uint8_t>(STATSD_MSG_DELIMITER)),
+                                         interval_ms, error)},
     m_prefix{[prefix]() { return !prefix.empty() ? prefix + STATSD_NS_DELIMITER : prefix; }()},
     m_suffix{[suffix]() { return !suffix.empty() ? STATSD_NS_DELIMITER + suffix : suffix; }()}
 {
-    m_sender = std::make_unique<RawSender>(host, port,
-                                           std::make_pair(batch_size, static_cast<uint8_t>(STATSD_MSG_DELIMITER)),
-                                           interval_ms, error);
     if (error.has_value()) {
         m_sender.reset();
         return;

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -44,7 +44,8 @@ class StatsdClientImpl final : public StatsdClient
 {
 public:
     explicit StatsdClientImpl(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
-                              const std::string& prefix, const std::string& suffix, std::optional<bilingual_str>& error);
+                              const std::string& prefix, const std::string& suffix,
+                              std::optional<bilingual_str>& error_out);
     ~StatsdClientImpl() override = default;
 
 public:
@@ -217,14 +218,14 @@ util::Result<std::unique_ptr<StatsdClient>> StatsdClient::make(const ArgsManager
 
 StatsdClientImpl::StatsdClientImpl(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
                                    const std::string& prefix, const std::string& suffix,
-                                   std::optional<bilingual_str>& error) :
+                                   std::optional<bilingual_str>& error_out) :
     m_sender{std::make_unique<RawSender>(host, port,
                                          std::make_pair(batch_size, static_cast<uint8_t>(STATSD_MSG_DELIMITER)),
-                                         interval_ms, error)},
+                                         interval_ms, error_out)},
     m_prefix{[prefix]() { return !prefix.empty() ? prefix + STATSD_NS_DELIMITER : prefix; }()},
     m_suffix{[suffix]() { return !suffix.empty() ? STATSD_NS_DELIMITER + suffix : suffix; }()}
 {
-    if (error.has_value()) {
+    if (error_out.has_value()) {
         m_sender.reset();
         return;
     }

--- a/src/stats/client.cpp
+++ b/src/stats/client.cpp
@@ -45,7 +45,7 @@ class StatsdClientImpl final : public StatsdClient
 public:
     explicit StatsdClientImpl(const std::string& host, uint16_t port, uint64_t batch_size, uint64_t interval_ms,
                               const std::string& prefix, const std::string& suffix, std::optional<bilingual_str>& error);
-    ~StatsdClientImpl() = default;
+    ~StatsdClientImpl() override = default;
 
 public:
     bool dec(std::string_view key, float sample_rate) override EXCLUSIVE_LOCKS_REQUIRED(!cs)

--- a/src/test/evo_netinfo_tests.cpp
+++ b/src/test/evo_netinfo_tests.cpp
@@ -19,8 +19,8 @@ BOOST_FIXTURE_TEST_SUITE(evo_netinfo_tests, BasicTestingSetup)
 
 struct TestEntry {
     std::pair</*purpose=*/NetInfoPurpose, /*addr=*/std::string> input;
-    NetInfoStatus expected_ret_mn;
-    NetInfoStatus expected_ret_ext;
+    NetInfoStatus expected_ret_mn{NetInfoStatus::BadInput};
+    NetInfoStatus expected_ret_ext{NetInfoStatus::BadInput};
 };
 
 static const std::vector<TestEntry> addr_vals_main{

--- a/src/util/ranges_set.cpp
+++ b/src/util/ranges_set.cpp
@@ -6,9 +6,9 @@
 
 CRangesSet::Range::Range() : CRangesSet::Range::Range(0, 0) {}
 
-CRangesSet::Range::Range(uint64_t begin, uint64_t end) :
-    begin(begin),
-    end(end)
+CRangesSet::Range::Range(uint64_t begin_in, uint64_t end_in) :
+    begin(begin_in),
+    end(end_in)
 {
 }
 
@@ -95,4 +95,3 @@ bool CRangesSet::Contains(uint64_t value) const noexcept
     --prev;
     return prev->begin <= value && prev->end > value;
 }
-

--- a/src/util/ranges_set.h
+++ b/src/util/ranges_set.h
@@ -30,7 +30,7 @@ class CRangesSet
         uint64_t begin;
         uint64_t end;
         Range();
-        Range(uint64_t begin, uint64_t end);
+        Range(uint64_t begin_in, uint64_t end_in);
         bool operator<(const Range& other) const
         {
             if (begin != other.begin) return begin < other.begin;

--- a/src/util/std23.h
+++ b/src/util/std23.h
@@ -95,7 +95,7 @@ template <typename T,
 inline constexpr auto enumerate(T && iterable)
 {
     struct iterator {
-        size_t i;
+        size_t i{0};
         TIter iter;
         bool operator!=(const iterator& other) const { return iter != other.iter; }
         void operator++()

--- a/src/wallet/hdchain.cpp
+++ b/src/wallet/hdchain.cpp
@@ -40,9 +40,9 @@ bool CHDChain::IsCrypted() const
     return fCrypted;
 }
 
-bool CHDChain::SetMnemonic(const SecureVector& vchMnemonic, const SecureVector& vchMnemonicPassphrase, bool fUpdateID)
+bool CHDChain::SetMnemonic(const SecureVector& mnemonic, const SecureVector& mnemonic_passphrase, bool fUpdateID)
 {
-    return SetMnemonic(SecureString(vchMnemonic.begin(), vchMnemonic.end()), SecureString(vchMnemonicPassphrase.begin(), vchMnemonicPassphrase.end()), fUpdateID);
+    return SetMnemonic(SecureString(mnemonic.begin(), mnemonic.end()), SecureString(mnemonic_passphrase.begin(), mnemonic_passphrase.end()), fUpdateID);
 }
 
 bool CHDChain::SetMnemonic(const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, bool fUpdateID)

--- a/src/wallet/hdchain.cpp
+++ b/src/wallet/hdchain.cpp
@@ -130,7 +130,7 @@ uint256 CHDChain::GetSeedHash()
 }
 
 //! Try to derive an extended key, throw if it fails.
-static void DeriveExtKey(CExtKey& key_in, unsigned int index, CExtKey& key_out)
+static void DeriveExtKey(const CExtKey& key_in, unsigned int index, CExtKey& key_out)
 {
     if (!key_in.Derive(key_out, index)) {
         throw std::runtime_error("Could not derive extended key");

--- a/src/wallet/hdchain.h
+++ b/src/wallet/hdchain.h
@@ -95,7 +95,7 @@ public:
     void SetCrypted(bool fCryptedIn);
     bool IsCrypted() const;
 
-    bool SetMnemonic(const SecureVector& vchMnemonic, const SecureVector& vchMnemonicPassphrase, bool fUpdateID);
+    bool SetMnemonic(const SecureVector& mnemonic, const SecureVector& mnemonic_passphrase, bool fUpdateID);
     bool SetMnemonic(const SecureString& ssMnemonic, const SecureString& ssMnemonicPassphrase, bool fUpdateID);
     bool GetMnemonic(SecureVector& vchMnemonicRet, SecureVector& vchMnemonicPassphraseRet) const;
     bool GetMnemonic(SecureString& ssMnemonicRet, SecureString& ssMnemonicPassphraseRet) const;

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -60,7 +60,6 @@ SUPPRESSED_WARNINGS = (
     "functionStatic",
     "knownConditionTrueFalse",
     "missingOverride",
-    "returnByReference",
     "shadowFunction",
     "shadowMember",
     "shadowVariable",

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -57,7 +57,6 @@ SUPPRESSED_WARNINGS = (
     # one at a time. Note that any message matching ALWAYS_ENABLED_WARNINGS is
     # still reported even if its check id is listed here.
     "duplInheritedMember",
-    "functionStatic",
     "shadowFunction",
     "uninitMemberVarNoCtor",
     "useStlAlgorithm",

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -55,7 +55,6 @@ SUPPRESSED_WARNINGS = (
     # the linter can be enforced. TODO: burn these down and re-enable them
     # one at a time. Note that any message matching ALWAYS_ENABLED_WARNINGS is
     # still reported even if its check id is listed here.
-    "constParameterReference",
     "duplInheritedMember",
     "functionStatic",
     "knownConditionTrueFalse",

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -48,6 +48,8 @@ SUPPRESSED_WARNINGS = (
     "src/stacktraces.cpp:.*: .*: Parameter 'info' can be declared as pointer to const",
     "Return value 'state.(Invalid|Error).*' is always false.*knownConditionTrueFalse",
     "Local variable '_' shadows outer function.*shadowFunction",
+    "Member variable 'ActiveDKG::.*' has no initializer.*uninitMemberVarNoCtor",
+    "Member variable 'UtilParameters::.*' has no initializer.*uninitMemberVarNoCtor",
 
     "unusedFunction",
     "unknownMacro",
@@ -58,7 +60,6 @@ SUPPRESSED_WARNINGS = (
     # one at a time. Note that any message matching ALWAYS_ENABLED_WARNINGS is
     # still reported even if its check id is listed here.
     "duplInheritedMember",
-    "uninitMemberVarNoCtor",
     "useStlAlgorithm",
 )
 

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -62,7 +62,6 @@ SUPPRESSED_WARNINGS = (
     "missingOverride",
     "shadowFunction",
     "shadowMember",
-    "shadowVariable",
     "uninitMemberVarNoCtor",
     "useStlAlgorithm",
 )

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -47,6 +47,7 @@ FATAL_ERRORS = (
 SUPPRESSED_WARNINGS = (
     "src/stacktraces.cpp:.*: .*: Parameter 'info' can be declared as pointer to const",
     "Return value 'state.(Invalid|Error).*' is always false.*knownConditionTrueFalse",
+    "Local variable '_' shadows outer function.*shadowFunction",
 
     "unusedFunction",
     "unknownMacro",
@@ -57,7 +58,6 @@ SUPPRESSED_WARNINGS = (
     # one at a time. Note that any message matching ALWAYS_ENABLED_WARNINGS is
     # still reported even if its check id is listed here.
     "duplInheritedMember",
-    "shadowFunction",
     "uninitMemberVarNoCtor",
     "useStlAlgorithm",
 )

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -33,27 +33,43 @@ ALWAYS_ENABLED_WARNINGS = (
     # ".*",
 )
 
+# Lines that indicate cppcheck itself failed to analyze a translation unit.
+# These must always fail the lint (regardless of which file they point at),
+# otherwise analysis silently ends up vacuous.
+FATAL_ERRORS = (
+    "preprocessorErrorDirective",
+    "cppcheckError",
+    "internalError",
+    "Internal error",
+    "syntaxError",
+)
+
 SUPPRESSED_WARNINGS = (
     "src/stacktraces.cpp:.*: .*: Parameter 'info' can be declared as pointer to const",
-    "src/stacktraces.cpp:.*: note: You might need to cast the function pointer here",
-
-    # current version of cppcheck fails with this error if exhaustive level is used
-    # TODO: remove with a newer version
-    "warning: Internal error: Child process crashed with signal 6",
-
-    # The following can be useful to ignore when the catch all is used
-    # "Consider performing initialization in initialization list.",
-    "Consider using std::transform algorithm instead of a raw loop.",
-    "Consider using std::accumulate algorithm instead of a raw loop.",
-    "Consider using std::any_of algorithm instead of a raw loop.",
-    "Consider using std::copy_if algorithm instead of a raw loop.",
-    # "Consider using std::count_if algorithm instead of a raw loop.",
-    # "Consider using std::find_if algorithm instead of a raw loop.",
-    # "Member variable '.*' is not initialized in the constructor.",
 
     "unusedFunction",
     "unknownMacro",
     "unusedStructMember",
+
+    # Checks with pre-existing violations in the tree; suppressed wholesale so
+    # the linter can be enforced. TODO: burn these down and re-enable them
+    # one at a time. Note that any message matching ALWAYS_ENABLED_WARNINGS is
+    # still reported even if its check id is listed here.
+    "assertWithSideEffect",
+    "constParameterReference",
+    "constVariablePointer",
+    "constVariableReference",
+    "duplInheritedMember",
+    "functionStatic",
+    "knownConditionTrueFalse",
+    "missingOverride",
+    "returnByReference",
+    "shadowFunction",
+    "shadowMember",
+    "shadowVariable",
+    "uninitMemberVarNoCtor",
+    "useInitializationList",
+    "useStlAlgorithm",
 )
 
 def main():
@@ -74,6 +90,7 @@ def main():
 
     always_enabled_regexp = '|'.join(ALWAYS_ENABLED_WARNINGS)
     suppressed_regexp = '|'.join(SUPPRESSED_WARNINGS)
+    fatal_regexp = '|'.join(FATAL_ERRORS)
     files_regexp = '|'.join(re.escape(f) for f in files)
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -96,6 +113,10 @@ def main():
         '--template=gcc',
         '--check-level=exhaustive',
         '-D__cplusplus',
+        # Pretend to be GCC so that headers which require a known compiler
+        # (e.g. src/attributes.h) don't hit an #error directive, which would
+        # abort analysis of every translation unit that includes them.
+        '-D__GNUC__',
         '-DENABLE_WALLET',
         '-DCLIENT_VERSION_BUILD',
         '-DCLIENT_VERSION_IS_RELEASE',
@@ -105,6 +126,10 @@ def main():
         '-DDEBUG',
         '-DUSE_EPOLL',
         '-DCHAR_BIT=8',
+        # Function-like macro that cppcheck cannot evaluate on its own; leaving
+        # it undefined aborts analysis of Qt translation units with a fatal
+        # syntaxError ("failed to evaluate #if condition").
+        '-DQT_VERSION_CHECK(major,minor,patch)=((major<<16)|(minor<<8)|(patch))',
         '-I', 'src/',
         '-q',
     ] + files
@@ -118,10 +143,32 @@ def main():
 
     unique_sorted_lines = sorted(set(dependencies_output.stdout.splitlines()))
     for line in unique_sorted_lines:
+        if re.search(fatal_regexp, line):
+            warnings.append(line)
+            continue
+        # 'note:' and source-context lines only make sense next to their parent
+        # warning; on their own (e.g. when the parent is suppressed) they are
+        # noise, and they don't carry the check id the suppressions match on.
+        # cppcheck's gcc template currently renders every non-error severity as
+        # 'warning:', but match the raw severities too in case that changes.
+        if not re.search(r' (?:error|warning|style|performance|portability): ', line):
+            continue
         if not re.search(files_regexp, line):
             continue
         if re.search(always_enabled_regexp, line) or not re.search(suppressed_regexp, line):
             warnings.append(line)
+
+    # Without --error-exitcode, diagnostics never make cppcheck return nonzero;
+    # any nonzero status (bad arguments, unloadable config, OOM kill, crash)
+    # means analysis did not complete and must not pass.
+    rc = dependencies_output.returncode
+    if rc != 0:
+        print(f"cppcheck exited with code {rc}")
+        if dependencies_output.stdout and not warnings:
+            # Show a short tail to aid CI debugging without flooding logs.
+            tail = dependencies_output.stdout.splitlines()[-50:]
+            print('\n'.join(tail))
+        exit_code = 1
 
     if warnings:
         print('\n'.join(warnings))

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -58,7 +58,6 @@ SUPPRESSED_WARNINGS = (
     "duplInheritedMember",
     "functionStatic",
     "knownConditionTrueFalse",
-    "missingOverride",
     "shadowFunction",
     "uninitMemberVarNoCtor",
     "useStlAlgorithm",

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -46,6 +46,7 @@ FATAL_ERRORS = (
 
 SUPPRESSED_WARNINGS = (
     "src/stacktraces.cpp:.*: .*: Parameter 'info' can be declared as pointer to const",
+    "Return value 'state.(Invalid|Error).*' is always false.*knownConditionTrueFalse",
 
     "unusedFunction",
     "unknownMacro",
@@ -57,7 +58,6 @@ SUPPRESSED_WARNINGS = (
     # still reported even if its check id is listed here.
     "duplInheritedMember",
     "functionStatic",
-    "knownConditionTrueFalse",
     "shadowFunction",
     "uninitMemberVarNoCtor",
     "useStlAlgorithm",

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -55,7 +55,6 @@ SUPPRESSED_WARNINGS = (
     # the linter can be enforced. TODO: burn these down and re-enable them
     # one at a time. Note that any message matching ALWAYS_ENABLED_WARNINGS is
     # still reported even if its check id is listed here.
-    "assertWithSideEffect",
     "constParameterReference",
     "constVariablePointer",
     "constVariableReference",

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -117,10 +117,11 @@ def main():
         '-DDEBUG',
         '-DUSE_EPOLL',
         '-DCHAR_BIT=8',
-        # Function-like macro that cppcheck cannot evaluate on its own; leaving
-        # it undefined aborts analysis of Qt translation units with a fatal
+        # Function-like macros that cppcheck cannot evaluate on its own; leaving
+        # them undefined aborts analysis of Qt translation units with a fatal
         # syntaxError ("failed to evaluate #if condition").
         '-DQT_VERSION_CHECK(major,minor,patch)=((major<<16)|(minor<<8)|(patch))',
+        '-DQT_CONFIG(x)=0',
         '-I', 'src/',
         '-q',
     ] + files

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -64,7 +64,6 @@ SUPPRESSED_WARNINGS = (
     "shadowMember",
     "shadowVariable",
     "uninitMemberVarNoCtor",
-    "useInitializationList",
     "useStlAlgorithm",
 )
 

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -61,7 +61,6 @@ SUPPRESSED_WARNINGS = (
     "knownConditionTrueFalse",
     "missingOverride",
     "shadowFunction",
-    "shadowMember",
     "uninitMemberVarNoCtor",
     "useStlAlgorithm",
 )

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -56,7 +56,6 @@ SUPPRESSED_WARNINGS = (
     # one at a time. Note that any message matching ALWAYS_ENABLED_WARNINGS is
     # still reported even if its check id is listed here.
     "constParameterReference",
-    "constVariableReference",
     "duplInheritedMember",
     "functionStatic",
     "knownConditionTrueFalse",

--- a/test/lint/lint-cppcheck-dash.py
+++ b/test/lint/lint-cppcheck-dash.py
@@ -56,7 +56,6 @@ SUPPRESSED_WARNINGS = (
     # one at a time. Note that any message matching ALWAYS_ENABLED_WARNINGS is
     # still reported even if its check id is listed here.
     "constParameterReference",
-    "constVariablePointer",
     "constVariableReference",
     "duplInheritedMember",
     "functionStatic",


### PR DESCRIPTION
## Issue being fixed or feature implemented
`test/lint/lint-cppcheck-dash.py` has been effectively vacuous — it ran cppcheck, silently analyzed almost nothing, and always passed. Two failure modes:

1. With the script's `-D` list, `__GNUC__` is not defined, so `src/attributes.h` hits `#error No known always_inline attribute` (`preprocessorErrorDirective`), aborting cppcheck's analysis of nearly every translation unit. The error lines were then dropped by the output filter, which only keeps lines pointing at files from `test/util/data/non-backported.txt`.
2. Even with preprocessing fixed, cppcheck 2.17.1 with `--check-level=exhaustive` crashes with an assertion in `TokenList::setLang` (child dies with signal 6) — and that crash message was explicitly listed in `SUPPRESSED_WARNINGS`.

Net effect: an injected canary warning in a non-backported file was not flagged, locally or in CI.

## What was done?
**Linter (`test/lint/lint-cppcheck-dash.py`):**
- Define `__GNUC__` so preprocessing succeeds.
- Add a `FATAL_ERRORS` list (`preprocessorErrorDirective`, `syntaxError`, internal errors/crashes) that fails the lint regardless of which file the line points at, so analysis failures can never again be silently filtered away. Making `syntaxError` fatal immediately surfaced real cases: `QT_VERSION_CHECK` and `QT_CONFIG` are function-like macros cppcheck cannot evaluate on its own, which aborted analysis of Qt translation units (especially in working trees with `uic`-generated headers like `ui_masternodelist.h`) — they are now defined on the cppcheck command line (`-DQT_VERSION_CHECK=...`, `-DQT_CONFIG(x)=0`).
- Fail on any nonzero cppcheck exit status. Without `--error-exitcode`, diagnostics never make cppcheck return nonzero, so a nonzero status always means the analysis itself failed (bad arguments, unloadable config, OOM kill, crash) and cannot be allowed to pass.
- Drop the signal-6 crash suppression (the TODO said to remove it with a newer cppcheck).
- Skip `note:`/source-context lines: they don't carry the check id that suppressions match on, so orphaned notes of suppressed warnings leaked through the filter.
- Suppress pre-existing violations so the linter can be enforced now, documented as a burn-down TODO. Most suppressions are deliberately narrow — targeted message/class-scoped regexes for `knownConditionTrueFalse` (always-false `state.Invalid(...)`/`state.Error(...)` returns), `shadowFunction` (the `_` translation function), and `uninitMemberVarNoCtor` (`ActiveDKG`/`UtilParameters` members) — so new violations of these checks elsewhere in the tree are still reported. `duplInheritedMember` and `useStlAlgorithm` are suppressed wholesale by check id: the former as a plain burn-down entry, the latter deliberately — earlier revisions of this branch rewrote the flagged raw loops into `std::ranges` algorithms, but lambda-based algorithms lose Clang thread-safety-analysis lock context (`cs_wallet`, `cs_coinjoin`, `cs_store`) and obscure otherwise-clear control flow, so the loops stay and the check is disabled instead. Messages matching `ALWAYS_ENABLED_WARNINGS` still override these suppressions.

**Container (`contrib/containers/ci/ci-slim.Dockerfile`):** bump cppcheck 2.17.1 → 2.21.0, which no longer crashes under `--check-level=exhaustive`.

**Code fixes** for the ~11 warnings that `ALWAYS_ENABLED_WARNINGS` patterns force-report (these cannot be suppressed by check id): removed dead locals (`src/active/dkgsession.cpp`, `src/rpc/evo.cpp`), made single-argument constructors `explicit` (`chainlock::Chainlocks`, `CDSTXManager`; no implicit-conversion call sites exist), inline-suppressed `CBLSIdImplicit`'s intentionally implicit constructor, narrowed three static benchmark counters to their usage scope in `src/evo/specialtxman.cpp` (static storage duration unchanged), passed `CSigBase` by const reference in `InitSession` (callers already sliced identically by value; accessors are non-virtual), moved `BlsCheck`'s by-value constructor parameters into members, and bound the temporary `RPCResult` returned by `GetVotesJsonHelp` to a local variable in `src/rpc/governance.cpp` (avoiding a C++20 dangling reference).

## How Has This Been Tested?
With cppcheck 2.21.0 locally (matching the bumped container version):
- Injected a canary (`unreadVariable`) into `src/spork.cpp`: the linter reports exactly that warning and exits 1.
- Canary removed: full 273-file run is clean and exits 0 (tested both clean and built working trees).
- Removed `-D__GNUC__` to simulate failure mode 1: the `attributes.h` `#error` line surfaces via `FATAL_ERRORS` and the linter exits 1.
- All touched translation units pass `clang -fsyntax-only` with the project's compile flags; `test/lint/lint-python.py` passes.

Note: the previously-suppressed `count_if`/`find_if` `useStlAlgorithm` variants are now covered by the wholesale id suppression along with the rest of the burn-down list.

## Breaking Changes
None. CI lint may take somewhat longer since cppcheck now actually analyzes all 273 non-backported files with `--check-level=exhaustive`.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_