### PR TITLE
refactor: drop redundant CConnman argument from NetHandler::ProcessGetData

### DIFF
--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -1004,7 +1004,7 @@ bool CCoinJoinServer::AlreadyHave(const CInv& inv)
     return (inv.type == MSG_DSQ) ? m_queueman.HasQueue(inv.hash) : false;
 }
 
-bool CCoinJoinServer::ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, const CNetMsgMaker& msgMaker)
+bool CCoinJoinServer::ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker)
 {
     if (inv.type != MSG_DSQ) return false;
 

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -111,7 +111,7 @@ public:
     ~CCoinJoinServer();
 
     void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv) override;
-    bool ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, const CNetMsgMaker& msgMaker) override;
+    bool ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker) override;
     bool AlreadyHave(const CInv& inv) override;
     void Schedule(CScheduler& scheduler) override;
 

--- a/src/governance/net_governance.cpp
+++ b/src/governance/net_governance.cpp
@@ -286,14 +286,14 @@ bool NetGovernance::AlreadyHave(const CInv& inv)
     return !m_gov_manager.ConfirmInventoryRequest(inv);
 }
 
-bool NetGovernance::ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, const CNetMsgMaker& msgMaker)
+bool NetGovernance::ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker)
 {
     if (inv.type == MSG_GOVERNANCE_OBJECT) {
         if (!m_gov_manager.HaveObjectForHash(inv.hash)) return false;
         CDataStream ss(SER_NETWORK, pfrom.GetCommonVersion());
         ss.reserve(1000);
         if (!m_gov_manager.SerializeObjectForHash(inv.hash, ss)) return false;
-        connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::MNGOVERNANCEOBJECT, ss));
+        m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::MNGOVERNANCEOBJECT, ss));
         return true;
     }
     if (inv.type == MSG_GOVERNANCE_OBJECT_VOTE) {
@@ -301,7 +301,7 @@ bool NetGovernance::ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& conn
         CDataStream ss(SER_NETWORK, pfrom.GetCommonVersion());
         ss.reserve(1000);
         if (!m_gov_manager.SerializeVoteForHash(inv.hash, ss)) return false;
-        connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::MNGOVERNANCEOBJECTVOTE, ss));
+        m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::MNGOVERNANCEOBJECTVOTE, ss));
         return true;
     }
     return false;

--- a/src/governance/net_governance.h
+++ b/src/governance/net_governance.h
@@ -28,7 +28,7 @@ public:
     void ProcessMessage(CNode& peer, const std::string& msg_type, CDataStream& vRecv) override;
 
     bool AlreadyHave(const CInv& inv) override;
-    bool ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, const CNetMsgMaker& msgMaker) override;
+    bool ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker) override;
 
 private:
     CGovernanceManager& m_gov_manager;

--- a/src/llmq/net_dkg.cpp
+++ b/src/llmq/net_dkg.cpp
@@ -557,18 +557,18 @@ bool NetDKG::AlreadyHave(const CInv& inv)
     return false;
 }
 
-bool NetDKG::ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, const CNetMsgMaker& msgMaker)
+bool NetDKG::ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker)
 {
-    // Default implementations of GetContribution and the other virtual methods
-    // return false in observer mode; m_active is only an early exit and does
-    // not affect logic.
+    // Observer mode holds no CConnman, so this null check guards the replies
+    // below rather than merely short-circuiting them. It costs no coverage: the
+    // Get* calls return false by construction in observer mode.
     if (m_active == nullptr) return false;
 
     switch (inv.type) {
     case MSG_QUORUM_CONTRIB: {
         CDKGContribution o;
         if (m_qdkgsman.GetContribution(inv.hash, o)) {
-            connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QCONTRIB, o));
+            m_active->connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QCONTRIB, o));
             return true;
         }
         return false;
@@ -576,7 +576,7 @@ bool NetDKG::ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, co
     case MSG_QUORUM_COMPLAINT: {
         CDKGComplaint o;
         if (m_qdkgsman.GetComplaint(inv.hash, o)) {
-            connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QCOMPLAINT, o));
+            m_active->connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QCOMPLAINT, o));
             return true;
         }
         return false;
@@ -584,7 +584,7 @@ bool NetDKG::ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, co
     case MSG_QUORUM_JUSTIFICATION: {
         CDKGJustification o;
         if (m_qdkgsman.GetJustification(inv.hash, o)) {
-            connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QJUSTIFICATION, o));
+            m_active->connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QJUSTIFICATION, o));
             return true;
         }
         return false;
@@ -592,7 +592,7 @@ bool NetDKG::ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, co
     case MSG_QUORUM_PREMATURE_COMMITMENT: {
         CDKGPrematureCommitment o;
         if (m_qdkgsman.GetPrematureCommitment(inv.hash, o)) {
-            connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QPCOMMITMENT, o));
+            m_active->connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::QPCOMMITMENT, o));
             return true;
         }
         return false;

--- a/src/llmq/net_dkg.h
+++ b/src/llmq/net_dkg.h
@@ -69,7 +69,7 @@ public:
     void ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRecv) override
         EXCLUSIVE_LOCKS_REQUIRED(!cs_indexed_quorums_cache);
     bool AlreadyHave(const CInv& inv) override;
-    bool ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, const CNetMsgMaker& msgMaker) override;
+    bool ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker) override;
     /**
      * Drives one phase-handler thread per ActiveDKGSessionHandler in active mode;
      * no-op in observer mode (no curSession to drive).

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2979,7 +2979,7 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
         }
         for (auto& handler : m_handlers) {
             if (!push) {
-                push = handler->ProcessGetData(pfrom, inv, m_connman, msgMaker);
+                push = handler->ProcessGetData(pfrom, inv, msgMaker);
             }
         }
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -136,7 +136,7 @@ public:
     virtual bool AlreadyHave(const CInv& inv) { return false; }
 
     // It should return true, if there's data has been pushed
-    virtual bool ProcessGetData(CNode& pfrom, const CInv& inv, CConnman& connman, const CNetMsgMaker& msgMaker) { return false; }
+    virtual bool ProcessGetData(CNode& pfrom, const CInv& inv, const CNetMsgMaker& msgMaker) { return false; }
 protected:
     PeerManagerInternal* m_peer_manager;
 };


### PR DESCRIPTION
## Issue being fixed or feature implemented

`NetHandler::ProcessGetData` takes a `CConnman&` argument that no implementation actually needs. Every handler that overrides it already holds its own `CConnman&`:

- `CCoinJoinServer::connman`
- `NetGovernance::m_connman`
- `NetDKG::ActiveDKG::connman`

In a running node there is exactly one `CConnman` — `node.connman` in `init.cpp` — and that is the same object `PeerManagerImpl` passes as `m_connman` at the call site, so the argument was always identical to the member.

The parameter is a mechanical artifact of a56c10698ee ("refactor: drop dependency of PeerManager on CoinJoinServer"), which moved these branches out of `PeerManagerImpl::ProcessGetData`. The moved lines read `m_connman.PushMessage(...)`, so `m_connman` was promoted to a parameter to keep the hunk a 1:1 move. Nobody reconciled it with the members the handlers already had.

In `CCoinJoinServer::ProcessGetData` the parameter additionally **shadowed** the class member of the same name, so the body silently used the argument while every other method in the file uses the member.

## What was done?

Dropped `CConnman& connman` from the `NetHandler::ProcessGetData` virtual and from all three overrides; each handler now replies through the `CConnman` it already holds.

`msgMaker` stays a parameter — it is `CNetMsgMaker(pfrom.GetCommonVersion())`, genuinely per-peer state the handler cannot reconstruct on its own.

`NetDKG` keeps its `CConnman` where it already lived, in the active-mode-only `ActiveDKG` bundle, and replies via `m_active->connman`. One consequence worth noting for review: this makes the existing `m_active == nullptr` early return *guard* the replies rather than merely short-circuit them, so the comment above it is updated to say so. That is not a behavior change — the class doc already documents `ProcessGetData` as active-mode only, because the underlying `Get*` calls return false by construction in observer mode.

No behavior change: same object, same call, in every case.

## How Has This Been Tested?

Not built or run locally — this branch was reviewed by inspection. Verified by grep that no `ProcessGetData` declaration, definition, or call site still carries a `CConnman` argument. Relying on CI for the compile and test run.

## Breaking Changes

None. `NetHandler` is an internal interface with no external implementors.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
