### PR TITLE
refactor: drop redundant CSigningManager argument from AsyncSignIfMember

### DIFF
--- a/src/chainlock/signing.cpp
+++ b/src/chainlock/signing.cpp
@@ -174,7 +174,7 @@ void ChainLockSigner::TrySignChainTip()
         lastSignedMsgHash = msgHash;
     }
 
-    m_shareman.AsyncSignIfMember(Params().GetConsensus().llmqTypeChainLocks, m_sigman, requestId, msgHash);
+    m_shareman.AsyncSignIfMember(Params().GetConsensus().llmqTypeChainLocks, requestId, msgHash);
 }
 
 void ChainLockSigner::BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)

--- a/src/instantsend/signing.cpp
+++ b/src/instantsend/signing.cpp
@@ -353,7 +353,7 @@ bool InstantSendSigner::TrySignInputLocks(const CTransaction& tx, bool fRetroact
         WITH_LOCK(cs_input_requests, inputRequestIds.emplace(id));
         LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: trying to vote on input %s with id %s. fRetroactive=%d\n",
                  __func__, tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString(), fRetroactive);
-        if (m_shareman.AsyncSignIfMember(llmqType, m_sigman, id, tx.GetHash(), {}, fRetroactive)) {
+        if (m_shareman.AsyncSignIfMember(llmqType, id, tx.GetHash(), {}, fRetroactive)) {
             LogPrint(BCLog::INSTANTSEND, "%s -- txid=%s: voted on input %s with id %s\n", __func__,
                      tx.GetHash().ToString(), in.prevout.ToStringShort(), id.ToString());
         }
@@ -412,6 +412,6 @@ void InstantSendSigner::TrySignInstantSendLock(const CTransaction& tx)
         txToCreatingInstantSendLocks.emplace(tx.GetHash(), &e.first->second);
     }
 
-    m_shareman.AsyncSignIfMember(llmqType, m_sigman, id, tx.GetHash(), quorum->m_quorum_base_block_index->GetBlockHash());
+    m_shareman.AsyncSignIfMember(llmqType, id, tx.GetHash(), quorum->m_quorum_base_block_index->GetBlockHash());
 }
 } // namespace instantsend

--- a/src/llmq/ehf_signals.cpp
+++ b/src/llmq/ehf_signals.cpp
@@ -79,7 +79,7 @@ void CEHFSignalsHandler::trySignEHFSignal(int bit, const CBlockIndex* const pind
     const uint256 msgHash = mnhfPayload.PrepareTx().GetHash();
 
     WITH_LOCK(cs, ids.insert(requestId));
-    shareman.AsyncSignIfMember(llmqType, sigman, requestId, msgHash, quorum->qc->quorumHash, false, true);
+    shareman.AsyncSignIfMember(llmqType, requestId, msgHash, quorum->qc->quorumHash, false, true);
 }
 
 RecoveredSigResult CEHFSignalsHandler::HandleNewRecoveredSig(const CRecoveredSig& recoveredSig)

--- a/src/llmq/signing_shares.cpp
+++ b/src/llmq/signing_shares.cpp
@@ -761,7 +761,7 @@ CDeterministicMNCPtr CSigSharesManager::SelectMemberForRecovery(const CQuorum& q
     return v[attempt % v.size()].second;
 }
 
-bool CSigSharesManager::AsyncSignIfMember(Consensus::LLMQType llmqType, CSigningManager& sigman, const uint256& id,
+bool CSigSharesManager::AsyncSignIfMember(Consensus::LLMQType llmqType, const uint256& id,
                                           const uint256& msgHash, const uint256& quorumHash, bool allowReSign,
                                           bool allowDiffMsgHashSigning)
 {

--- a/src/llmq/signing_shares.h
+++ b/src/llmq/signing_shares.h
@@ -508,7 +508,7 @@ public:
 
     static CDeterministicMNCPtr SelectMemberForRecovery(const CQuorum& quorum, const uint256& id, int attempt);
 
-    bool AsyncSignIfMember(Consensus::LLMQType llmqType, CSigningManager& sigman, const uint256& id,
+    bool AsyncSignIfMember(Consensus::LLMQType llmqType, const uint256& id,
                            const uint256& msgHash, const uint256& quorumHash = uint256(), bool allowReSign = false,
                            bool allowDiffMsgHashSigning = false) EXCLUSIVE_LOCKS_REQUIRED(!cs_pendingSigns, !cs);
 private:

--- a/src/rpc/quorums.cpp
+++ b/src/rpc/quorums.cpp
@@ -530,7 +530,7 @@ static UniValue quorum_sign_helper(const JSONRPCRequest& request, Consensus::LLM
         fSubmit = ParseBoolV(request.params[3], "submit");
     }
     if (fSubmit) {
-        return CHECK_NONFATAL(node.active_ctx)->shareman->AsyncSignIfMember(llmqType, *llmq_ctx.sigman, id, msgHash, quorumHash);
+        return CHECK_NONFATAL(node.active_ctx)->shareman->AsyncSignIfMember(llmqType, id, msgHash, quorumHash);
     } else {
         const auto pQuorum = [&]() {
             if (quorumHash.IsNull()) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CSigSharesManager::AsyncSignIfMember` takes a `CSigningManager&` argument it does not need. The class has held a `CSigningManager& sigman` member since a35245653c15 (#4988), declared 34 lines above the method in the same header, and the parameter **shadows** it.

There is exactly one `CSigningManager` in a node — `node.llmq_ctx->sigman`. `init.cpp` threads it into `ActiveContext`, which hands the same reference to `CSigSharesManager`'s member and to each caller's own member, so every call site already passes the object the member points at:

| Call site | Passes |
|---|---|
| `chainlock/signing.cpp:177` | `m_sigman` |
| `instantsend/signing.cpp:356`, `:415` | `m_sigman` |
| `llmq/ehf_signals.cpp:82` | `sigman` |
| `rpc/quorums.cpp:533` | `*llmq_ctx.sigman` |

The parameter comes from 0052fcaa59bd ("refactor: move `AsyncSignIfMember()` to `CSigSharesManager`"). Before that move the method lived on `CSigningManager` and took the *opposite* manager, `CSigSharesManager& shareman`. After the move that argument became `this`, and a `sigman` argument was added to reach back for the recovered-sigs db — a mirror-image swap that is correct in isolation, but that nobody reconciled with the member the destination class already had.

Consequence today: the single `sigman.GetDb()` in the body resolves to the argument, while the surrounding code in the same function reaches for `qman` and `m_chainman` as members.

## What was done?

Dropped the `CSigningManager& sigman` parameter from the declaration, the definition, and all five call sites.

The body is untouched — `sigman` now resolves to the member, which is the same object it already received. Parameter-list continuation lines keep their alignment because the opening paren does not move.

## How Has This Been Tested?

Not built or run locally — reviewed by inspection. Verified by grep that no declaration, definition, or call site still passes a `CSigningManager` to `AsyncSignIfMember`, and that removing the argument leaves no caller-side variable unused (`llmq_ctx` in `rpc/quorums.cpp` is still used a few lines below). Relying on CI for the compile and test run.

Worth noting for reviewers: this class of shadowing is invisible to our warning set. Dash configures `-Wshadow-field`, which only fires when a field shadows a *base class* field; a parameter shadowing a member of the same class needs `-Wshadow-all` (or GCC's `-Wshadow`).

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
