### PR TITLE
build: fix mac CI ccache, only wrap darwin CC/CXX in env -u when include paths are set

### DIFF
--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -57,15 +57,24 @@ darwin_STRIP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-strip")
 #         in the SDK, where __has_feature(modules) is used to define USE_CLANG_TYPES,
 #         which is in turn used as an include guard.
 
-# TODO: remove C_INCLUDE_PATH when it is indeed useless
-# https://github.com/bitcoin/bitcoin/pull/30451 has been partiall reverted in #7184 and should be re-applied
-darwin_CC=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH $(clang_prog) --target=$(host) \
+# C_INCLUDE_PATH/CPLUS_INCLUDE_PATH leak native-toolchain headers into the
+# darwin cross-build and conflict with the SDK headers. Guix exports them
+# (contrib/guix/libexec/build.sh), so strip them there with an `env -u`
+# prefix. The prefix must not be emitted when the variables aren't set:
+# ccache cannot parse a compiler command starting with `env` (it treats
+# `env` as the compiler and the absolute clang path as a second source
+# file), so an unconditional prefix silently disables ccache for every
+# darwin compile. Unlike upstream (bitcoin#30451, which dropped the prefix
+# entirely), our Guix environment still sets these variables.
+ifneq ($(origin C_INCLUDE_PATH) $(origin CPLUS_INCLUDE_PATH),undefined undefined)
+darwin_env_unset=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH
+endif
+
+darwin_CC=$(darwin_env_unset) $(clang_prog) --target=$(host) \
               -isysroot$(OSX_SDK) -nostdlibinc \
               -iwithsysroot/usr/include -iframeworkwithsysroot/System/Library/Frameworks
 
-# TODO: remove C_INCLUDE_PATH when it is indeed useless
-# https://github.com/bitcoin/bitcoin/pull/30451 has been partiall reverted in #7184 and should be re-applied
-darwin_CXX=env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH $(clangxx_prog) --target=$(host) \
+darwin_CXX=$(darwin_env_unset) $(clangxx_prog) --target=$(host) \
                -isysroot$(OSX_SDK) -nostdlibinc \
                -iwithsysroot/usr/include/c++/v1 \
                -iwithsysroot/usr/include -iframeworkwithsysroot/System/Library/Frameworks

--- a/depends/hosts/darwin.mk
+++ b/depends/hosts/darwin.mk
@@ -57,6 +57,7 @@ darwin_STRIP=$(shell $(SHELL) $(.SHELLFLAGS) "command -v llvm-strip")
 #         in the SDK, where __has_feature(modules) is used to define USE_CLANG_TYPES,
 #         which is in turn used as an include guard.
 
+# TODO: remove C_INCLUDE_PATH/darwin_env_unset when bitcoin#30451 is fully backported.
 # C_INCLUDE_PATH/CPLUS_INCLUDE_PATH leak native-toolchain headers into the
 # darwin cross-build and conflict with the SDK headers. Guix exports them
 # (contrib/guix/libexec/build.sh), so strip them there with an `env -u`


### PR DESCRIPTION
## Issue being fixed or feature implemented

ccache is silently disabled for the entire `mac-build` CI job, and has been since d201e4396c85 (2026-01-19) re-added the `env -u` prefix to `darwin_CC`/`darwin_CXX` (it was previously broken from 2020-08 until the bitcoin#30451 backport in 1d8868b3c621 removed the prefix in 2025-02).

Every mac CI run shows:

```
Cacheable calls:      0 / 1021 ( 0.00%)
Uncacheable calls: 1021 / 1021 (100.0%)
```

and recompiles all objects from scratch (~22 min compile in run 30848679596), while saving a 17 KB ccache cache entry.

**Root cause:** configure prepends ccache to `CC`, producing `ccache env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH /usr/bin/clang ...`. ccache treats `env` as the compiler (type `other`), consumes `-u VAR` as an option taking an argument, then classifies the absolute clang path — an existing file not starting with `-` — as a second source file. `CCACHE_DEBUG` shows the verdict:

```
Compiler: /usr/bin/env
Compiler type: other
Result: multiple_source_files
```

Every call is rejected and silently falls back to the real compiler, so the build succeeds and nothing ever flagged it. Current ccache master has the same parsing behavior; this is not fixed by upgrading ccache.

## What was done?

The `env -u` prefix exists to stop Guix (`contrib/guix/libexec/build.sh` exports `C_INCLUDE_PATH="${NATIVE_GCC}/include"` etc.) from leaking native-toolchain headers into the darwin cross-build — the conflict d201e4396c85 fixed. CI never sets those variables, so the prefix does nothing there except break ccache.

The prefix is now emitted only when `C_INCLUDE_PATH` or `CPLUS_INCLUDE_PATH` is actually defined (checked via `$(origin ...)`, so set-but-empty still counts as set):

- **Guix:** variables are exported → prefix present → behavior unchanged (Guix doesn't use ccache, so the ccache issue never applied there).
- **CI / containers:** variables unset → plain `$(clang_prog)` → ccache wraps clang directly and caching works.

Upstream removed the prefix entirely (bitcoin#30451) because their Guix build.sh no longer exports these variables; ours still does, so the conditional keeps the Guix protection while re-applying the effect of #30451 everywhere else. The stale TODO comments pointing at #30451/#7184 are replaced with an explanation of both constraints.

Cached depends are not invalidated by this change: `depends/gen_id` hashes compiler `-v` output, which is byte-identical with and without the prefix when the variables are unset (verified below).

## How Has This Been Tested?

All in `ubuntu:24.04` (same ccache 4.9.1 + clang 18 as the CI image), plus a make-level check:

1. **Repro of the bug:** `ccache env -u C_INCLUDE_PATH -u CPLUS_INCLUDE_PATH /usr/bin/clang --target=x86_64-apple-darwin -isysroot... -nostdlibinc ... -c t.c` → `Uncacheable calls: 1/1`, `CCACHE_DEBUG` log shows `Result: multiple_source_files`. Bare `clang` instead of an absolute path does not trigger it, confirming the source-file misparse.
2. **New shape:** same flags without the prefix → `Cacheable calls: 2/2`, second compile is a cache hit.
3. **Conditional:** scratch makefile including `depends/hosts/darwin.mk`: with both variables unset `darwin_CC` has no prefix; with `C_INCLUDE_PATH` set (or set-but-empty) the prefix is emitted.
4. **depends build id stability:** `{clang -v; clang -v -E -xc -o /dev/null -}` output (the `gen_id` preimage components) is byte-identical with and without the `env -u` prefix when the variables are unset, so CI's cached depends remain valid.

Guix builds are unaffected by construction (the conditional evaluates true in that environment), but a `guix-build` run on this PR will confirm.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
