### PR TITLE
ci: hash all depends recipe inputs

### DIFF
--- a/.github/workflows/build-depends.yml
+++ b/.github/workflows/build-depends.yml
@@ -57,9 +57,7 @@ jobs:
           sparse-checkout: |
             ci/dash
             ci/test
-            depends/Makefile
-            depends/packages
-            depends/hosts
+            depends
             contrib/containers/ci/ci.Dockerfile
             contrib/containers/ci/ci-slim.Dockerfile
             contrib/containers/guix/scripts/setup-sdk
@@ -75,9 +73,9 @@ jobs:
           DEP_HASH="$(echo -n "${BUILD_TARGET}" "${DEP_OPTS}" "${HOST}" | sha256sum | head -c 64)"
           echo "DEP_HASH=${DEP_HASH}" >> "${GITHUB_OUTPUT}"
           DOCKERFILE_HASH="${{ hashFiles('contrib/containers/ci/ci.Dockerfile', 'contrib/containers/ci/ci-slim.Dockerfile') }}"
-          PACKAGES_HASH="${{ hashFiles('depends/packages/*', 'depends/Makefile') }}"
+          DEPENDS_INPUTS_HASH="${{ hashFiles('depends/Makefile', 'depends/funcs.mk', 'depends/gen_id', 'depends/config.guess', 'depends/config.sub', 'depends/config.site.in', 'depends/builders/**', 'depends/hosts/**', 'depends/packages/**', 'depends/patches/**') }}"
           CACHE_KEY_PREFIX="depends-${DOCKERFILE_HASH}-${{ inputs.base-image-digest }}-${{ inputs.runs-on }}-${{ inputs.build-target }}"
-          CACHE_KEY="${CACHE_KEY_PREFIX}-${DEP_HASH}-${PACKAGES_HASH}"
+          CACHE_KEY="${CACHE_KEY_PREFIX}-${DEP_HASH}-${DEPENDS_INPUTS_HASH}"
           echo "cache-key-prefix=${CACHE_KEY_PREFIX}" >> "${GITHUB_OUTPUT}"
           echo "cache-key=${CACHE_KEY}" >> "${GITHUB_OUTPUT}"
           echo "Cache key: ${CACHE_KEY}"


### PR DESCRIPTION
## Issue being fixed or feature implemented

The depends cache key did not cover every file used to derive depends package build IDs. In [run 30864594362](https://github.com/dashpay/dash/actions/runs/30864594362/job/91859430920?pr=7540), PR #7540 changed `depends/hosts/darwin.mk`, but cache lookup still reported a hit and skipped the dedicated depends build. The macOS source job then rebuilt packages for about 17 minutes.

## What was done?

- Include the complete static depends recipe inputs in the cache key: the Makefiles, ID generator, config files, builders, hosts, packages, and patches.
- Check out the full tracked `depends/` directory in the cache-check job so those inputs are available to `hashFiles`.

This causes a true cache miss when a relevant depends input changes, allowing the existing depends job/artifact handoff to provide matching packages to source jobs.

## How Has This Been Tested?

- Ran `git diff --check`.
- Ran `actionlint .github/workflows/build-depends.yml`. It reports existing diagnostics for the repository's custom checkout input and pre-existing shell-style issues; no diagnostics are caused by this change.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.