### PR TITLE
fix: treat unregistered types as inactive in IsQuorumActive

### DIFF
--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -649,7 +649,11 @@ bool IsQuorumActive(Consensus::LLMQType llmqType, const CQuorumManager& qman, co
     // we allow one more active quorum as specified in consensus, as otherwise there is a small window where things could
     // fail while we are on the brink of a new quorum
     const auto& llmq_params_opt = Params().GetLLMQ(llmqType);
-    assert(llmq_params_opt.has_value());
+    // Unregistered / unknown types are never active. Callers may pass wire-derived
+    // llmqType values, so return false instead of asserting.
+    if (!llmq_params_opt.has_value()) {
+        return false;
+    }
     auto quorums = qman.ScanQuorums(llmqType, llmq_params_opt->keepOldConnections);
     return std::ranges::any_of(quorums, [&quorumHash](const auto& q) { return q->qc->quorumHash == quorumHash; });
 }

--- a/src/llmq/signing.cpp
+++ b/src/llmq/signing.cpp
@@ -649,8 +649,6 @@ bool IsQuorumActive(Consensus::LLMQType llmqType, const CQuorumManager& qman, co
     // we allow one more active quorum as specified in consensus, as otherwise there is a small window where things could
     // fail while we are on the brink of a new quorum
     const auto& llmq_params_opt = Params().GetLLMQ(llmqType);
-    // Unregistered / unknown types are never active. Callers may pass wire-derived
-    // llmqType values, so return false instead of asserting.
     if (!llmq_params_opt.has_value()) {
         return false;
     }

--- a/src/test/llmq_invalid_type_tests.cpp
+++ b/src/test/llmq_invalid_type_tests.cpp
@@ -9,6 +9,7 @@
 #include <llmq/context.h>
 #include <llmq/params.h>
 #include <llmq/quorumsman.h>
+#include <llmq/signing.h>
 #include <llmq/utils.h>
 #include <saltedhasher.h>
 #include <sync.h>
@@ -81,6 +82,21 @@ BOOST_FIXTURE_TEST_CASE(get_quorum_unknown_llmq_type_is_safe, RegTestingSetup)
 
     BOOST_CHECK(qman.GetQuorum(UNKNOWN_LLMQ_TYPE, tip_hash) == nullptr);
     BOOST_CHECK(qman.GetQuorum(UNREGISTERED_LLMQ_TYPE, tip_hash) == nullptr);
+}
+
+// IsQuorumActive used to assert(GetLLMQ(...).has_value()). Wire-derived types can
+// reach it if a caller reorders checks or omits the net-layer type gate; treat
+// unregistered types as inactive instead of aborting.
+BOOST_FIXTURE_TEST_CASE(is_quorum_active_unknown_llmq_type_is_safe, RegTestingSetup)
+{
+    const auto& qman = *Assert(Assert(m_node.llmq_ctx)->qman);
+    const uint256 tip_hash = WITH_LOCK(::cs_main, return Assert(m_node.chainman->ActiveTip())->GetBlockHash());
+
+    BOOST_REQUIRE(!Params().GetLLMQ(UNKNOWN_LLMQ_TYPE).has_value());
+    BOOST_REQUIRE(!Params().GetLLMQ(UNREGISTERED_LLMQ_TYPE).has_value());
+
+    BOOST_CHECK(!llmq::IsQuorumActive(UNKNOWN_LLMQ_TYPE, qman, tip_hash));
+    BOOST_CHECK(!llmq::IsQuorumActive(UNREGISTERED_LLMQ_TYPE, qman, tip_hash));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/llmq_invalid_type_tests.cpp
+++ b/src/test/llmq_invalid_type_tests.cpp
@@ -9,7 +9,6 @@
 #include <llmq/context.h>
 #include <llmq/params.h>
 #include <llmq/quorumsman.h>
-#include <llmq/signing.h>
 #include <llmq/utils.h>
 #include <saltedhasher.h>
 #include <sync.h>
@@ -82,21 +81,6 @@ BOOST_FIXTURE_TEST_CASE(get_quorum_unknown_llmq_type_is_safe, RegTestingSetup)
 
     BOOST_CHECK(qman.GetQuorum(UNKNOWN_LLMQ_TYPE, tip_hash) == nullptr);
     BOOST_CHECK(qman.GetQuorum(UNREGISTERED_LLMQ_TYPE, tip_hash) == nullptr);
-}
-
-// IsQuorumActive used to assert(GetLLMQ(...).has_value()). Wire-derived types can
-// reach it if a caller reorders checks or omits the net-layer type gate; treat
-// unregistered types as inactive instead of aborting.
-BOOST_FIXTURE_TEST_CASE(is_quorum_active_unknown_llmq_type_is_safe, RegTestingSetup)
-{
-    const auto& qman = *Assert(Assert(m_node.llmq_ctx)->qman);
-    const uint256 tip_hash = WITH_LOCK(::cs_main, return Assert(m_node.chainman->ActiveTip())->GetBlockHash());
-
-    BOOST_REQUIRE(!Params().GetLLMQ(UNKNOWN_LLMQ_TYPE).has_value());
-    BOOST_REQUIRE(!Params().GetLLMQ(UNREGISTERED_LLMQ_TYPE).has_value());
-
-    BOOST_CHECK(!llmq::IsQuorumActive(UNKNOWN_LLMQ_TYPE, qman, tip_hash));
-    BOOST_CHECK(!llmq::IsQuorumActive(UNREGISTERED_LLMQ_TYPE, qman, tip_hash));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Issue being fixed or feature implemented
`IsQuorumActive` previously aborted via `assert` when given an LLMQ type that is not registered in the active chain's consensus params. Call sites are currently gated or reach this helper only with validated types, so this is defense-in-depth rather than a live remote crash today. If a future caller reorders checks or omits the net-layer type gate, an unregistered wire-derived type would still abort the node.

## What was done?
- Return `false` from `IsQuorumActive` when `Params().GetLLMQ(llmqType)` is empty instead of asserting

## How Has This Been Tested?
- Built `src/test/test_dash` against prebuilt depends (`aarch64-apple-darwin25.3.0`)
- Ran `./src/test/test_dash --run_test=llmq_invalid_type_tests` (pass)
- No new dedicated unit case: an unknown-type-only assertion would only restate the early return, and a meaningful active/inactive fixture needs full mined-quorum setup not warranted for this one-liner

## Breaking Changes
None. Unregistered types were never valid active quorums; callers that asserted-failed now simply treat them as inactive.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

This pull request was created by Codex.
