### PR TITLE
docs: instruct agents to follow PR template and title linter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,12 @@ CI/lint list changes.
 ## Test Commands
 
 Choose tests based on the files touched. Do not claim broad validation if only a
-targeted test was run.
+targeted test was run. Prefer adding test cases to existing files over creating a
+new unit or functional test file. Only create a new test file when the additions
+would make an existing file overly complicated, when a separate file yields
+clearly improved performance (e.g. parallel execution or isolation), or when the
+subject being tested is distinctly separate and does not logically belong in an
+existing file. Fewer files reduce test setup overhead and compilation time.
 
 ```bash
 # All unit tests
@@ -176,17 +181,12 @@ For these areas, prefer small tests that prove the invariant being changed.
 
 ## PR Hygiene
 
-- When creating pull requests, automated agents must follow `.github/PULL_REQUEST_TEMPLATE.md` for the description and ensure the PR title satisfies the active linter in `.github/workflows/semantic-pull-request.yml` (using Conventional Commits).
+- When creating pull requests, follow `.github/PULL_REQUEST_TEMPLATE.md` for the description and ensure the PR title satisfies the active linter in `.github/workflows/semantic-pull-request.yml` (using Conventional Commits, including `backport:` for Bitcoin Core backports).
 - Use atomic commits. Each commit should make sense on its own and generally
   build and pass tests. An intentionally non-building commit (e.g. a
   regression test landing before its fix) is fine if called out explicitly so
   it isn't mistaken for an oversight.
-- PR titles follow Conventional Commits, including `backport:` for Bitcoin Core
-  backports. Valid types/scopes are enforced by CI; see
-  `.github/workflows/semantic-pull-request.yml`.
-- PR descriptions must follow `.github/PULL_REQUEST_TEMPLATE.md`: remove the
-  italicized helper prompts, fill in the required sections, and keep the
-  checklist accurate for the change.
+- Remove the italicized helper prompts from `.github/PULL_REQUEST_TEMPLATE.md`, fill in the required sections, and keep the checklist accurate for the change.
 - Do not put `@` mentions in PR descriptions; they are copied into merge
   commits and notify users repeatedly.
 - Explain what changed and why. For bug fixes, include the failure mode and why

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ For these areas, prefer small tests that prove the invariant being changed.
 
 ## PR Hygiene
 
+- When creating pull requests, automated agents must follow `.github/PULL_REQUEST_TEMPLATE.md` for the description and ensure the PR title satisfies the active linter in `.github/workflows/semantic-pull-request.yml` (using Conventional Commits).
 - Use atomic commits. Each commit should make sense on its own and generally
   build and pass tests. An intentionally non-building commit (e.g. a
   regression test landing before its fix) is fine if called out explicitly so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,12 @@ CI/lint list changes.
 ## Test Commands
 
 Choose tests based on the files touched. Do not claim broad validation if only a
-targeted test was run.
+targeted test was run. Prefer adding test cases to existing files over creating a
+new unit or functional test file. Only create a new test file when the additions
+would make an existing file overly complicated, when a separate file yields
+clearly improved performance (e.g. parallel execution or isolation), or when the
+subject being tested is distinctly separate and does not logically belong in an
+existing file. Fewer files reduce test setup overhead and compilation time.
 
 ```bash
 # All unit tests
@@ -176,17 +181,12 @@ For these areas, prefer small tests that prove the invariant being changed.
 
 ## PR Hygiene
 
-- When creating pull requests, automated agents must follow `.github/PULL_REQUEST_TEMPLATE.md` for the description and ensure the PR title satisfies the active linter in `.github/workflows/semantic-pull-request.yml` (using Conventional Commits).
+- When creating pull requests, follow `.github/PULL_REQUEST_TEMPLATE.md` for the description and ensure the PR title satisfies the active linter in `.github/workflows/semantic-pull-request.yml` (using Conventional Commits, including `backport:` for Bitcoin Core backports).
 - Use atomic commits. Each commit should make sense on its own and generally
   build and pass tests. An intentionally non-building commit (e.g. a
   regression test landing before its fix) is fine if called out explicitly so
   it isn't mistaken for an oversight.
-- PR titles follow Conventional Commits, including `backport:` for Bitcoin Core
-  backports. Valid types/scopes are enforced by CI; see
-  `.github/workflows/semantic-pull-request.yml`.
-- PR descriptions must follow `.github/PULL_REQUEST_TEMPLATE.md`: remove the
-  italicized helper prompts, fill in the required sections, and keep the
-  checklist accurate for the change.
+- Remove the italicized helper prompts from `.github/PULL_REQUEST_TEMPLATE.md`, fill in the required sections, and keep the checklist accurate for the change.
 - Do not put `@` mentions in PR descriptions; they are copied into merge
   commits and notify users repeatedly.
 - Explain what changed and why. For bug fixes, include the failure mode and why

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,7 @@ For these areas, prefer small tests that prove the invariant being changed.
 
 ## PR Hygiene
 
+- When creating pull requests, automated agents must follow `.github/PULL_REQUEST_TEMPLATE.md` for the description and ensure the PR title satisfies the active linter in `.github/workflows/semantic-pull-request.yml` (using Conventional Commits).
 - Use atomic commits. Each commit should make sense on its own and generally
   build and pass tests. An intentionally non-building commit (e.g. a
   regression test landing before its fix) is fine if called out explicitly so


### PR DESCRIPTION
## Issue being fixed or feature implemented

Guidance in `AGENTS.md` and `CLAUDE.md` should clearly instruct coding agents on PR hygiene (template, title linter) and test file creation strategy.

## What was done?

- Updated `AGENTS.md` and `CLAUDE.md` under `## PR Hygiene` to instruct agents to follow `.github/PULL_REQUEST_TEMPLATE.md` for descriptions and satisfy the active PR title linter in `.github/workflows/semantic-pull-request.yml`.
- Added test file selection guidance under `## Test Commands` instructing agents to prefer adding test cases to existing test files unless creating a new file is justified by complexity, performance/parallelism, or logical distinction.

## How Has This Been Tested?

Verified that `AGENTS.md` and `CLAUDE.md` contain identical guidance (`diff AGENTS.md CLAUDE.md`).

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

This pull request was created by Codex.
