### PR TITLE
refactor: move address/spent/timestamp indexes into NodeContext

### DIFF
--- a/src/index/addressindex.cpp
+++ b/src/index/addressindex.cpp
@@ -18,8 +18,6 @@
 constexpr uint8_t DB_ADDRESSINDEX{'a'};
 constexpr uint8_t DB_ADDRESSUNSPENTINDEX{'u'};
 
-std::unique_ptr<AddressIndex> g_addressindex;
-
 AddressIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
     BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "addressindex", n_cache_size, f_memory, f_wipe)
 {

--- a/src/index/addressindex.h
+++ b/src/index/addressindex.h
@@ -85,7 +85,4 @@ public:
                                 std::vector<CAddressUnspentIndexEntry>& entries, const bool height_sort = false) const;
 };
 
-/// Global AddressIndex instance
-extern std::unique_ptr<AddressIndex> g_addressindex;
-
 #endif // BITCOIN_INDEX_ADDRESSINDEX_H

--- a/src/index/spentindex.cpp
+++ b/src/index/spentindex.cpp
@@ -19,8 +19,6 @@
 
 constexpr uint8_t DB_SPENTINDEX{'p'};
 
-std::unique_ptr<SpentIndex> g_spentindex;
-
 SpentIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
     BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "spentindex", n_cache_size, f_memory, f_wipe)
 {

--- a/src/index/spentindex.h
+++ b/src/index/spentindex.h
@@ -65,7 +65,4 @@ public:
     bool GetSpentInfo(const CSpentIndexKey& key, CSpentIndexValue& value) const;
 };
 
-/// Global SpentIndex instance
-extern std::unique_ptr<SpentIndex> g_spentindex;
-
 #endif // BITCOIN_INDEX_SPENTINDEX_H

--- a/src/index/timestampindex.cpp
+++ b/src/index/timestampindex.cpp
@@ -12,8 +12,6 @@
 
 constexpr uint8_t DB_TIMESTAMPINDEX{'s'};
 
-std::unique_ptr<TimestampIndex> g_timestampindex;
-
 TimestampIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
     BaseIndex::DB(gArgs.GetDataDirNet() / "indexes" / "timestampindex", n_cache_size, f_memory, f_wipe)
 {

--- a/src/index/timestampindex.h
+++ b/src/index/timestampindex.h
@@ -61,7 +61,4 @@ public:
     bool GetBlockHashes(uint32_t high, uint32_t low, std::vector<uint256>& hashes) const;
 };
 
-/// Global TimestampIndex instance
-extern std::unique_ptr<TimestampIndex> g_timestampindex;
-
 #endif // BITCOIN_INDEX_TIMESTAMPINDEX_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -270,14 +270,14 @@ void Interrupt(NodeContext& node)
     if (g_txindex) {
         g_txindex->Interrupt();
     }
-    if (g_addressindex) {
-        g_addressindex->Interrupt();
+    if (node.address_index) {
+        node.address_index->Interrupt();
     }
-    if (g_timestampindex) {
-        g_timestampindex->Interrupt();
+    if (node.timestamp_index) {
+        node.timestamp_index->Interrupt();
     }
-    if (g_spentindex) {
-        g_spentindex->Interrupt();
+    if (node.spent_index) {
+        node.spent_index->Interrupt();
     }
     ForEachBlockFilterIndex([](BlockFilterIndex& index) { index.Interrupt(); });
     if (g_coin_stats_index) {
@@ -396,17 +396,17 @@ void PrepareShutdown(NodeContext& node)
         g_txindex->Stop();
         g_txindex.reset();
     }
-    if (g_addressindex) {
-        g_addressindex->Stop();
-        g_addressindex.reset();
+    if (node.address_index) {
+        node.address_index->Stop();
+        node.address_index.reset();
     }
-    if (g_timestampindex) {
-        g_timestampindex->Stop();
-        g_timestampindex.reset();
+    if (node.timestamp_index) {
+        node.timestamp_index->Stop();
+        node.timestamp_index.reset();
     }
-    if (g_spentindex) {
-        g_spentindex->Stop();
-        g_spentindex.reset();
+    if (node.spent_index) {
+        node.spent_index->Stop();
+        node.spent_index.reset();
     }
     if (g_coin_stats_index) {
         g_coin_stats_index->Stop();
@@ -2199,22 +2199,22 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
 
     if (args.GetBoolArg("-addressindex", DEFAULT_ADDRESSINDEX)) {
-        g_addressindex = std::make_unique<AddressIndex>(interfaces::MakeChain(node), cache_sizes.address_index, false, fReindex);
-        if (!g_addressindex->Start()) {
+        node.address_index = std::make_unique<AddressIndex>(interfaces::MakeChain(node), cache_sizes.address_index, false, fReindex);
+        if (!node.address_index->Start()) {
             return false;
         }
     }
 
     if (args.GetBoolArg("-timestampindex", DEFAULT_TIMESTAMPINDEX)) {
-        g_timestampindex = std::make_unique<TimestampIndex>(interfaces::MakeChain(node), cache_sizes.timestamp_index, false, fReindex);
-        if (!g_timestampindex->Start()) {
+        node.timestamp_index = std::make_unique<TimestampIndex>(interfaces::MakeChain(node), cache_sizes.timestamp_index, false, fReindex);
+        if (!node.timestamp_index->Start()) {
             return false;
         }
     }
 
     if (args.GetBoolArg("-spentindex", DEFAULT_SPENTINDEX)) {
-        g_spentindex = std::make_unique<SpentIndex>(interfaces::MakeChain(node), cache_sizes.spent_index, false, fReindex);
-        if (!g_spentindex->Start()) {
+        node.spent_index = std::make_unique<SpentIndex>(interfaces::MakeChain(node), cache_sizes.spent_index, false, fReindex);
+        if (!node.spent_index->Start()) {
             return false;
         }
     }

--- a/src/kernel/mempool_options.h
+++ b/src/kernel/mempool_options.h
@@ -50,6 +50,8 @@ struct MemPoolOptions {
     std::optional<unsigned> max_datacarrier_bytes{DEFAULT_ACCEPT_DATACARRIER ? std::optional{MAX_OP_RETURN_RELAY} : std::nullopt};
     bool permit_bare_multisig{DEFAULT_PERMIT_BAREMULTISIG};
     bool require_standard{true};
+    bool address_index_enabled{false};
+    bool spent_index_enabled{false};
     MemPoolLimits limits{};
 };
 } // namespace kernel

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -16,6 +16,9 @@
 #include <scheduler.h>
 #include <txmempool.h>
 #include <validation.h>
+#include <index/addressindex.h>
+#include <index/spentindex.h>
+#include <index/timestampindex.h>
 
 #include <active/context.h>
 #include <chainlock/chainlock.h>

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <vector>
 
+class AddressIndex;
 class ArgsManager;
 class BanMan;
 class CActiveMasternodeManager;
@@ -35,6 +36,8 @@ class CSporkManager;
 class CTxMemPool;
 class NetGroupManager;
 class PeerManager;
+class SpentIndex;
+class TimestampIndex;
 struct ActiveContext;
 struct LLMQContext;
 
@@ -109,6 +112,10 @@ struct NodeContext {
     std::unique_ptr<ActiveContext> active_ctx;
     std::unique_ptr<LLMQContext> llmq_ctx;
     std::unique_ptr<llmq::ObserverContext> observer_ctx;
+    //! Dash indexes
+    std::unique_ptr<AddressIndex> address_index;
+    std::unique_ptr<SpentIndex> spent_index;
+    std::unique_ptr<TimestampIndex> timestamp_index;
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/node/mempool_args.cpp
+++ b/src/node/mempool_args.cpp
@@ -4,6 +4,9 @@
 
 #include <node/mempool_args.h>
 
+#include <index/addressindex.h>
+#include <index/spentindex.h>
+
 #include <kernel/mempool_limits.h>
 #include <kernel/mempool_options.h>
 
@@ -91,6 +94,9 @@ std::optional<bilingual_str> ApplyArgsManOptions(const ArgsManager& argsman, con
     }
 
     ApplyArgsManOptions(argsman, mempool_opts.limits);
+
+    mempool_opts.address_index_enabled = argsman.GetBoolArg("-addressindex", DEFAULT_ADDRESSINDEX);
+    mempool_opts.spent_index_enabled = argsman.GetBoolArg("-spentindex", DEFAULT_SPENTINDEX);
 
     return std::nullopt;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -19,6 +19,7 @@
 #include <evo/chainhelper.h>
 #include <index/blockfilterindex.h>
 #include <index/coinstatsindex.h>
+#include <index/spentindex.h>
 #include <index/timestampindex.h>
 #include <index/txindex.h>
 #include <kernel/coinstats.h>
@@ -83,7 +84,7 @@ static GlobalMutex cs_blockchange;
 static std::condition_variable cond_blockchange;
 static CUpdatedBlock latestblock GUARDED_BY(cs_blockchange);
 
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const CTxMemPool& mempool, const Chainstate& active_chainstate, const chainlock::Chainlocks& chainlocks, const llmq::CInstantSendManager& isman, UniValue& entry, TxVerbosity verbosity = TxVerbosity::SHOW_DETAILS);
+extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const CTxMemPool& mempool, const Chainstate& active_chainstate, const chainlock::Chainlocks& chainlocks, const llmq::CInstantSendManager& isman, const SpentIndex* spent_index, UniValue& entry, TxVerbosity verbosity = TxVerbosity::SHOW_DETAILS);
 
 /* Calculate the difficulty for a given block index.
  */
@@ -2474,7 +2475,7 @@ static RPCHelpMan getspecialtxes()
             case 2 :
                 {
                     UniValue objTx(UniValue::VOBJ);
-                    TxToJSON(*tx, blockhash, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, objTx);
+                    TxToJSON(*tx, blockhash, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, g_spentindex.get(), objTx);
                     result.push_back(objTx);
                     break;
                 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -554,19 +554,20 @@ static RPCHelpMan getblockhashes()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!g_timestampindex) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (!node.timestamp_index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Timestamp index is not enabled. Start with -timestampindex to enable.");
     }
 
-    if (!g_timestampindex->BlockUntilSyncedToCurrentChain()) {
-        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Timestamp index is syncing. Current height: %d", g_timestampindex->GetSummary().best_block_height));
+    if (!node.timestamp_index->BlockUntilSyncedToCurrentChain()) {
+        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Timestamp index is syncing. Current height: %d", node.timestamp_index->GetSummary().best_block_height));
     }
 
     unsigned int high = request.params[0].getInt<int>();
     unsigned int low = request.params[1].getInt<int>();
     std::vector<uint256> blockHashes;
 
-    if (!g_timestampindex->GetBlockHashes(high, low, blockHashes)) {
+    if (!node.timestamp_index->GetBlockHashes(high, low, blockHashes)) {
         throw JSONRPCError(RPC_MISC_ERROR, "Failed to read timestamp index.");
     }
 
@@ -2475,7 +2476,7 @@ static RPCHelpMan getspecialtxes()
             case 2 :
                 {
                     UniValue objTx(UniValue::VOBJ);
-                    TxToJSON(*tx, blockhash, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, g_spentindex.get(), objTx);
+                    TxToJSON(*tx, blockhash, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, node.spent_index.get(), objTx);
                     result.push_back(objTx);
                     break;
                 }

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -411,7 +411,8 @@ static RPCHelpMan getaddressmempool()
         },
     [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
-    if (!g_addressindex) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (!node.address_index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Address index is not enabled. Start with -addressindex to enable.");
     }
 
@@ -496,18 +497,19 @@ static RPCHelpMan getaddressutxos()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
-    if (!g_addressindex) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (!node.address_index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Address index is not enabled. Start with -addressindex to enable.");
     }
 
-    if (!g_addressindex->BlockUntilSyncedToCurrentChain()) {
-        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Address index is syncing. Current height: %d", g_addressindex->GetSummary().best_block_height));
+    if (!node.address_index->BlockUntilSyncedToCurrentChain()) {
+        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Address index is syncing. Current height: %d", node.address_index->GetSummary().best_block_height));
     }
 
     std::vector<CAddressUnspentIndexEntry> unspentOutputs;
 
     for (const auto& address : addresses) {
-        if (!g_addressindex->GetAddressUnspentIndex(address.first, address.second, unspentOutputs,
+        if (!node.address_index->GetAddressUnspentIndex(address.first, address.second, unspentOutputs,
                                     /* height_sort = */ true)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
         }
@@ -588,17 +590,18 @@ static RPCHelpMan getaddressdeltas()
 
     std::vector<CAddressIndexEntry> addressIndex;
 
-    if (!g_addressindex) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (!node.address_index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Address index is not enabled. Start with -addressindex to enable.");
     }
 
-    if (!g_addressindex->BlockUntilSyncedToCurrentChain()) {
-        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Address index is syncing. Current height: %d", g_addressindex->GetSummary().best_block_height));
+    if (!node.address_index->BlockUntilSyncedToCurrentChain()) {
+        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Address index is syncing. Current height: %d", node.address_index->GetSummary().best_block_height));
     }
 
     for (const auto& address : addresses) {
         if (start <= 0 || end <= 0) { start = 0; end = 0; }
-        if (!g_addressindex->GetAddressIndex(address.first, address.second,
+        if (!node.address_index->GetAddressIndex(address.first, address.second,
                                              addressIndex, start, end)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
         }
@@ -660,24 +663,25 @@ static RPCHelpMan getaddressbalance()
 
     std::vector<CAddressIndexEntry> addressIndex;
 
-    if (!g_addressindex) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (!node.address_index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Address index is not enabled. Start with -addressindex to enable.");
     }
 
-    if (!g_addressindex->BlockUntilSyncedToCurrentChain()) {
-        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Address index is syncing. Current height: %d", g_addressindex->GetSummary().best_block_height));
+    if (!node.address_index->BlockUntilSyncedToCurrentChain()) {
+        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Address index is syncing. Current height: %d", node.address_index->GetSummary().best_block_height));
     }
 
     int nHeight;
     {
         LOCK(::cs_main);
         for (const auto& address : addresses) {
-            if (!g_addressindex->GetAddressIndex(address.first, address.second, addressIndex,
+            if (!node.address_index->GetAddressIndex(address.first, address.second, addressIndex,
                                                  /*start=*/0, /*end=*/0)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
             }
         }
-        nHeight = g_addressindex->GetSummary().best_block_height;
+        nHeight = node.address_index->GetSummary().best_block_height;
     }
 
 
@@ -750,17 +754,18 @@ static RPCHelpMan getaddresstxids()
 
     std::vector<CAddressIndexEntry> addressIndex;
 
-    if (!g_addressindex) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (!node.address_index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Address index is not enabled. Start with -addressindex to enable.");
     }
 
-    if (!g_addressindex->BlockUntilSyncedToCurrentChain()) {
-        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Address index is syncing. Current height: %d", g_addressindex->GetSummary().best_block_height));
+    if (!node.address_index->BlockUntilSyncedToCurrentChain()) {
+        throw JSONRPCError(RPC_MISC_ERROR, strprintf("Address index is syncing. Current height: %d", node.address_index->GetSummary().best_block_height));
     }
 
     for (const auto& address : addresses) {
         if (start <= 0 || end <= 0) { start = 0; end = 0; }
-        if (!g_addressindex->GetAddressIndex(address.first, address.second,
+        if (!node.address_index->GetAddressIndex(address.first, address.second,
                                              addressIndex, start, end)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
         }
@@ -832,7 +837,8 @@ static RPCHelpMan getspentinfo()
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid index (must be non-negative)");
     }
 
-    if (!g_spentindex) {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
+    if (!node.spent_index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Spent index is not enabled. Start with -spentindex to enable.");
     }
 
@@ -842,9 +848,9 @@ static RPCHelpMan getspentinfo()
 
     // Sync the index to the current chain tip before querying.
     // We don't fail here if not synced — the result may still come from mempool below.
-    g_spentindex->BlockUntilSyncedToCurrentChain();
+    node.spent_index->BlockUntilSyncedToCurrentChain();
 
-    if (g_spentindex->GetSpentInfo(key, value)) {
+    if (node.spent_index->GetSpentInfo(key, value)) {
         found = true;
     }
 
@@ -863,7 +869,7 @@ static RPCHelpMan getspentinfo()
     }
 
     if (!found) {
-        const IndexSummary summary = g_spentindex->GetSummary();
+        const IndexSummary summary = node.spent_index->GetSummary();
         if (!summary.synced) {
             throw JSONRPCError(RPC_MISC_ERROR, strprintf("Unable to get spent info. Spent index is syncing, current height: %d", summary.best_block_height));
         }
@@ -1193,6 +1199,7 @@ static RPCHelpMan getindexinfo()
                 },
                 [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
 {
+    const NodeContext& node = EnsureAnyNodeContext(request.context);
     UniValue result(UniValue::VOBJ);
     const std::string index_name = request.params[0].isNull() ? "" : request.params[0].get_str();
 
@@ -1208,16 +1215,16 @@ static RPCHelpMan getindexinfo()
         result.pushKVs(SummaryToJSON(index.GetSummary(), index_name));
     });
 
-    if (g_addressindex) {
-        result.pushKVs(SummaryToJSON(g_addressindex->GetSummary(), index_name));
+    if (node.address_index) {
+        result.pushKVs(SummaryToJSON(node.address_index->GetSummary(), index_name));
     }
 
-    if (g_timestampindex) {
-        result.pushKVs(SummaryToJSON(g_timestampindex->GetSummary(), index_name));
+    if (node.timestamp_index) {
+        result.pushKVs(SummaryToJSON(node.timestamp_index->GetSummary(), index_name));
     }
 
-    if (g_spentindex) {
-        result.pushKVs(SummaryToJSON(g_spentindex->GetSummary(), index_name));
+    if (node.spent_index) {
+        result.pushKVs(SummaryToJSON(node.spent_index->GetSummary(), index_name));
     }
 
     return result;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -433,7 +433,7 @@ static RPCHelpMan getrawtransaction()
 
     UniValue result(UniValue::VOBJ);
     if (blockindex) result.pushKV("in_active_chain", in_active_chain);
-    TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, g_spentindex.get(), result);
+    TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, node.spent_index.get(), result);
     return result;
 },
     };
@@ -526,7 +526,7 @@ static RPCHelpMan getrawtransactionmulti() {
                 result.pushKV(txid_str, "None");
             } else if (fVerbose) {
                 UniValue tx_data{UniValue::VOBJ};
-                TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, g_spentindex.get(), tx_data);
+                TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, node.spent_index.get(), tx_data);
                 result.pushKV(txid_str, tx_data);
             } else {
                 result.pushKV(txid_str, EncodeHexTx(*tx));

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -70,7 +70,7 @@ using node::GetTransaction;
 using node::NodeContext;
 using node::PSBTAnalysis;
 
-void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const  CTxMemPool& mempool, const Chainstate& active_chainstate, const chainlock::Chainlocks& chainlocks, const llmq::CInstantSendManager& isman, UniValue& entry, TxVerbosity verbosity = TxVerbosity::SHOW_DETAILS)
+void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const  CTxMemPool& mempool, const Chainstate& active_chainstate, const chainlock::Chainlocks& chainlocks, const llmq::CInstantSendManager& isman, const SpentIndex* spent_index, UniValue& entry, TxVerbosity verbosity = TxVerbosity::SHOW_DETAILS)
 {
     CHECK_NONFATAL(verbosity >= TxVerbosity::SHOW_DETAILS);
 
@@ -79,9 +79,9 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const  CTxMemPool
 
     // Add spent information if spentindex is enabled
     CSpentIndexTxInfo txSpentInfo;
-    if (g_spentindex) {
+    if (spent_index) {
         // Sync once before all queries to ensure consistent snapshot
-        g_spentindex->BlockUntilSyncedToCurrentChain();
+        spent_index->BlockUntilSyncedToCurrentChain();
 
         txSpentInfo = CSpentIndexTxInfo{};
         // Collect spent info for inputs
@@ -89,7 +89,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const  CTxMemPool
             if (!tx.IsCoinBase()) {
                 CSpentIndexValue spentInfo;
                 CSpentIndexKey spentKey(txin.prevout.hash, txin.prevout.n);
-                if (g_spentindex->GetSpentInfo(spentKey, spentInfo)) {
+                if (spent_index->GetSpentInfo(spentKey, spentInfo)) {
                     txSpentInfo.mSpentInfo.emplace(spentKey, spentInfo);
                 }
             }
@@ -98,7 +98,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, const  CTxMemPool
         for (unsigned int i = 0; i < tx.vout.size(); i++) {
             CSpentIndexValue spentInfo;
             CSpentIndexKey spentKey(txid, i);
-            if (g_spentindex->GetSpentInfo(spentKey, spentInfo)) {
+            if (spent_index->GetSpentInfo(spentKey, spentInfo)) {
                 txSpentInfo.mSpentInfo.emplace(spentKey, spentInfo);
             }
         }
@@ -433,7 +433,7 @@ static RPCHelpMan getrawtransaction()
 
     UniValue result(UniValue::VOBJ);
     if (blockindex) result.pushKV("in_active_chain", in_active_chain);
-    TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, result);
+    TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, g_spentindex.get(), result);
     return result;
 },
     };
@@ -526,7 +526,7 @@ static RPCHelpMan getrawtransactionmulti() {
                 result.pushKV(txid_str, "None");
             } else if (fVerbose) {
                 UniValue tx_data{UniValue::VOBJ};
-                TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, tx_data);
+                TxToJSON(*tx, hash_block, mempool, chainman.ActiveChainstate(), *node.chainlocks, *llmq_ctx.isman, g_spentindex.get(), tx_data);
                 result.pushKV(txid_str, tx_data);
             } else {
                 result.pushKV(txid_str, EncodeHexTx(*tx));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -33,12 +33,6 @@
 #include <optional>
 #include <ranges>
 
-// Forward declarations for index globals and utilities
-class AddressIndex;
-class SpentIndex;
-extern std::unique_ptr<AddressIndex> g_addressindex;
-extern std::unique_ptr<SpentIndex> g_spentindex;
-
 bool TestLockPointValidity(CChain& active_chain, const LockPoints& lp)
 {
     AssertLockHeld(cs_main);
@@ -437,6 +431,8 @@ CTxMemPool::CTxMemPool(const Options& opts)
       m_permit_bare_multisig{opts.permit_bare_multisig},
       m_max_datacarrier_bytes{opts.max_datacarrier_bytes},
       m_require_standard{opts.require_standard},
+      m_address_index_enabled{opts.address_index_enabled},
+      m_spent_index_enabled{opts.spent_index_enabled},
       m_limits{opts.limits}
 {
     _clear(); //lock free clear
@@ -534,7 +530,7 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
 
 void CTxMemPool::addAddressIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view)
 {
-    if (!g_addressindex) return;
+    if (!m_address_index_enabled) return;
 
     LOCK(cs);
     const CTransaction& tx = entry.GetTx();
@@ -604,7 +600,7 @@ void CTxMemPool::removeAddressIndex(const uint256 txhash)
 
 void CTxMemPool::addSpentIndex(const CTxMemPoolEntry& entry, const CCoinsViewCache& view)
 {
-    if (!g_spentindex) return;
+    if (!m_spent_index_enabled) return;
 
     LOCK(cs);
 
@@ -1792,7 +1788,6 @@ void CTxMemPool::SetLoadTried(bool load_tried)
     LOCK(cs);
     m_load_tried = load_tried;
 }
-
 
 std::string RemovalReasonToString(const MemPoolRemovalReason& r) noexcept
 {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -598,6 +598,8 @@ public:
     const bool m_permit_bare_multisig;
     const std::optional<unsigned> m_max_datacarrier_bytes;
     const bool m_require_standard;
+    const bool m_address_index_enabled;
+    const bool m_spent_index_enabled;
 
     const Limits m_limits;
 

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -29,6 +29,9 @@ EXPECTED_BITCOIN_CIRCULAR_DEPENDENCIES = (
 )
 
 EXPECTED_DASH_CIRCULAR_DEPENDENCIES = (
+    "index/addressindex -> index/base -> node/context -> index/addressindex",
+    "index/base -> node/context -> index/spentindex -> index/base",
+    "index/base -> node/context -> index/timestampindex -> index/base",
     "banman -> common/bloom -> evo/assetlocktx -> llmq/quorumsman -> llmq/blockprocessor -> net -> banman",
     "coinjoin/client -> coinjoin/util -> wallet/wallet -> psbt -> node/transaction -> net_processing -> coinjoin/walletman -> coinjoin/client",
     "common/bloom -> evo/assetlocktx -> llmq/commitment -> evo/deterministicmns -> evo/simplifiedmns -> merkleblock -> common/bloom",


### PR DESCRIPTION
## Issue being fixed or feature implemented
`AddressIndex`, `SpentIndex`, and `TimestampIndex` are the last Dash-specific indexes still owned by process-global `std::unique_ptr`s (`g_addressindex`, `g_spentindex`, `g_timestampindex`). Global ownership prevents running multiple node contexts in tests, hides the mempool's dependency on index configuration behind re-declared externs, and relies on global teardown ordering. This moves them into `node::NodeContext`, following the same direction as #7546 (`CDSNotificationInterface`).

## What was done?
Three commits, each self-contained:

1. **`refactor: replace mempool's index-global checks with explicit enable flags`** — `CTxMemPool::addAddressIndex`/`addSpentIndex` only used `g_addressindex`/`g_spentindex` (via forward-declared externs in `txmempool.cpp`) as enable flags for the mempool's own in-memory maps. Those checks are now `m_address_index_enabled`/`m_spent_index_enabled` bools on the mempool, populated from `-addressindex`/`-spentindex` via `kernel::MemPoolOptions` in `ApplyArgsManOptions`. Since index creation is gated by exactly the same args, behavior is identical, and the extern re-declaration hack is deleted.
2. **`refactor: pass SpentIndex into TxToJSON instead of reading a global`** — `TxToJSON` is a free function with no access to the request context; it now takes `const SpentIndex*` and callers (`getrawtransaction`, `getrawtransactionmulti`, `getspecialtxes`) pass it in.
3. **`refactor: move address/spent/timestamp indexes into NodeContext`** — the three `unique_ptr`s become `NodeContext` members. Creation/`Start()` (init step 8), `Interrupt()`, and `PrepareShutdown()` operate on the members in the same positions and order as before (in particular, indexes are still stopped only after the second `FlushBackgroundCallbacks()`). RPC handlers reach them via `EnsureAnyNodeContext(request.context)`; all user-visible error strings are unchanged. The globals are deleted.

Notes for reviewers:

- Three new entries in `test/lint/lint-circular-dependencies.py` are deliberate: `node/context.cpp` must include the index headers so `NodeContext`'s out-of-line destructor can delete the `unique_ptr` members, and `index/base.cpp` already includes `node/context.h`. This is the same module-level cycle shape as the pre-existing tolerated `index/base -> node/context -> net_processing -> index/txindex -> index/base` entry. These entries would collapse if/when the tree adopts upstream's `node.indexes` ownership for the remaining index globals (`g_txindex`, `g_coin_stats_index`, blockfilter indexes), which is a natural follow-up.
- The indexes are declared last in `NodeContext`, so they are destroyed first — before anything they depend on.

## How Has This Been Tested?
Built locally on macOS (autotools). `feature_addressindex.py`, `feature_spentindex.py`, `feature_timestampindex.py` all pass (these cover the moved query paths, the mempool overlays of `getaddressmempool`/`getspentinfo`, and `getrawtransaction` spent-info output). `test/lint/lint-circular-dependencies.py` and `test/lint/lint-whitespace.py` pass.

## Breaking Changes
None. RPC behavior, error messages, and startup/shutdown ordering are unchanged.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
