### PR TITLE
ci: remove temporary linux64_ubsan workaround following #7503

### DIFF
--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -32,12 +32,6 @@ elif [ "$BUILD_TARGET" = "linux64_sqlite" ]; then
   source ./ci/test/00_setup_env_native_sqlite.sh
 elif [ "$BUILD_TARGET" = "linux64_tsan" ]; then
   source ./ci/test/00_setup_env_native_tsan.sh
-elif [ "$BUILD_TARGET" = "linux64_ubsan" ]; then
-  # TODO: remove it when #7503 will get merged. That's a temporary workaround to check asan on CI
-  # Compatibility for pull_request_target workflows that still request the legacy target.
-  # Their default-branch container setup does not grant SYS_PTRACE.
-  export ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
-  source ./ci/test/00_setup_env_native_asan.sh
 elif [ "$BUILD_TARGET" = "linux64_valgrind" ]; then
   source ./ci/test/00_setup_env_native_valgrind.sh
 elif [ "$BUILD_TARGET" = "mac" ]; then


### PR DESCRIPTION
## Issue being fixed or feature implemented
Follow-up to PR #7503. Removes the temporary CI matrix workaround for `linux64_ubsan` that mapped `linux64_ubsan` to `00_setup_env_native_asan.sh` while testing #7503 before merge.

## What was done?
Removed the `elif [ "$BUILD_TARGET" = "linux64_ubsan" ]; then` workaround block in `ci/dash/matrix.sh`.

## How Has This Been Tested?
Ran `test/lint/lint-shell.py` locally.

This pull request was created by Codex.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
