### PR TITLE
fix: gate BLS vote-signature failure log behind gobject category

### DIFF
--- a/src/governance/object.cpp
+++ b/src/governance/object.cpp
@@ -408,7 +408,7 @@ bool CGovernanceObject::ProcessVote(CMasternodeMetaMan& mn_metaman, bool fRateCh
     if (eSignal < VOTE_SIGNAL_NONE || eSignal >= VOTE_SIGNAL_UNKNOWN) {
         std::string msg{strprintf("CGovernanceObject::%s -- Unsupported vote signal: %s", __func__,
             CGovernanceVoting::ConvertSignalToString(vote.GetSignal()))};
-        LogPrintf("%s\n", msg);
+        LogPrint(BCLog::GOBJECT, "%s\n", msg);
         exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
         return false;
     }
@@ -459,7 +459,7 @@ bool CGovernanceObject::ProcessVote(CMasternodeMetaMan& mn_metaman, bool fRateCh
         std::string msg{strprintf("CGovernanceObject::%s -- Invalid vote, MN outpoint = %s, governance object hash = %s, "
                                   "vote hash = %s",
             __func__, vote.GetMasternodeOutpoint().ToStringShort(), GetHash().ToString(), vote.GetHash().ToString())};
-        LogPrintf("%s\n", msg);
+        LogPrint(BCLog::GOBJECT, "%s\n", msg);
         exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
         return false;
     }

--- a/src/governance/vote.cpp
+++ b/src/governance/vote.cpp
@@ -201,7 +201,7 @@ bool CGovernanceVote::CheckSignature(const CBLSPublicKey& pubKey) const
     sig.SetBytes(vchSig, false);
     const bool valid{sig.VerifyInsecure(pubKey, sigHash, false)};
     if (!valid) {
-        LogPrintf("CGovernanceVote::CheckSignature -- VerifyInsecure() failed\n");
+        LogPrint(BCLog::GOBJECT, "CGovernanceVote::CheckSignature -- VerifyInsecure() failed\n");
     }
 
     m_sig_memo.Store(fingerprint, valid);


### PR DESCRIPTION
## Issue being fixed or feature implemented
In `CGovernanceVote::CheckSignature(const CBLSPublicKey&)` (`src/governance/vote.cpp`), a signature verification failure was logged unconditionally via `LogPrintf` instead of `LogPrint(BCLog::GOBJECT, ...)`, unlike key ID signature verification and the rest of vote validation.
After PR #7527 (orphan governance votes must pass `GovernanceVote::IsValid` before caching), a peer holding a valid masternode outpoint (public data) plus an invalid BLS signature can reach this path with a vote naming an arbitrary parent hash, producing a `debug.log` line per message without `-debug=gobject` set.

Similarly, `CGovernanceObject::ProcessVote` (`src/governance/object.cpp`) logged unsupported vote signals and invalid votes via unconditional `LogPrintf`.

## What was done?
Updated the unconditional `LogPrintf` calls in `CGovernanceVote::CheckSignature` and `CGovernanceObject::ProcessVote` to use `LogPrint(BCLog::GOBJECT, ...)`.

- `src/governance/vote.cpp`: `CGovernanceVote::CheckSignature(const CBLSPublicKey&)`
- `src/governance/object.cpp`: `CGovernanceObject::ProcessVote` (unsupported vote signal and invalid vote paths)

## How Has This Been Tested?
- Built locally with dependencies prefix.
- Unit tests (`./src/test/test_dash --run_test="*gov*"`) pass.
- Log and whitespace linters (`test/lint/lint-logs.py`, `test/lint/lint-whitespace.py`) pass.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

This pull request was created by Codex.
