### PR TITLE
test: suppress TSan data race in mimalloc metadata allocator

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -38,6 +38,11 @@ deadlock:src/qt/test/*
 deadlock:libdb
 race:libzmq
 
+# Data race in mimalloc metadata allocator during concurrent BLS worker thread execution
+# https://github.com/dashpay/dash/issues/7558
+race:_mi_meta_zalloc
+race:_mi_heap_init
+
 # Race in headers only Boost Test
 race:std::__1::ios_base::flags
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes #7558.

Suppresses a ThreadSanitizer data race between `_mi_meta_zalloc` (`memset`) and `_mi_heap_init` (`memcpy`) in `mimalloc` during concurrent BLS worker thread execution in `test_dash`.

## What was done?
Added `race:_mi_meta_zalloc` and `race:_mi_heap_init` suppressions to `test/sanitizer_suppressions/tsan`.

## How Has This Been Tested?
Validated suppression syntax against `test/sanitizer_suppressions/tsan` and ran `python3 test/lint/lint-whitespace.py`.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

This pull request was created by Codex.
