### PR TITLE
test: narrow Qt and BDB LSan suppressions

### DIFF
--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -12,7 +12,9 @@ source ./ci/test/00_setup_env.sh
 
 # Configure sanitizers options
 export ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
-export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan"
+# depends libraries omit frame pointers, so use DWARF unwinding to reach
+# dependency-specific suppression frames instead of matching allocators.
+export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan:fast_unwind_on_malloc=0"
 export TSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/tsan:halt_on_error=1:second_deadlock_stack=1"
 export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -17,6 +17,7 @@ import re
 import subprocess
 import tempfile
 import time
+import unittest
 import urllib.parse
 import shlex
 import collections
@@ -37,6 +38,7 @@ from .util import (
     get_auth_cookie,
     get_rpc_proxy,
     rpc_url,
+    split_lsan_suppression_summary,
     wait_until_helper,
     p2p_port,
     get_chain_folder,
@@ -53,6 +55,38 @@ class ErrorMatch(Enum):
     FULL_TEXT = 1
     FULL_REGEX = 2
     PARTIAL_REGEX = 3
+
+
+class TestFrameworkTestNode(unittest.TestCase):
+    def test_split_lsan_suppression_summary(self):
+        separator = '-' * 53
+        summary = (
+            f'\n{separator}\nSuppressions used:\n  count      bytes template\n'
+            '      1        160 __lock_open\n'
+            '     28       1939 __memp_fopen\n'
+            f'{separator}\n\n'
+        )
+        application_stderr = 'Error: expected failure\nunexpected application output'
+
+        self.assertEqual(
+            split_lsan_suppression_summary(application_stderr + summary),
+            (application_stderr, [('__lock_open', 1, 160), ('__memp_fopen', 28, 1939)]),
+        )
+        self.assertEqual(
+            split_lsan_suppression_summary(summary[1:]),
+            ('', [('__lock_open', 1, 160), ('__memp_fopen', 28, 1939)]),
+        )
+        self.assertEqual(
+            split_lsan_suppression_summary(summary[1:].strip()),
+            ('', [('__lock_open', 1, 160), ('__memp_fopen', 28, 1939)]),
+        )
+        self.assertEqual(
+            split_lsan_suppression_summary(application_stderr),
+            (application_stderr, None),
+        )
+
+        malformed = (application_stderr + summary).replace('      1        160', 'invalid')
+        self.assertEqual(split_lsan_suppression_summary(malformed), (malformed, None))
 
 
 class TestNode():
@@ -627,11 +661,15 @@ class TestNode():
             report_cmd = "perf report -i {}".format(output_path)
             self.log.info("See perf output by running '{}'".format(report_cmd))
 
-    def assert_start_raises_init_error(self, extra_args=None, expected_msg=None, match=ErrorMatch.FULL_TEXT, *args, **kwargs):
+    def assert_start_raises_init_error(
+            self, extra_args=None, expected_msg=None, match=ErrorMatch.FULL_TEXT, *args,
+            expected_lsan_suppressions=None, **kwargs):
         """Attempt to start the node and expect it to raise an error.
 
         extra_args: extra arguments to pass through to dashd
         expected_msg: regex that stderr should match when dashd fails
+        expected_lsan_suppressions: optional list of (template, count, bytes)
+            entries permitted in a trailing LeakSanitizer suppression summary
 
         Will throw if dashd starts without an error.
         Will throw if an expected_msg is provided and it does not match dashd's stdout."""
@@ -649,6 +687,12 @@ class TestNode():
                 if expected_msg is not None:
                     log_stderr.seek(0)
                     stderr = log_stderr.read().decode('utf-8').strip()
+                    if expected_lsan_suppressions is not None:
+                        stderr, lsan_suppressions = split_lsan_suppression_summary(stderr)
+                        if lsan_suppressions is not None and lsan_suppressions != expected_lsan_suppressions:
+                            self._raise_assertion_error(
+                                'Expected LSan suppressions {} do not match stderr suppressions {}'.format(
+                                    expected_lsan_suppressions, lsan_suppressions))
                     if match == ErrorMatch.PARTIAL_REGEX:
                         if re.search(expected_msg, stderr, flags=re.MULTILINE) is None:
                             self._raise_assertion_error(

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -25,6 +25,31 @@ from typing import Callable, Optional
 
 logger = logging.getLogger("TestFramework.utils")
 
+
+def split_lsan_suppression_summary(stderr):
+    separator = '-' * 53
+    header = f'{separator}\nSuppressions used:\n  count      bytes template\n'
+    if stderr.startswith(header):
+        application_stderr, summary = '', stderr[len(header):]
+    else:
+        marker = f'\n{header}'
+        if marker not in stderr:
+            return stderr, None
+        application_stderr, summary = stderr.rsplit(marker, 1)
+    footer = f'\n{separator}'
+    footer_index = summary.rfind(footer)
+    if footer_index == -1 or summary[footer_index + len(footer):] not in ('', '\n', '\n\n'):
+        return stderr, None
+
+    suppressions = []
+    for row in summary[:footer_index].splitlines():
+        match = re.fullmatch(r'\s*(\d+)\s+(\d+)\s+(\S+)', row)
+        if match is None:
+            return stderr, None
+        suppressions.append((match[3], int(match[1]), int(match[2])))
+    return application_stderr, suppressions
+
+
 # Assert functions
 ##################
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -85,6 +85,7 @@ TEST_FRAMEWORK_MODULES = [
     "crypto.ripemd160",
     "script",
     "segwit_addr",
+    "test_node",
 ]
 
 EXTENDED_SCRIPTS = [

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -15,6 +15,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     sha256sum_file,
+    split_lsan_suppression_summary,
 )
 
 class ToolWalletTest(BitcoinTestFramework):
@@ -37,17 +38,23 @@ class ToolWalletTest(BitcoinTestFramework):
 
         return subprocess.Popen([self.options.bitcoinwallet] + default_args + list(args), stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
+    def strip_expected_lsan_summary(self, stderr):
+        stderr, lsan_suppressions = split_lsan_suppression_summary(stderr)
+        if lsan_suppressions not in (None, [('__lock_open', 1, 160)]):
+            raise AssertionError('Unexpected LSan suppressions {}'.format(lsan_suppressions))
+        return stderr
+
     def assert_raises_tool_error(self, error, *args):
         p = self.dash_wallet_process(*args)
         stdout, stderr = p.communicate()
         assert_equal(p.poll(), 1)
         assert_equal(stdout, '')
-        assert_equal(stderr.strip(), error)
+        assert_equal(self.strip_expected_lsan_summary(stderr).strip(), error)
 
     def assert_tool_output(self, output, *args):
         p = self.dash_wallet_process(*args)
         stdout, stderr = p.communicate()
-        assert_equal(stderr, '')
+        assert_equal(self.strip_expected_lsan_summary(stderr), '')
         assert_equal(stdout, output)
         assert_equal(p.poll(), 0)
 

--- a/test/functional/wallet_dust_protection.py
+++ b/test/functional/wallet_dust_protection.py
@@ -231,12 +231,14 @@ class WalletDustProtectionTest(BitcoinTestFramework):
         self.nodes[3].assert_start_raises_init_error(
             ["-dustprotectionthreshold=-1"],
             "Error: Invalid value for -dustprotectionthreshold: must be >= 0",
+            expected_lsan_suppressions=[('__lock_open', 1, 160)],
         )
 
         # Above maximum (1000000)
         self.nodes[3].assert_start_raises_init_error(
             ["-dustprotectionthreshold=1000001"],
             "Error: Invalid value for -dustprotectionthreshold: exceeds maximum (1000000)",
+            expected_lsan_suppressions=[('__lock_open', 1, 160)],
         )
 
         # Restart node3 normally for clean state

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -38,7 +38,11 @@ class WalletHDTest(BitcoinTestFramework):
         hardened = "h" if self.options.descriptors else "'"
         # Make sure can't switch off usehd after wallet creation
         self.stop_node(1)
-        self.nodes[1].assert_start_raises_init_error(['-usehd=0'], "Error: Error loading %s: You can't disable HD on an already existing HD wallet" % self.default_wallet_name)
+        self.nodes[1].assert_start_raises_init_error(
+            ['-usehd=0'],
+            "Error: Error loading %s: You can't disable HD on an already existing HD wallet" % self.default_wallet_name,
+            expected_lsan_suppressions=[('__lock_open', 1, 160)],
+        )
         self.start_node(1)
         self.connect_nodes(0, 1)
 

--- a/test/sanitizer_suppressions/lsan
+++ b/test/sanitizer_suppressions/lsan
@@ -2,3 +2,9 @@
 leak:libQt5Widgets
 leak:QDBusConnectionPrivate
 leak:QLayoutPrivate
+# Qt's process-global DBus manager retains these allocations at shutdown.
+leak:QDBusConnectionManager
+# Berkeley DB 4.8 retains DB_PRIVATE lock objects after reopened environments
+# are torn down, and memory-pool file metadata after mock databases are closed.
+leak:__lock_open
+leak:__memp_fopen


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Linux ASan job exposed two independent dependency-owned lifetime reports:

1. Qt's process-global DBus connection manager retains 86 bytes across four allocations at shutdown. The same `QDBusConnectionManager::executeConnectionRequest` report appears on unrelated `develop`-based PRs.
2. Berkeley DB 4.8 retains DB_PRIVATE lock objects after reopened environments are torn down and memory-pool file metadata after mock databases are closed.

The previous branch suppressed Berkeley DB's shared `__os_malloc` allocator and changed Dash wallet environment lifecycle code. The allocator rule was too broad, and the production changes were not the cause of either retained allocation. LeakSanitizer also appends a suppression summary to subprocess stderr, breaking exact stderr checks in `wallet_hd.py` and `tool_wallet.py`.

## What was done?

- Enabled DWARF allocation unwinding for LSan so optimized depends libraries expose stable dependency frames.
- Added narrow rules for `QDBusConnectionManager`, `__lock_open`, and `__memp_fopen`; removed the shared `__os_malloc` rule.
- Restored the original Berkeley DB production lifecycle behavior.
- Added a strict shared parser for a structured trailing LSan suppression summary.
- Added an opt-in `assert_start_raises_init_error()` parameter for startup-error tests and made `wallet_hd.py` declare its exact `__lock_open / 1 allocation / 160 bytes` entry.
- Made successful `dash-wallet` subprocess checks accept only that same exact BDB summary when present. Application stderr, malformed summaries, and different suppression rows still fail.
- Added framework regression coverage for valid, absent, and malformed summaries.

## How Has This Been Tested?

On current `develop` with the configured macOS depends tree:

- `make -j13`
- `./src/test/test_dash --run_test=wallet_tests`
- `QT_QPA_PLATFORM=cocoa ./src/qt/test/test_dash-qt` (full app and wallet cases, no skips)
- `test/functional/test_runner.py wallet_hd.py` (descriptor and legacy modes)
- `python3 -m unittest test_framework.test_node`
- Python, shell, and whitespace lint (Python lint reports flake8 unavailable locally; the framework unit test imports and executes the changed Python)
- Independent code review and simplification passes

Using the exact `linux64_asan` artifact from failed job 93167272068 in an x86 CI-faithful container:

- Wallet tests pass with exactly 4 allocations / 640 bytes matched by `__lock_open`.
- Benchmark sanity passes with exactly 28 allocations / 1,939 bytes matched by `__memp_fopen`.
- `wallet_hd.py` passes in descriptor and legacy modes with the final framework code and suppression file mounted in.
- Qt tests pass with the narrow Qt rules. Historical unrelated CI jobs 92994161462 and 92967635309 independently reproduce the same DBus-owned 86-byte report.

The next ASan cycle additionally demonstrated that both `wallet_hd.py` modes pass and that `tool_wallet.py` receives exactly one 160-byte `__lock_open` summary; commit 587108a38280 applies the same strict parsing to that subprocess path.

No generic allocator suppression, disabled leak detection, skipped affected test, diagnostic instrumentation, or production wallet behavior change remains.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_