### PR TITLE
fix: stop caching invalid governance votes

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -63,7 +63,6 @@ GovernanceStore::GovernanceStore() :
     cs_store(),
     mapObjects(),
     mapErasedGovernanceObjects(),
-    cmapInvalidVotes(MAX_CACHE_SIZE),
     cmmapOrphanVotes(MAX_CACHE_SIZE),
     mapLastMasternodeObject(),
     lastMNListForVotingKeys(std::make_shared<CDeterministicMNList>())
@@ -816,14 +815,6 @@ bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceExc
         return false;
     }
 
-    if (cmapInvalidVotes.HasKey(nHashVote)) {
-        std::string msg{strprintf("CGovernanceManager::%s -- Old invalid vote, MN outpoint = %s, governance object hash = %s",
-            __func__, vote.GetMasternodeOutpoint().ToStringShort(), nHashGovobj.ToString())};
-        LogPrint(BCLog::GOBJECT, "%s\n", msg);
-        exception = CGovernanceException(msg, GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
-        return false;
-    }
-
     auto it = mapObjects.find(nHashGovobj);
     if (it == mapObjects.end()) {
         if (!vote.IsValidForUnknownParent(tip_mn_list)) {
@@ -856,8 +847,6 @@ bool CGovernanceManager::ProcessVote(const CGovernanceVote& vote, CGovernanceExc
     bool fOk = govobj.ProcessVote(m_mn_metaman, fRateChecksEnabled, tip_mn_list, vote, exception);
     if (fOk) {
         fOk = cmapVoteToObject.Insert(nHashVote, it->second);
-    } else if (exception.GetType() == GOVERNANCE_EXCEPTION_PERMANENT_ERROR && exception.GetNodePenalty() == 20) {
-        cmapInvalidVotes.Insert(nHashVote, vote);
     }
     return fOk;
 }
@@ -1022,7 +1011,6 @@ void GovernanceStore::Clear()
     LOCK(cs_store);
     mapObjects.clear();
     mapErasedGovernanceObjects.clear();
-    cmapInvalidVotes.Clear();
     cmmapOrphanVotes.Clear();
     mapLastMasternodeObject.clear();
     lastMNListForVotingKeys = std::make_shared<CDeterministicMNList>();
@@ -1169,7 +1157,6 @@ void CGovernanceManager::RemoveInvalidVotes()
             }
             for (const auto& voteHash : removed) {
                 cmapVoteToObject.Erase(voteHash);
-                cmapInvalidVotes.Erase(voteHash);
                 cmmapOrphanVotes.Erase(voteHash);
             }
         }

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -190,7 +190,6 @@ protected:
     //   key   - governance object's hash
     //   value - expiration time for deleted objects
     std::map<uint256, int64_t> mapErasedGovernanceObjects GUARDED_BY(cs_store);
-    CacheMap<uint256, CGovernanceVote> cmapInvalidVotes GUARDED_BY(cs_store);
     vote_cmm_t cmmapOrphanVotes GUARDED_BY(cs_store);
     txout_m_t mapLastMasternodeObject GUARDED_BY(cs_store);
     // used to check for changed voting keys
@@ -204,9 +203,11 @@ public:
     void Serialize(Stream &s) const EXCLUSIVE_LOCKS_REQUIRED(!cs_store)
     {
         LOCK(cs_store);
+        // TODO: Remove the historical invalid-vote-cache field on the next disk-format version bump.
+        const CacheMap<uint256, CGovernanceVote> empty_invalid_votes{MAX_CACHE_SIZE};
         s   << SERIALIZATION_VERSION_STRING
             << mapErasedGovernanceObjects
-            << cmapInvalidVotes
+            << empty_invalid_votes
             << cmmapOrphanVotes
             << mapObjects
             << mapLastMasternodeObject
@@ -225,8 +226,10 @@ public:
             return;
         }
 
+        // TODO: Stop consuming the historical invalid-vote-cache field on the next disk-format version bump.
+        CacheMap<uint256, CGovernanceVote> discarded_invalid_votes;
         s   >> mapErasedGovernanceObjects
-            >> cmapInvalidVotes
+            >> discarded_invalid_votes
             >> cmmapOrphanVotes
             >> mapObjects
             >> mapLastMasternodeObject

--- a/src/test/governance_vote_processing_tests.cpp
+++ b/src/test/governance_vote_processing_tests.cpp
@@ -18,6 +18,7 @@
 #include <netfulfilledman.h>
 #include <primitives/transaction.h>
 #include <script/standard.h>
+#include <streams.h>
 #include <timedata.h>
 #include <uint256.h>
 #include <util/strencodings.h>
@@ -202,6 +203,16 @@ struct GovernanceVoteSetup : public TestChainSetup {
         return vote;
     }
 };
+
+struct TestGovernanceStore : GovernanceStore {
+    using GovernanceStore::last_object_rec;
+
+    size_t ObjectCount() const
+    {
+        LOCK(cs_store);
+        return mapObjects.size();
+    }
+};
 } // namespace
 
 BOOST_FIXTURE_TEST_SUITE(governance_vote_processing_tests, GovernanceVoteSetup)
@@ -280,7 +291,7 @@ BOOST_AUTO_TEST_CASE(unsigned_and_unknown_masternode_votes_are_rejected)
     BOOST_CHECK_EQUAL(exception.GetNodePenalty(), 20);
     BOOST_CHECK(!govman.HaveVoteForHash(forged.GetHash()));
 
-    // Re-sending a vote already known to be invalid is still punished, without re-verifying it.
+    // Re-sending the same invalid vote is still rejected and punished.
     CGovernanceException repeat_exception;
     BOOST_CHECK(!govman.ProcessVote(forged, repeat_exception, hash_to_request));
     BOOST_CHECK_EQUAL(repeat_exception.GetType(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR);
@@ -324,6 +335,47 @@ BOOST_AUTO_TEST_CASE(unsigned_and_unknown_masternode_votes_are_rejected)
     BOOST_REQUIRE(stored != nullptr);
     BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 0);
     BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_VALID), 0);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_signature_does_not_suppress_valid_vote)
+{
+    auto& govman = *m_node.govman;
+    const CGovernanceObject proposal{MakeProposal(uint256::ONE)};
+    const uint256 parent_hash{proposal.GetHash()};
+    govman.AddGovernanceObjectForTesting(proposal);
+    auto stored = govman.FindConstGovernanceObject(parent_hash);
+    BOOST_REQUIRE(stored != nullptr);
+
+    CKey attacker_key;
+    attacker_key.MakeNewKey(true);
+    CGovernanceVote forged{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+    SignWithVotingKey(forged, attacker_key);
+
+    CGovernanceException exception;
+    uint256 hash_to_request;
+    BOOST_CHECK(!govman.ProcessVote(forged, exception, hash_to_request));
+    BOOST_CHECK_EQUAL(exception.GetNodePenalty(), 20);
+
+    CGovernanceVote legitimate{forged};
+    SignWithVotingKey(legitimate, mn_voting_key);
+    BOOST_CHECK_EQUAL(forged.GetHash(), legitimate.GetHash());
+    BOOST_CHECK(govman.ProcessVote(legitimate, exception, hash_to_request));
+    BOOST_CHECK(govman.HaveVoteForHash(legitimate.GetHash()));
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 1);
+
+    CBLSSecretKey attacker_operator_key;
+    attacker_operator_key.MakeNewKey();
+    CGovernanceVote forged_bls{MakeVote(parent_hash, VOTE_SIGNAL_VALID, VOTE_OUTCOME_YES)};
+    SignWithOperatorKey(forged_bls, attacker_operator_key);
+    BOOST_CHECK(!govman.ProcessVote(forged_bls, exception, hash_to_request));
+    BOOST_CHECK_EQUAL(exception.GetNodePenalty(), 20);
+
+    CGovernanceVote legitimate_bls{forged_bls};
+    SignWithOperatorKey(legitimate_bls, mn_operator_key);
+    BOOST_CHECK_EQUAL(forged_bls.GetHash(), legitimate_bls.GetHash());
+    BOOST_CHECK(govman.ProcessVote(legitimate_bls, exception, hash_to_request));
+    BOOST_CHECK(govman.HaveVoteForHash(legitimate_bls.GetHash()));
+    BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_VALID), 1);
 }
 
 // Funding a proposal is the one decision reserved for the voting key; every other signal may be
@@ -379,6 +431,42 @@ BOOST_AUTO_TEST_CASE(proposal_funding_votes_require_the_voting_key)
     BOOST_CHECK(!govman.ProcessVote(funding_by_voting_key, duplicate_exception, hash_to_request));
     BOOST_CHECK_EQUAL(duplicate_exception.GetNodePenalty(), 0);
     BOOST_CHECK_EQUAL(stored->GetAbsoluteYesCount(tip_mn_list(), VOTE_SIGNAL_FUNDING), 1);
+}
+
+BOOST_AUTO_TEST_CASE(legacy_invalid_vote_cache_is_discarded)
+{
+    const uint256 parent_hash{MakeProposal(uint256::ONE).GetHash()};
+    CKey attacker_key;
+    attacker_key.MakeNewKey(true);
+
+    CGovernanceVote forged{MakeVote(parent_hash, VOTE_SIGNAL_FUNDING, VOTE_OUTCOME_YES)};
+    SignWithVotingKey(forged, attacker_key);
+
+    CacheMap<uint256, CGovernanceVote> legacy_invalid_votes{3};
+    legacy_invalid_votes.Insert(forged.GetHash(), forged);
+    const auto proposal = std::make_shared<CGovernanceObject>(MakeProposal(uint256::ONE));
+
+    CDataStream stream{SER_DISK, CLIENT_VERSION};
+    stream << std::string{"CGovernanceManager-Version-16"}
+           << std::map<uint256, int64_t>{}
+           << legacy_invalid_votes
+           << CacheMultiMap<uint256, governance::OrphanVote>{3}
+           << std::map<uint256, std::shared_ptr<CGovernanceObject>>{{proposal->GetHash(), proposal}}
+           << std::map<COutPoint, TestGovernanceStore::last_object_rec>{}
+           << CDeterministicMNList{};
+
+    TestGovernanceStore store;
+    store.Unserialize(stream);
+    BOOST_CHECK_EQUAL(store.ObjectCount(), 1U);
+
+    CDataStream saved{SER_DISK, CLIENT_VERSION};
+    store.Serialize(saved);
+    std::string version;
+    std::map<uint256, int64_t> erased_objects;
+    CacheMap<uint256, CGovernanceVote> saved_invalid_votes;
+    saved >> version >> erased_objects >> saved_invalid_votes;
+    BOOST_CHECK_EQUAL(version, "CGovernanceManager-Version-16");
+    BOOST_CHECK_EQUAL(saved_invalid_votes.GetSize(), 0U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Issue being fixed or feature implemented

Governance cached permanently rejected votes by their semantic vote hash, which excludes the signature. A forged signature cached first could therefore suppress a later legitimate signature over the same vote fields.

The cache did not provide meaningful protection against adaptive verification work: a peer can always produce a fresh cache miss by changing the signature, timestamp, or parent hash. Invalid votes already carry a misbehavior penalty of 20, discouraging a peer after five failures.

## What was done?

- Removed invalid-vote cache lookup and insertion from vote processing.
- Removed the in-memory invalid-vote cache and its key-rotation cleanup.
- Preserved the existing `governance.dat` version and field layout by consuming legacy invalid-cache entries during deserialization and writing the historical field back empty.
- Added ECDSA and BLS regressions proving a forged vote cannot suppress a legitimate vote with the same semantic hash.
- Added persistence coverage proving legacy invalid-cache entries are discarded without losing following governance objects.

Valid-vote inventory and deduplication remain keyed by the existing semantic vote hash.

## How Has This Been Tested?

- `make -j4`
- `./src/test/test_dash --run_test=governance_vote_processing_tests`
- `./src/test/test_dash --run_test=cachemap_tests`
- `make check -j4`
- `test/lint/all-lint.py`

Tested on macOS arm64 using the repository's depends toolchain.

## Breaking Changes

None. This does not change vote serialization, inventory hashes, protocol versions, database versions, consensus rules, or valid-vote deduplication.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
