### PR TITLE
test: fix CoinJoin debug log wait helper

### DIFF
--- a/test/functional/rpc_coinjoin.py
+++ b/test/functional/rpc_coinjoin.py
@@ -112,7 +112,7 @@ class CoinJoinTest(BitcoinTestFramework):
         # cs_wallet_manager_map, so the newkeypool call below, which acquires
         # cs_wallet_manager_map while holding cs_wallet, would abort
         # -DDEBUG_LOCKORDER builds with a potential-deadlock error.
-        with self.nodes[0].wait_for_debug_log([b'Not enough funds to mix.']):
+        with self.nodes[0].busy_wait_for_debug_log([b'Not enough funds to mix.']):
             node.coinjoin('start')
             assert_equal(node.getcoinjoininfo()['running'], True)
         node.newkeypool()


### PR DESCRIPTION
## Issue being fixed or feature implemented

The partial Bitcoin Core #30006 backport renamed `TestNode.wait_for_debug_log()` to `busy_wait_for_debug_log()`, but missed the call in `rpc_coinjoin.py`. The unknown method consequently falls through to RPC dispatch, where serializing the byte-string log message raises `TypeError` and fails the functional test.

## What was done?

Update the CoinJoin functional test to call `busy_wait_for_debug_log()`, matching the renamed binary-log helper.

## How Has This Been Tested?

- `test/functional/rpc_coinjoin.py --legacy-wallet`
- `test/lint/lint-whitespace.py`
- Python byte-compilation of `test/functional/rpc_coinjoin.py`

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
