### PR TITLE
ci: cache cppcheck analysis

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,10 +32,20 @@ jobs:
         run: |
           git config --global --add safe.directory "$PWD"
           git fetch --no-tags -fu origin develop:develop
+          mkdir -p /cache/cppcheck
         shell: bash
+
+      - name: Restore cppcheck cache
+        uses: actions/cache/restore@v5
+        with:
+          path: /cache/cppcheck
+          key: cppcheck-${{ hashFiles('contrib/containers/ci/ci-slim.Dockerfile') }}-${{ github.sha }}
+          restore-keys: |
+            cppcheck-${{ hashFiles('contrib/containers/ci/ci-slim.Dockerfile') }}-
 
       - name: Run linters
         run: |
+          export CACHE_DIR="/cache"
           export BUILD_TARGET="linux64"
           export CHECK_DOC=1
 
@@ -61,4 +71,14 @@ jobs:
           git log --oneline ${COMMIT_RANGE} || echo "Could not show commit range"
 
           ./ci/dash/lint.sh
+          du -sh "${CACHE_DIR}/cppcheck"
         shell: bash
+
+      - name: Save cppcheck cache
+        if: |
+          github.event_name == 'push' &&
+          github.ref_name == github.event.repository.default_branch
+        uses: actions/cache/save@v5
+        with:
+          path: /cache/cppcheck
+          key: cppcheck-${{ hashFiles('contrib/containers/ci/ci-slim.Dockerfile') }}-${{ github.sha }}


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Dash-specific cppcheck lint now performs a real exhaustive analysis, which takes roughly 20–30 minutes from a cold start. Although the linter already writes incremental analysis data through `--cppcheck-build-dir`, the standalone lint workflow discarded that directory after every job.

## What was done?

- Restore the cppcheck analysis directory before running the linters.
- Set `CACHE_DIR` so `lint-cppcheck-dash.py` uses the restored directory.
- Key caches by the slim CI container definition and commit, with a compatible-prefix fallback for incremental reuse.
- Save updated caches after successful pushes to the default branch.
- Report the resulting cache size in the job log for observability.

## How Has This Been Tested?

- Parsed `.github/workflows/lint.yml` with Ruby's YAML parser.
- Ran `test/lint/lint-whitespace.py`.
- Ran `git diff --check`.
- Ran `actionlint`; the modified workflow introduced no new findings. Existing findings for `allow-unsafe-pr-checkout` and existing shell snippets remain unchanged.

The first default-branch run will populate the cache; subsequent runs can reuse unchanged cppcheck translation-unit results.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
