### PR TITLE
perf(crypto): enable configured SHA256 acceleration

### DIFF
--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <crypto/sha256.h>
 #include <crypto/common.h>
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Dash Core's SHA-256 runtime dispatcher did not include the generated configuration header. As a result, it could not see configured `ENABLE_*` feature macros even when the corresponding optimized implementations were built and linked.

On ARM64 this left `CSHA256` using the portable implementation instead of the configured ARMv8 SHA2 implementation. On supported x86 builds it also prevented the dispatcher from selecting configured SHA-NI and multi-way implementations, although the existing single-way SSE4 fallback remained available.

### Regression history

The optimized SHA-256 implementations were inherited from Bitcoin Core and originally worked in Dash because `crypto/sha256.cpp` received the generated configuration macros transitively through `crypto/common.h`.

Bitcoin Core removed that fragile transitive dependency in [bitcoin/bitcoin#29404](https://github.com/bitcoin/bitcoin/pull/29404), merged on February 20, 2024. That PR added explicit `bitcoin-config.h` includes to translation units that consume configuration macros, including the exact include added here to `crypto/sha256.cpp`.

Bitcoin subsequently merged [bitcoin/bitcoin#29263](https://github.com/bitcoin/bitcoin/pull/29263) on March 1, 2024, which removed `bitcoin-config.h` from `crypto/common.h`. This was safe upstream because #29404 had already made the direct dependencies explicit.

Dash backported #29263 in [dashpay/dash#6378](https://github.com/dashpay/dash/pull/6378), merged on February 21, 2025, without first backporting #29404. This removed the only path by which `crypto/sha256.cpp` saw `ENABLE_SSE41`, `ENABLE_AVX2`, `ENABLE_X86_SHANI`, and `ENABLE_ARM_SHANI`, silently disabling those configured runtime selections while preserving correct portable SHA-256 behavior.

The regression is present in Dash Core releases v23.0.0 through v23.1.8. It is therefore a Dash backport dependency gap rather than a defect Bitcoin shipped.

[dashpay/dash#7124](https://github.com/dashpay/dash/pull/7124) is an open, broader backport of Bitcoin #29404 and contains the same `sha256.cpp` hunk among many configuration-include cleanups. This PR intentionally isolates the performance-critical SHA-256 fix so it can land independently.

## What was done?

Include `config/bitcoin-config.h` from `crypto/sha256.cpp` when `HAVE_CONFIG_H` is defined, restoring the exact upstream `sha256.cpp` change from Bitcoin #29404.

Runtime feature detection and the existing SHA-256 self-test remain responsible for selecting and validating the implementation. Builds using `DISABLE_OPTIMIZED_SHA256`, including `libdashconsensus`, remain unaffected.

## How Has This Been Tested?

Tested on Apple Silicon using the depends-based build:

- Full `make` build
- Full `make check`
- Verified startup selection changed from `standard` to `arm_shani(1way,2way)`
- SHA-256 benchmark throughput improved from approximately 562 MB/s to 2.66 GB/s (4.7x)
- A real rust-dashcore full testnet sync through a proxy adding 50 ms in each direction (approximately 100 ms RTT) improved from a 28.402 second median to 22.943 seconds (19.2%) across three measured runs per build

The end-to-end comparison held the testnet data, rust-dashcore revision, proxy configuration, and other Dash Core changes constant; only the generated-config include differed between the two measured builds.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
