### PR TITLE
docs: fix list of dependencies on Arch Linux

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -258,7 +258,7 @@ Setup and Build Example: Arch Linux
 This example lists the steps necessary to setup and build a command line only distribution of the latest changes on Arch Linux:
 
 ```sh
-pacman --sync --needed autoconf automake boost gcc git libbacktrace libevent libtool make pkgconf python sqlite
+pacman --sync --needed autoconf automake boost gcc git libbacktrace libevent libtool make patch pkgconf python sqlite
 git clone https://github.com/dashpay/dash.git
 cd dash/
 ./autogen.sh

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -258,7 +258,7 @@ Setup and Build Example: Arch Linux
 This example lists the steps necessary to setup and build a command line only distribution of the latest changes on Arch Linux:
 
 ```sh
-pacman --sync --needed autoconf automake boost gcc git libbacktrace libevent libtool make patch pkgconf python sqlite
+pacman --sync --needed autoconf automake boost cmake gcc git libbacktrace libevent libtool make patch pkgconf python sqlite
 git clone https://github.com/dashpay/dash.git
 cd dash/
 ./autogen.sh

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -258,7 +258,7 @@ Setup and Build Example: Arch Linux
 This example lists the steps necessary to setup and build a command line only distribution of the latest changes on Arch Linux:
 
 ```sh
-pacman --sync --needed autoconf automake boost cmake gcc git libbacktrace libevent libtool make patch pkgconf python sqlite
+pacman --sync --needed autoconf automake base-devel boost cmake gcc git libbacktrace libevent libtool make patch pkgconf python sqlite
 git clone https://github.com/dashpay/dash.git
 cd dash/
 ./autogen.sh


### PR DESCRIPTION
## Issue being fixed or feature implemented
Some packages are missing in documentation that are required to build Dash Core on fresh installation of Arch linux / Manjaro linux

## What was done?
Added `cmake`, `base-devel`, `patch` to the list of packages necessary to build Dash Core on the latest Arch Linux.

## How Has This Been Tested?
Tested on fresh install.

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

