### PR TITLE
ci: drop Berkeley DB from the asan job, extend the Qt lsan suppressions

### DIFF
--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -7,12 +7,12 @@
 export LC_ALL=C.UTF-8
 
 export CONTAINER_NAME=ci_native_asan
-export PACKAGES="clang-19 llvm-19 libclang-rt-19-dev python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
+export PACKAGES="clang-19 llvm-19 libclang-rt-19-dev python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
 # Reuses the depends built for the linux64 target, which uses the defaults.
 export DEP_OPTS=""
 export TEST_RUNNER_EXTRA="--timeout-factor=4 -j2"  # Increase timeout because sanitizers slow down
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --enable-crash-hooks --with-gui=qt5 \
+export BITCOIN_CONFIG="--enable-zmq --enable-crash-hooks --with-gui=qt5 --without-bdb --with-sqlite \
 --with-sanitizers=address,float-divide-by-zero,integer,undefined \
 CPPFLAGS='-DARENA_DEBUG -DDEBUG_LOCKORDER' \
 CC='clang-19 -ftrivial-auto-var-init=pattern' CXX='clang++-19 -ftrivial-auto-var-init=pattern'"

--- a/test/sanitizer_suppressions/lsan
+++ b/test/sanitizer_suppressions/lsan
@@ -1,4 +1,5 @@
 # Suppress warnings triggered in dependencies
 leak:libQt5Widgets
 leak:QDBusConnectionPrivate
+leak:QDBusConnectionManager
 leak:QLayoutPrivate


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR should replace https://github.com/dashpay/dash/pull/7560/changes
The Linux ASan job exposed two independent dependency-owned lifetime reports:

    Qt's process-global DBus connection manager retains 86 bytes across four allocations at shutdown. The same QDBusConnectionManager::executeConnectionRequest report appears on unrelated develop-based PRs.
    Berkeley DB 4.8 retains DB_PRIVATE lock objects after reopened environments are torn down and memory-pool file metadata after mock databases are closed.

The previous branch suppressed Berkeley DB's shared __os_malloc allocator and changed Dash wallet environment lifecycle code. The allocator rule was too broad, and the production changes were not the cause of either retained allocation. LeakSanitizer also appends a suppression summary to subprocess stderr, breaking exact stderr checks in wallet_hd.py and tool_wallet.py.



## What was done?


For Berkeley DB, do what upstream did in 04a7a7a28c and stop building it in this job. Upstream's asan job carried -DWITH_BDB=ON and libdb5.3++-dev until that commit, ran the same tool_wallet.py and wallet_hd.py, and never needed a Berkeley DB entry in test/sanitizer_suppressions/lsan; the file has never contained one. BerkeleyEnvironment::Close() here is identical to the last upstream version, so the difference is not wallet code but the dependency: upstream linked the system libdb 5.3 shared library, while this job takes DEP_OPTS="" and so links 4.8.30 statically out of depends. The msan job is already configured the same way.

Qt still needs a suppression, and by symbol rather than by module. Upstream suppresses Qt with leak:libQt6Widgets, which only works for a shared library; with Qt linked statically from depends the allocation belongs to the executable and that form cannot match. Upstream hit this in 5be31b20e5 and answered it with per-symbol rules, so add QDBusConnectionManager next to the two symbols already taken from that commit.


## How Has This Been Tested?
N/A

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone