### PR TITLE
fix(rpc): refuse to pay Platform addresses before the v24 hard fork

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -267,6 +267,10 @@ public:
     //! Always false when non-standard transactions are accepted.
     virtual bool isNonStandardSpecialTx(const CTransactionRef& tx, std::string& reason) = 0;
 
+    //! Whether v24 hard fork rules apply to the next block, which is what
+    //! enables version 2 asset lock transactions by consensus.
+    virtual bool isV24Active() = 0;
+
     //! Check if any block has been pruned.
     virtual bool havePruned() = 0;
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -1441,6 +1441,11 @@ public:
         if (!m_node.mempool || !m_node.mempool->m_require_standard) return false;
         return !IsStandardSpecialTx(*tx, reason);
     }
+    bool isV24Active() override
+    {
+        LOCK(::cs_main);
+        return DeploymentActiveAfter(chainman().ActiveChain().Tip(), chainman(), Consensus::DEPLOYMENT_V24);
+    }
     bool havePruned() override
     {
         LOCK(::cs_main);

--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -4,6 +4,7 @@
 
 #include <consensus/validation.h>
 #include <core_io.h>
+#include <interfaces/chain.h>
 #include <key_io.h>
 #include <policy/policy.h>
 #include <rpc/rawtransaction_util.h>
@@ -22,7 +23,7 @@
 #include <map>
 
 namespace wallet {
-static void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_fee_outputs, std::vector<CRecipient>& recipients)
+static void ParseRecipients(interfaces::Chain& chain, const UniValue& address_amounts, const UniValue& subtract_fee_outputs, std::vector<CRecipient>& recipients)
 {
     // A Platform address and a base58 address can encode the same hash, so recipients
     // are deduplicated by the script they pay rather than by the decoded destination.
@@ -39,6 +40,12 @@ static void ParseRecipients(const UniValue& address_amounts, const UniValue& sub
             if (!IsValidPlatformDestination(platform_dest)) {
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY,
                                    strprintf("Invalid Dash address: %s (%s)", address, error_msg));
+            }
+            if (!chain.isV24Active()) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER,
+                                   strprintf("Invalid param for %s, paying a Platform address requires an asset lock "
+                                             "transaction of version 2, which is only valid after v24 activation",
+                                             address));
             }
             script_pub_key = GetScriptForPlatformDestination(platform_dest);
         } else {
@@ -316,7 +323,7 @@ RPCHelpMan sendtoaddress()
     }
 
     std::vector<CRecipient> recipients;
-    ParseRecipients(address_amounts, subtractFeeFromAmount, recipients);
+    ParseRecipients(pwallet->chain(), address_amounts, subtractFeeFromAmount, recipients);
     const bool verbose{request.params[11].isNull() ? false : request.params[11].get_bool()};
 
     return SendMoney(*pwallet, coin_control, recipients, mapValue, verbose);
@@ -412,7 +419,7 @@ RPCHelpMan sendmany()
     SetFeeEstimateMode(*pwallet, coin_control, /*conf_target=*/request.params[8], /*estimate_mode=*/request.params[9], /*fee_rate=*/request.params[10], /*override_min_fee=*/false);
 
     std::vector<CRecipient> recipients;
-    ParseRecipients(sendTo, subtractFeeFromAmount, recipients);
+    ParseRecipients(pwallet->chain(), sendTo, subtractFeeFromAmount, recipients);
     const bool verbose{request.params[11].isNull() ? false : request.params[11].get_bool()};
 
     return SendMoney(*pwallet, coin_control, recipients, std::move(mapValue), verbose);

--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -774,6 +774,12 @@ class AssetLocksTest(DashTestFramework):
             result_expected={'allowed': False, 'reject-reason': 'bad-assetlocktx-version-2'})
         self.log.info("v2 asset lock correctly rejected pre-v24")
 
+        self.log.info("Spending RPCs refuse to pay a Platform address before the fork")
+        assert_raises_rpc_error(-8, "only valid after v24 activation", node_wallet.sendtoaddress,
+                                encode_platform_p2pkh('tdash', hash160(pubkey)), 1)
+        assert_raises_rpc_error(-8, "only valid after v24 activation", node_wallet.sendmany, "",
+                                {encode_platform_p2pkh('tdash', hash160(pubkey)): 1})
+
     def test_asset_locks_v2(self, node_wallet, node, pubkey):
         self.log.info("Testing asset lock v2 after v24 activation...")
         assert softfork_active(node_wallet, 'v24')


### PR DESCRIPTION
## Issue being fixed or feature implemented
Follow-up to #7294. Built on top of that PR's branch; **only the last commit is new here** — please review just `fix(rpc): refuse to pay Platform addresses before the v24 hard fork`.

`sendtoaddress` and `sendmany` build a version 2 asset lock for Platform recipients unconditionally, without checking whether the v24 hard fork has activated. On a node running with `-acceptnonstdtxn=1` — currently the only configuration where Platform sends relay at all, since v2 asset locks are deliberately non-standard — paying a Platform address before v24 activation builds, signs and commits a consensus-invalid transaction (`bad-assetlocktx-version-2`).

That is not a recoverable error today. `CWallet::CommitTransaction` returns `void` and only logs the broadcast failure, so the RPC still returns a txid and the user is left with inputs marked spent, a wallet entry pending forever, a failed rebroadcast every 1-3 hours, and `abandontransaction` as the only way out. On default-policy nodes the standardness pre-flight happens to block it, but with an error suggesting `-acceptnonstdtxn=1`, which pre-fork would only make things worse.

## What was done?
Gated it the same way ProTx RPCs already gate on DIP0003 in `SignAndSendSpecialTx()` (`src/rpc/evo.cpp:434`) — in the RPC layer, not in the wallet, which has never consulted deployment state.

- The check lives in `ParseRecipients`, next to the other Platform-address validation, and throws `RPC_INVALID_PARAMETER` with wording matching the existing `"... requires <version>"` refusals in `src/rpc/evo_util.cpp:97` and `src/rpc/evo.cpp:847`.
- `Chain::isV24Active()` is added because `src/wallet/rpc/` has no direct `ChainstateManager` access — wallet RPCs reach the node only through `interfaces::Chain`.

`ParseRecipients` is the only place in the tree that sets `CRecipient::fPlatformTransfer`; every other `CRecipient` construction uses 3-element aggregate initialisation, and the GUI cannot reach the path at all (`WalletModel::validateAddress` uses `IsValidDestinationString`, which rejects DIP-18 addresses). So the RPC-layer check covers every reachable path today. Worth noting for the Platform GUI work: a future `walletmodel.cpp` path that constructs Platform recipients would reach `CreateTransaction` without passing through `ParseRecipients` and would need the same guard.

## How Has This Been Tested?
Extended `feature_asset_locks.py`: in the pre-v24 section, both `sendtoaddress` and `sendmany` to a Platform address on the permissive (`-acceptnonstdtxn=1`) node must now fail with `-8` instead of committing an unconfirmable transaction. The full file was run end-to-end against a debug build with `-DDEBUG_LOCKORDER` and passes, with no lock-order warnings from the new `cs_wallet` -> `cs_main` call (the same order already used by `chain().havePruned()` at `src/wallet/rpc/backup.cpp:143`). Existing post-fork wallet tests in the same file cover that the gate does not block sends after activation.

## Breaking Changes
None beyond #7294 itself. Paying a Platform address pre-v24 now fails cleanly with `-8` instead of producing a stuck transaction.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
