### PR TITLE
refactor: assumeutxo M3 review follow-ups

### DIFF
--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -11,6 +11,7 @@
 #include <deploymentstatus.h>
 #include <node/blockstorage.h>
 #include <node/caches.h>
+#include <node/utxo_snapshot.h>
 #include <sync.h>
 #include <threadsafety.h>
 #include <tinyformat.h>
@@ -39,9 +40,12 @@ namespace node {
 static bool RecoverSnapshotCleanup(CEvoDB& evodb, const fs::path& data_dir, bilingual_str& error)
 {
     const fs::path normal{data_dir / "chainstate"};
-    const fs::path snapshot{data_dir / "chainstate_snapshot"};
-    const fs::path to_delete{data_dir / "chainstate_todelete"};
-    const fs::path invalid{data_dir / "chainstate_snapshot_INVALID"};
+    fs::path snapshot{normal};
+    snapshot += SNAPSHOT_CHAINSTATE_SUFFIX;
+    fs::path to_delete{normal};
+    to_delete += SNAPSHOT_TODELETE_SUFFIX;
+    fs::path invalid{snapshot};
+    invalid += SNAPSHOT_INVALID_SUFFIX;
 
     uint256 snapshot_tip;
     const bool has_snapshot_tip{evodb.ReadBestBlock(EvoDbIdentity::SNAPSHOT, snapshot_tip)};

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -60,6 +60,14 @@ std::optional<uint256> ReadSnapshotBaseBlockhash(fs::path chaindir)
 //! a snapshot.
 constexpr std::string_view SNAPSHOT_CHAINSTATE_SUFFIX = "_snapshot";
 
+//! Suffix appended to the snapshot chainstate dir when the snapshot fails
+//! validation and the directory is set aside for later inspection.
+constexpr std::string_view SNAPSHOT_INVALID_SUFFIX = "_INVALID";
+
+//! Suffix appended to the background chainstate dir while a fully validated
+//! snapshot chainstate is moved into its place.
+constexpr std::string_view SNAPSHOT_TODELETE_SUFFIX = "_todelete";
+
 
 //! Return a path to the snapshot-based chainstate dir, if one exists.
 std::optional<fs::path> FindSnapshotChainstateDir();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3848,9 +3848,10 @@ void Chainstate::ResetBlockFailureFlags(CBlockIndex *pindex, bool ignore_chainlo
 
     // Failure flags and m_best_invalid are shared by all chainstates, so
     // candidate admission must be recomputed for all of them as well.
+    const auto chainstates{m_chainman.GetAll()};
     for (CBlockIndex* reconsidered : reconsidered_blocks) {
         if (!reconsidered->IsValid(BLOCK_VALID_TRANSACTIONS) || !reconsidered->HaveTxsDownloaded()) continue;
-        for (Chainstate* chainstate : m_chainman.GetAll()) {
+        for (Chainstate* chainstate : chainstates) {
             chainstate->TryAddBlockIndexCandidate(reconsidered);
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -6097,7 +6097,6 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation(
     int curr_height = m_ibd_chainstate->m_chain.Height();
 
     assert(snapshot_base_height == curr_height);
-    assert(snapshot_base_height == index_new.nHeight);
     assert(this->IsUsable(m_snapshot_chainstate.get()));
     assert(this->GetAll().size() == 2);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -6404,7 +6404,8 @@ util::Result<void> Chainstate::InvalidateCoinsDBOnDisk()
     // Coins views no longer usable.
     m_coins_views.reset();
 
-    auto invalid_path = snapshot_datadir + "_INVALID";
+    fs::path invalid_path{snapshot_datadir};
+    invalid_path += node::SNAPSHOT_INVALID_SUFFIX;
     std::string dbpath = fs::PathToString(snapshot_datadir);
     std::string target = fs::PathToString(invalid_path);
     LogPrintf("[snapshot] renaming snapshot datadir %s to %s\n", dbpath, target);
@@ -6486,7 +6487,8 @@ bool ChainstateManager::ValidatedSnapshotCleanup()
     LogPrintf("[snapshot] deleting background chainstate directory (now unnecessary) (%s)\n",
               fs::PathToString(ibd_chainstate_path));
 
-    fs::path tmp_old{ibd_chainstate_path + "_todelete"};
+    fs::path tmp_old{ibd_chainstate_path};
+    tmp_old += node::SNAPSHOT_TODELETE_SUFFIX;
 
     auto rename_failed_abort = [](
                                    fs::path p_old,


### PR DESCRIPTION
## Issue being fixed or feature implemented
Review of the assumeutxo M3 PR (#7553, now merged) surfaced three small non-blocking cleanups. They were split out so #7553 could merge as-is:

1. `RecoverSnapshotCleanup()` re-spelled all four snapshot-lifecycle directory names as string literals while the rename sites derived them from `SNAPSHOT_CHAINSTATE_SUFFIX` or inlined them. A rename of any suffix would compile cleanly while crash recovery silently stopped matching the on-disk layout.
2. The candidate-admission pass in `ResetBlockFailureFlags()` called `ChainstateManager::GetAll()` inside the per-block loop, re-acquiring `cs_main` recursively and heap-allocating a vector per reconsidered block even though the chainstate set cannot change while `cs_main` is held for the whole function.
3. `MaybeCompleteSnapshotValidation()` carried `assert(snapshot_base_height == index_new.nHeight)` four lines after asserting the same equality.

## What was done?
- Added `SNAPSHOT_INVALID_SUFFIX` and `SNAPSHOT_TODELETE_SUFFIX` next to `SNAPSHOT_CHAINSTATE_SUFFIX` in `node/utxo_snapshot.h` and consume them in `RecoverSnapshotCleanup()`, `InvalidateCoinsDBOnDisk()`, and `ValidatedSnapshotCleanup()`. Test files intentionally keep spelled-out literals so they would catch an accidental rename of the on-disk names.
- Hoisted the `GetAll()` call above the admission loop.
- Dropped the duplicated assert.

## How Has This Been Tested?
Both touched translation units compile with `--enable-werror`. No behavior change is intended; the existing `validation_chainstatemanager_tests` snapshot-recovery cases cover the renamed-directory handling.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

