### PR TITLE
fix: avoid maybe-uninitialized warning in ScopedBLSLegacyScheme

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -161,12 +161,16 @@ namespace {
 class ScopedBLSLegacyScheme
 {
 public:
-    explicit ScopedBLSLegacyScheme(std::optional<bool> enter = std::nullopt) noexcept :
+    ScopedBLSLegacyScheme() noexcept :
         m_saved(bls::bls_legacy_scheme.load())
     {
-        if (enter.has_value() && *enter != m_saved) {
-            bls::bls_legacy_scheme.store(*enter);
-            LogPrintf("ScopedBLSLegacyScheme: entered bls_legacy_scheme=%d\n", *enter);
+    }
+    explicit ScopedBLSLegacyScheme(bool enter) noexcept :
+        m_saved(bls::bls_legacy_scheme.load())
+    {
+        if (enter != m_saved) {
+            bls::bls_legacy_scheme.store(enter);
+            LogPrintf("ScopedBLSLegacyScheme: entered bls_legacy_scheme=%d\n", enter);
         }
     }
     ~ScopedBLSLegacyScheme() noexcept


### PR DESCRIPTION
## Issue being fixed or feature implemented

`develop` is currently red: the `linux64_nowallet` build fails with

```
validation.cpp:167:34: error: 'enter' may be used uninitialized [-Werror=maybe-uninitialized]
```

GCC 14 at `-O2` (the nowallet job's compiler) loses track of the `has_value()` check guarding the `std::optional<bool>` payload read in `ScopedBLSLegacyScheme`'s constructor when the guard is default-constructed from `ConnectTip`. Introduced by 311efbc18149; every PR based on the current tip inherits the failure.

## What was done?

Replaced the `std::optional<bool>` constructor parameter with a default constructor and an explicit `bool` constructor. Both existing value-passing call sites already pass a plain `bool` (`!DeploymentActiveAt(...)`), so no caller changes; the optional deref the warning pointed at no longer exists. No behavior change.

The asan `test_dash-qt` QThread leak that was briefly bundled here has been split into its own PR per review feedback, so this PR is only the build fix.

## How Has This Been Tested?

- Local build (clang, macOS) clean; `test_dash --run_test=evo_dip3_activation_tests` and `bls_tests` pass.
- The failing configuration is GCC 14 `-Werror` in the `linux64_nowallet` CI job — this PR's CI run is the authoritative check.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
