### PR TITLE
fix(util): handle the UINT64_MAX-containing range in CRangesSet

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1423,6 +1423,35 @@ BOOST_AUTO_TEST_CASE(test_CRanges)
             BOOST_CHECK(ranges.Size() > ((1u << test) / 4));
         }
     }
+
+    // The range containing UINT64_MAX is stored with a wrapped half-open end
+    // of 0. Membership, sizing, duplicate detection, and removal must all
+    // treat that representation as "extends through the maximum value".
+    const uint64_t max{std::numeric_limits<uint64_t>::max()};
+    CRangesSet max_values;
+    BOOST_CHECK(max_values.Add(max - 2));
+    BOOST_CHECK(max_values.Add(max - 1));
+    BOOST_CHECK(max_values.Add(max));
+    BOOST_CHECK_EQUAL(max_values.Size(), 3U);
+    BOOST_CHECK(max_values.Contains(max - 2));
+    BOOST_CHECK(max_values.Contains(max - 1));
+    BOOST_CHECK(max_values.Contains(max));
+    BOOST_CHECK(!max_values.Contains(0));
+    BOOST_CHECK(!max_values.Add(max));
+    BOOST_CHECK(max_values.Remove(max));
+    BOOST_CHECK_EQUAL(max_values.Size(), 2U);
+    BOOST_CHECK(max_values.Contains(max - 1));
+    BOOST_CHECK(!max_values.Contains(max));
+    BOOST_CHECK(max_values.Add(max));
+    BOOST_CHECK(max_values.Contains(max));
+
+    CRangesSet lone_max;
+    BOOST_CHECK(lone_max.Add(max));
+    BOOST_CHECK_EQUAL(lone_max.Size(), 1U);
+    BOOST_CHECK(lone_max.Contains(max));
+    BOOST_CHECK(!lone_max.Add(max));
+    BOOST_CHECK(lone_max.Remove(max));
+    BOOST_CHECK(lone_max.IsEmpty());
 }
 
 static std::string SpanToStr(const Span<const char>& span)

--- a/src/util/ranges_set.cpp
+++ b/src/util/ranges_set.cpp
@@ -4,6 +4,8 @@
 
 #include <util/ranges_set.h>
 
+#include <limits>
+
 CRangesSet::Range::Range() : CRangesSet::Range::Range(0, 0) {}
 
 CRangesSet::Range::Range(uint64_t begin_in, uint64_t end_in) :
@@ -81,7 +83,9 @@ size_t CRangesSet::Size() const noexcept
 {
     size_t result{0};
     for (auto i : ranges) {
-        result += i.end - i.begin;
+        // end == 0 is the half-open representation of a range containing
+        // UINT64_MAX. Avoid the unsigned subtraction wrap for that range.
+        result += i.end == 0 ? std::numeric_limits<uint64_t>::max() - i.begin + 1 : i.end - i.begin;
     }
     return result;
 }
@@ -93,5 +97,5 @@ bool CRangesSet::Contains(uint64_t value) const noexcept
     if (it == ranges.begin()) return false;
     auto prev = it;
     --prev;
-    return prev->begin <= value && prev->end > value;
+    return prev->begin <= value && (prev->end == 0 || prev->end > value);
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
`CRangesSet` stores half-open `[begin, end)` ranges of `uint64_t`. Adding `UINT64_MAX` stores `end = UINT64_MAX + 1`, which wraps to `0`, and the rest of the class does not understand that representation:

- `Contains(UINT64_MAX)` returns false for a set that holds it (`prev->end > value` is `0 > UINT64_MAX`), so a duplicate `Add()` walks past the duplicate guard and trips `assert(ret.second)` on the underlying `std::set` insert. Via the asset-unlock duplicate-index check (`src/evo/assetlocktx.cpp:204`), a platform-quorum-signed withdrawal with index `2^64 - 1` would crash the node in `GetCreditPool()` instead of being rejected with `bad-assetunlock-duplicated-index`. Platform assigns withdrawal indexes sequentially, so nothing produces that index today — this is a latent boundary bug, not an exploitable path — but consensus code should reject strange quorum-signed data cleanly, never abort on it.
- `Size()` computes the width of such a range through an unsigned wrap. The wrapped arithmetic happens to produce the right number, but it is exactly the class of intentional-looking overflow that `-fsanitize=integer` flags, and it costs nothing to state the intent explicitly.

This was found while building the bounded snapshot codec for AssumeUTXO M4 (#7579). Per review feedback there (knst), the fix is split out so a small consensus-adjacent change can be reviewed on its own; nothing in it depends on the snapshot work. It is a prerequisite of the M4 series only in the sense that the snapshot codec serializes `CRangesSet` and wants the boundary semantics to be trustworthy.

## What was done?
- `Contains()`: treat `end == 0` as "extends through `UINT64_MAX`".
- `Size()`: compute the width of the wrapped range explicitly instead of relying on modular subtraction.
- Extended the existing `test_CRanges` unit test with boundary coverage: membership, sizing, duplicate detection, removal, and re-add at and around `UINT64_MAX`, plus the single-element `{UINT64_MAX}` set. The new checks fail eight ways against the previous implementation.

## How Has This Been Tested?
`./src/test/test_dash --run_test=util_tests/test_CRanges` — green with the fix; verified the new assertions fail (8 failures) with the fix reverted. Full unit suite run locally on the branch.

## Breaking Changes
None. The serialized encoding of `CRangesSet` is unchanged; only in-memory queries over the wrapped-end representation change, and no currently reachable chain state produces that representation.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
