### PR TITLE
fix: remove every snapshot lifecycle directory on explicit reindex

### DIFF
--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -37,6 +37,35 @@
 #include <vector>
 
 namespace node {
+static bool RemoveSnapshotChainstateArtifacts(const fs::path& data_dir, bilingual_str& error)
+{
+    // Explicit reindexing discards both coins databases and EvoDB, so remove
+    // every snapshot lifecycle directory in the same stroke. A directory must
+    // not outlive the markers that describe it: a chainstate_snapshot dir whose
+    // EvoDB markers were just wiped can no longer be revived by
+    // ActivateExistingSnapshot(), and a reindex is also the user's request to
+    // discard the _INVALID forensics directory and any interrupted-swap
+    // remnant, neither of which the (skipped) recovery pass will see.
+    const fs::path normal{data_dir / "chainstate"};
+    fs::path snapshot{normal};
+    snapshot += SNAPSHOT_CHAINSTATE_SUFFIX;
+    fs::path invalid{snapshot};
+    invalid += SNAPSHOT_INVALID_SUFFIX;
+    fs::path to_delete{normal};
+    to_delete += SNAPSHOT_TODELETE_SUFFIX;
+    for (const auto& path : {snapshot, invalid, to_delete}) {
+        if (!fs::exists(path)) continue;
+        try {
+            RemoveAllDurably(path);
+        } catch (const fs::filesystem_error& e) {
+            error = strprintf(_("Failed to remove snapshot chainstate artifact %s for reindex: %s"),
+                              fs::PathToString(path), e.what());
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool RecoverSnapshotCleanup(CEvoDB& evodb, const fs::path& data_dir, bilingual_str& error)
 {
     const fs::path normal{data_dir / "chainstate"};
@@ -326,6 +355,13 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
 
     LOCK(cs_main);
 
+    if (options.reindex || options.reindex_chainstate) {
+        bilingual_str cleanup_error;
+        if (!RemoveSnapshotChainstateArtifacts(options.data_dir, cleanup_error)) {
+            return {ChainstateLoadStatus::FAILURE, cleanup_error};
+        }
+    }
+
     evodb.reset();
     // TODO: pass DbWrapperParams as options instead multiple params
     evodb = std::make_unique<CEvoDB>(util::DbWrapperParams{
@@ -343,15 +379,6 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
 
     // Load the fully validated chainstate.
     chainman.InitializeChainstate(options.mempool, *evodb, chain_helper);
-
-    // Wiping the shared EvoDB above erased the SNAPSHOT best-block marker that
-    // ActivateExistingSnapshot() requires, so a persisted snapshot chainstate can
-    // no longer be revived. Discard it here rather than letting startup fail with
-    // advice ("reindex") the user has just followed, which would never recover.
-    if ((options.reindex || options.reindex_chainstate) && !DeleteSnapshotChainstateFromDisk()) {
-        return {ChainstateLoadStatus::FAILURE,
-                _("Failed to remove the snapshot chainstate directory. Remove it manually before restarting.")};
-    }
 
     // Load a chain created from a UTXO snapshot, if any exist.
     bilingual_str snapshot_error;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5570,19 +5570,6 @@ static bool DeleteCoinsDBFromDisk(const fs::path db_path, bool is_snapshot)
     return destroyed && !fs::exists(db_path);
 }
 
-bool DeleteSnapshotChainstateFromDisk()
-{
-    AssertLockHeld(::cs_main);
-
-    auto snapshot_datadir = node::FindSnapshotChainstateDir();
-    if (!snapshot_datadir) {
-        return true;
-    }
-    LogPrintf("[snapshot] discarding persisted snapshot chainstate at %s\n",
-              fs::PathToString(*snapshot_datadir));
-    return DeleteCoinsDBFromDisk(*snapshot_datadir, /*is_snapshot=*/true);
-}
-
 bool ChainstateManager::ActivateSnapshot(
         AutoFile& coins_file,
         const SnapshotMetadata& metadata,

--- a/src/validation.h
+++ b/src/validation.h
@@ -1294,16 +1294,6 @@ MnRewardEra GetMnRewardEraAfter(const CBlockIndex* pindexPrev, const ChainstateM
  */
 const AssumeutxoData* ExpectedAssumeutxo(const int height, const CChainParams& params);
 
-/**
- * Remove a persisted snapshot chainstate's on-disk artifacts: its coins database
- * and the base-blockhash file identifying it. Only valid while no snapshot
- * Chainstate object exists, i.e. at startup before DetectSnapshotChainstate().
- *
- * @returns false only if a snapshot chainstate was found but could not be fully
- *          removed; true when there was nothing to remove.
- */
-bool DeleteSnapshotChainstateFromDisk() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-
 /** Identifies blocks that overwrote an existing coinbase output in the UTXO set (see BIP30) */
 bool IsBIP30Repeat(const CBlockIndex& block_index);
 

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -11,6 +11,7 @@
 """
 
 import os
+from pathlib import Path
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import MAGIC_BYTES
 from test_framework.util import assert_equal
@@ -25,9 +26,19 @@ class ReindexTest(BitcoinTestFramework):
         self.generatetoaddress(self.nodes[0], 3, self.nodes[0].get_deterministic_priv_key().address)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
+        chain_dir = Path(self.nodes[0].datadir) / self.nodes[0].chain
+        snapshot_artifacts = [
+            chain_dir / "chainstate_snapshot",
+            chain_dir / "chainstate_snapshot_INVALID",
+            chain_dir / "chainstate_todelete",
+        ]
+        for artifact in snapshot_artifacts:
+            artifact.mkdir()
+            (artifact / "stale").touch()
         extra_args = [["-reindex-chainstate", "-txindex=0"]] if justchainstate else [["-reindex", f"-txindex={txindex}"]]
         self.start_nodes(extra_args)
         assert_equal(self.nodes[0].getblockcount(), blockcount)  # start_node is blocking on reindex
+        assert all(not artifact.exists() for artifact in snapshot_artifacts)
         self.log.info("Success")
 
     # Check that blocks can be processed out of order


### PR DESCRIPTION
## Issue being fixed or feature implemented
An explicit `-reindex`/`-reindex-chainstate` wipes EvoDB, which destroys the snapshot lifecycle markers (`b_dcs*`, SNAPSHOT best-block) while the directories they describe stay on disk. Today `LoadChainstate` handles only part of that: `chainstate_snapshot` is deleted via `DeleteSnapshotChainstateFromDisk()` after the new EvoDB and chainstate are already constructed, while `chainstate_snapshot_INVALID` (the forensics directory from a failed snapshot) and `chainstate_todelete` (an interrupted-swap remnant) survive the reindex entirely — the recovery pass that knows how to interpret them (`RecoverSnapshotCleanup`) is deliberately skipped when reindexing.

Nothing misbehaves on develop today because detection keys on the now-deleted main directory, but the state it leaves is wrong on its own terms: a reindex is the user's request to rebuild from scratch, and it should not leave stale snapshot artifacts that no longer correspond to any marker. It also matters for the AssumeUTXO series (#7579 decomposition, of which this is an early standalone piece, split out per review feedback there): later milestones grow more startup logic that inspects these directories, and every such consumer is simpler if "reindex ⇒ no snapshot artifacts exist" is an invariant established in one place, before EvoDB is recreated.

## What was done?
- Added `RemoveSnapshotChainstateArtifacts()` in `src/node/chainstate.cpp`: durably (`fs::remove_all` + `DirectoryCommit`) removes `chainstate_snapshot`, `chainstate_snapshot_INVALID`, and `chainstate_todelete`, with the names derived from the shared suffix constants introduced in #7585 rather than re-spelled literals. It runs at the top of `LoadChainstate` under `cs_main` when reindexing, before the EvoDB wipe and chainstate construction.
- Removed `DeleteSnapshotChainstateFromDisk()` (validation.{h,cpp}) — the early cleanup makes it dead code, and this was its only call site. Removing it now also avoids the known dead-code trap a later milestone would otherwise inherit (its post-initialization call could never fire again once the early cleanup exists).
- Extended `feature_reindex.py` to seed all three artifact directories before restarting and assert both reindex flavors remove them. The `_INVALID`/`_todelete` assertions fail against develop's current partial cleanup.

## How Has This Been Tested?
`test/functional/test_runner.py feature_reindex.py` (passes; the new assertions cover both `-reindex` and `-reindex-chainstate`), plus `validation_chainstatemanager_tests` and `evo_db_tests` unit suites. Built with `--enable-werror`.

## Breaking Changes
None. One behavior change by design: `chainstate_snapshot_INVALID` no longer survives an explicit reindex. It exists for post-failure forensics, and a user who reindexes has chosen to rebuild; keeping a forensics directory whose EvoDB context was just destroyed has little diagnostic value.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
