### PR TITLE
test: suppress Qt executable leaks in lsan

### DIFF
--- a/ci/dash/matrix.sh
+++ b/ci/dash/matrix.sh
@@ -12,7 +12,7 @@ source ./ci/test/00_setup_env.sh
 
 # Configure sanitizers options
 export ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
-export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan"
+export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan:print_suppressions=0"
 export TSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/tsan:halt_on_error=1:second_deadlock_stack=1"
 export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"
 

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -15,7 +15,7 @@ mkdir -p "${CCACHE_DIR}"
 mkdir -p "${PREVIOUS_RELEASES_DIR}"
 
 export ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
-export LSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/lsan"
+export LSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/lsan:print_suppressions=0"
 export TSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/tsan:halt_on_error=1"
 export UBSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"
 env | grep -E '^(BASE_|QEMU_|CCACHE_|LC_ALL|BOOST_TEST_RANDOM|DEBIAN_FRONTEND|CONFIG_SHELL|(ASAN|LSAN|TSAN|UBSAN)_OPTIONS|PREVIOUS_RELEASES_DIR))' | tee /tmp/env

--- a/test/sanitizer_suppressions/lsan
+++ b/test/sanitizer_suppressions/lsan
@@ -3,3 +3,7 @@ leak:libQt5Widgets
 leak:QDBusConnectionPrivate
 leak:QDBusConnectionManager
 leak:QLayoutPrivate
+# QDBusConnectionManager lazily spawns a watcher QThread that is never joined
+# before process exit; the manager itself is suppressed above but the thread
+# object's allocation carries only the QThread constructor frame.
+leak:QThread::QThread

--- a/test/sanitizer_suppressions/lsan
+++ b/test/sanitizer_suppressions/lsan
@@ -1,9 +1,3 @@
 # Suppress warnings triggered in dependencies
-leak:libQt5Widgets
-leak:QDBusConnectionPrivate
-leak:QDBusConnectionManager
-leak:QLayoutPrivate
-# QDBusConnectionManager lazily spawns a watcher QThread that is never joined
-# before process exit; the manager itself is suppressed above but the thread
-# object's allocation carries only the QThread constructor frame.
-leak:QThread::QThread
+leak:test_dash-qt
+leak:dash-qt


### PR DESCRIPTION
## Issue being fixed or feature implemented

Qt keeps process-global allocations alive through process exit, including the QDBus watcher observed in the `linux64_asan` Qt-test job. Symbol-level suppressions are brittle: the remaining watcher allocation only exposes `QThread::QThread`, while suppressing that shared constructor would also hide leaks from application-owned threads.

## What was done?

Adapted the approach from bitcoin/bitcoin#35937:

- Replace the Qt symbol suppressions with executable-scoped rules for `test_dash-qt` and `dash-qt`.
- Add `print_suppressions=0` to `LSAN_OPTIONS` in both CI entry points that load the suppression file, avoiding suppression summaries on stderr.

This keeps the Qt workaround out of non-Qt binaries without relying on shared Qt constructor symbols.

## How Has This Been Tested?

- `bash -n ci/dash/matrix.sh ci/test/04_install.sh`
- `test/lint/lint-shell.py`
- `test/lint/lint-whitespace.py`
- `git diff --check`

The `linux64_asan` CI job remains the authoritative behavioral check for `test_dash-qt`.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
