### PR TITLE
fix: make the wrapped successor explicit in CRangesSet under -fsanitize=integer

### DIFF
--- a/src/util/ranges_set.cpp
+++ b/src/util/ranges_set.cpp
@@ -6,6 +6,16 @@
 
 #include <limits>
 
+namespace {
+//! Successor of a value in the half-open range encoding: the range containing
+//! UINT64_MAX stores a wrapped end of 0. Spelled as a branch so the wrap is
+//! explicit intent rather than arithmetic overflow (-fsanitize=integer).
+constexpr uint64_t WrappedSuccessor(uint64_t value) noexcept
+{
+    return value == std::numeric_limits<uint64_t>::max() ? 0 : value + 1;
+}
+} // namespace
+
 CRangesSet::Range::Range() : CRangesSet::Range::Range(0, 0) {}
 
 CRangesSet::Range::Range(uint64_t begin_in, uint64_t end_in) :
@@ -24,7 +34,7 @@ bool CRangesSet::Add(uint64_t value)
     //   all 3 of them should be merged in one range [x, y)
     // - if there's exist a range [x, value) - we need to replace it to new range [x, value + 1)
     // - if there's exist a range [value + 1, y) - we need to replace it to new range [value, y)
-    Range new_range{value, value + 1};
+    Range new_range{value, WrappedSuccessor(value)};
     auto it = ranges.lower_bound({value, value});
     if (it != ranges.begin()) {
         auto prev = it;
@@ -37,7 +47,7 @@ bool CRangesSet::Add(uint64_t value)
     }
     const auto next = it;
     if (next != ranges.end()) {
-        if (next->begin == value + 1) {
+        if (next->begin == WrappedSuccessor(value)) {
             new_range.end = next->end;
             ranges.erase(next);
         }
@@ -67,8 +77,8 @@ bool CRangesSet::Remove(uint64_t value)
         const auto ret = ranges.insert({current_range.begin, value});
         assert(ret.second);
     }
-    if (value + 1 != current_range.end) {
-        const auto ret = ranges.insert({value + 1, current_range.end});
+    if (WrappedSuccessor(value) != current_range.end) {
+        const auto ret = ranges.insert({WrappedSuccessor(value), current_range.end});
         assert(ret.second);
     }
     return true;


### PR DESCRIPTION
## Issue being fixed or feature implemented
**develop's `linux64_asan` job is red since #7587 merged.** The boundary tests merged there exercise `Add(UINT64_MAX)`, whose half-open end `value + 1` intentionally wraps to `0` — the representation the rest of #7587 teaches the class to understand. The asan job builds with `-fsanitize=integer`, which reports the intentional wrap as `unsigned integer overflow: 18446744073709551615 + 1` at `util/ranges_set.cpp:27` and fails `make check`. My verification of #7587 ran the full unit suite but not under sanitizers, which is exactly the gap this slipped through; apologies for the breakage.

## What was done?
Spelled the successor as an explicit branch — a file-local `WrappedSuccessor(value)` (`value == UINT64_MAX ? 0 : value + 1`) — at the three arithmetic sites in `Add()`/`Remove()`. This states the wrap as intent instead of overflow, which is preferable to a sanitizer suppression here: unlike the quorum-snapshot skip-list encoding (suppressed by symbol in eacd9e05fb73 because its wraparound is consensus wire format), this is a private in-memory representation that can simply be written unambiguously.

No behavior change: for every `value != UINT64_MAX` the expression is `value + 1` as before, and for `UINT64_MAX` it produces the same `0` the wrap produced.

## How Has This Been Tested?
Built with `--with-sanitizers=undefined,integer` (the failing job's relevant checks): `util_tests/test_CRanges` reproduces the exact CI failure without the fix and passes with it, using the repo's ubsan suppressions file. Full unit suite green on a regular `--enable-werror` build, rebased on current develop (the `linux64_nowallet` failure visible on this branch's earlier CI was the pre-existing `ScopedBLSLegacyScheme` gcc-14 warning, fixed independently by #7586).

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
