### PR TITLE
feat(qt): identify masternode transactions in history

### DIFF
--- a/doc/release-notes-7595.md
+++ b/doc/release-notes-7595.md
@@ -1,0 +1,9 @@
+GUI changes
+-----------
+
+- Dash-Qt now labels masternode registration and update transactions in the
+  transaction history as **Masternode Registration** and **Masternode Update**
+  instead of generic "Payment to yourself" rows. A new **Masternode** filter
+  shows only these operations. The amount shown is the transaction's net effect
+  on your wallet (for example, the network fee on a self-funded registration).
+  (#7595)

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -16,6 +16,7 @@ TEST_QT_MOC_CPP = \
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += \
   qt/test/moc_addressbooktests.cpp \
+  qt/test/moc_providertransactiontests.cpp \
   qt/test/moc_wallettests.cpp
 endif # ENABLE_WALLET
 
@@ -23,6 +24,7 @@ TEST_QT_H = \
   qt/test/addressbooktests.h \
   qt/test/apptests.h \
   qt/test/optiontests.h \
+  qt/test/providertransactiontests.h \
   qt/test/rpcnestedtests.h \
   qt/test/uritests.h \
   qt/test/util.h \
@@ -45,6 +47,7 @@ qt_test_test_dash_qt_SOURCES = \
 if ENABLE_WALLET
 qt_test_test_dash_qt_SOURCES += \
   qt/test/addressbooktests.cpp \
+  qt/test/providertransactiontests.cpp \
   qt/test/wallettests.cpp \
   wallet/test/wallet_test_fixture.cpp
 endif # ENABLE_WALLET

--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -1,0 +1,383 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/providertransactiontests.h>
+
+#include <interfaces/chain.h>
+#include <interfaces/node.h>
+#include <key.h>
+#include <key_io.h>
+#include <primitives/transaction.h>
+#include <qt/clientmodel.h>
+#include <qt/optionsmodel.h>
+#include <qt/transactionfilterproxy.h>
+#include <qt/transactionrecord.h>
+#include <qt/transactiontablemodel.h>
+#include <qt/transactionview.h>
+#include <qt/walletmodel.h>
+#include <script/standard.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+#include <wallet/wallet.h>
+#include <wallet/walletdb.h>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include <QApplication>
+#include <QComboBox>
+#include <QListView>
+#include <QSettings>
+#include <QTableView>
+#include <QTest>
+
+using wallet::AddWallet;
+using wallet::CreateMockWalletDatabase;
+using wallet::CWallet;
+using wallet::RemoveWallet;
+using wallet::TxStateInactive;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+using wallet::WalletContext;
+using wallet::WalletDescriptor;
+using wallet::WalletRescanReserver;
+
+namespace {
+
+struct ExpectedRecord {
+    uint256 txid;
+    TransactionRecord::Type type;
+    CAmount amount;
+    QString label;
+    QString tooltip_text;
+};
+
+CTransactionRef MakeSpecialTransaction(uint16_t type, const COutPoint& input, CAmount output_amount,
+                                       const CScript& output_script)
+{
+    CMutableTransaction tx;
+    tx.nVersion = CTransaction::SPECIAL_VERSION;
+    tx.nType = type;
+    tx.vin.emplace_back(input);
+    tx.vout.emplace_back(output_amount, output_script);
+    return MakeTransactionRef(std::move(tx));
+}
+
+std::vector<int> FindTransactionRows(const QAbstractItemModel& model, const uint256& txid)
+{
+    const QString hash{QString::fromStdString(txid.ToString())};
+    std::vector<int> rows;
+    for (int row = 0; row < model.rowCount(); ++row) {
+        if (model.index(row, 0).data(TransactionTableModel::TxHashRole).toString() == hash) {
+            rows.push_back(row);
+        }
+    }
+    return rows;
+}
+
+QComboBox* FindTransactionTypeWidget(TransactionView& view)
+{
+    for (QComboBox* combo : view.findChildren<QComboBox*>()) {
+        if (combo->findText("Masternode") >= 0) return combo;
+    }
+    return nullptr;
+}
+
+class WalletCleanup
+{
+public:
+    WalletCleanup(WalletContext& context, std::shared_ptr<CWallet> wallet) :
+        m_context(context),
+        m_wallet(std::move(wallet))
+    {
+    }
+    ~WalletCleanup() { RemoveWallet(m_context, m_wallet, /*load_on_start=*/std::nullopt); }
+
+private:
+    WalletContext& m_context;
+    std::shared_ptr<CWallet> m_wallet;
+};
+
+class CoinJoinOptionsRestorer
+{
+public:
+    explicit CoinJoinOptionsRestorer(interfaces::CoinJoin::Options& options) :
+        m_options(options),
+        m_enabled(options.isEnabled())
+    {
+    }
+    ~CoinJoinOptionsRestorer() { m_options.setEnabled(m_enabled); }
+
+private:
+    interfaces::CoinJoin::Options& m_options;
+    const bool m_enabled;
+};
+
+class TransactionTypeSettingRestorer
+{
+public:
+    TransactionTypeSettingRestorer() :
+        m_had_value(m_settings.contains("transactionType")),
+        m_value(m_settings.value("transactionType"))
+    {
+    }
+    ~TransactionTypeSettingRestorer()
+    {
+        if (m_had_value) {
+            m_settings.setValue("transactionType", m_value);
+        } else {
+            m_settings.remove("transactionType");
+        }
+    }
+
+private:
+    QSettings m_settings;
+    const bool m_had_value;
+    const QVariant m_value;
+};
+
+void CheckProviderRecords(const TransactionTableModel& model, const std::vector<ExpectedRecord>& expected)
+{
+    for (const ExpectedRecord& record : expected) {
+        const std::vector<int> rows{FindTransactionRows(model, record.txid)};
+        QCOMPARE(rows.size(), size_t{1});
+
+        const QModelIndex base{model.index(rows.front(), 0)};
+        const QModelIndex type_index{model.index(rows.front(), TransactionTableModel::Type)};
+        const QModelIndex address_index{model.index(rows.front(), TransactionTableModel::ToAddress)};
+
+        QCOMPARE(base.data(TransactionTableModel::TypeRole).toInt(), static_cast<int>(record.type));
+        QCOMPARE(base.data(TransactionTableModel::AmountRole).toLongLong(), record.amount);
+        QCOMPARE(base.data(TransactionTableModel::AddressRole).toString(), QString{});
+        QCOMPARE(base.data(TransactionTableModel::LabelRole).toString(), QString{});
+        QCOMPARE(type_index.data(Qt::DisplayRole).toString(), record.label);
+        QCOMPARE(address_index.data(Qt::DisplayRole).toString(), QString{"(n/a)"});
+
+        const QString tooltip{type_index.data(Qt::ToolTipRole).toString()};
+        QVERIFY(tooltip.contains(record.label));
+        QVERIFY(tooltip.contains(record.tooltip_text));
+        QVERIFY(!tooltip.contains("Payment to yourself"));
+
+        const QString plain_text{base.data(TransactionTableModel::TxPlainTextRole).toString()};
+        QVERIFY(plain_text.contains(record.label));
+        QVERIFY(!plain_text.contains("Payment to yourself"));
+
+        const QString description{base.data(TransactionTableModel::LongDescriptionRole).toString()};
+        QVERIFY(description.contains(record.label));
+        QVERIFY(description.contains(QString::fromStdString(record.txid.ToString())));
+        QVERIFY(description.contains("Net amount"));
+        QVERIFY(description.contains("Transaction total size"));
+        const QString summary{description.section("<hr>", 0, 0)};
+        QVERIFY(!summary.contains("From:"));
+        QVERIFY(!summary.contains("To:"));
+        QVERIFY(!summary.contains("<b>Debit:</b>"));
+        QVERIFY(!summary.contains("<b>Credit:</b>"));
+        QVERIFY(!summary.contains("Output index"));
+    }
+}
+
+} // namespace
+
+void ProviderTransactionTests::transactionTypeSettingCompatibility_data()
+{
+    QTest::addColumn<int>("saved_index");
+    QTest::addColumn<QString>("expected_text");
+    QTest::addColumn<quint32>("expected_filter");
+
+    QTest::newRow("data") << 12 << QString{"Data Transaction"}
+                          << TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction);
+    QTest::newRow("dust") << 13 << QString{"Dust Receive"} << TransactionFilterProxy::TYPE(TransactionRecord::DustReceive);
+    QTest::newRow("other") << 14 << QString{"Other"} << TransactionFilterProxy::TYPE(TransactionRecord::Other);
+}
+
+void ProviderTransactionTests::transactionTypeSettingCompatibility()
+{
+    QFETCH(int, saved_index);
+    QFETCH(QString, expected_text);
+    QFETCH(quint32, expected_filter);
+
+    TransactionTypeSettingRestorer setting_restorer;
+    QSettings{}.setValue("transactionType", saved_index);
+
+    TransactionView transaction_view;
+    QComboBox* const type_widget{FindTransactionTypeWidget(transaction_view)};
+    QVERIFY(type_widget != nullptr);
+    QCOMPARE(type_widget->currentIndex(), saved_index);
+    QCOMPARE(type_widget->currentText(), expected_text);
+    QCOMPARE(type_widget->currentData().toUInt(), expected_filter);
+    QCOMPARE(type_widget->findText("Masternode"), 15);
+}
+
+void ProviderTransactionTests::providerTransactionHistory()
+{
+    TestChain100Setup test;
+    m_node.setContext(&test.m_node);
+
+    WalletContext& context{*m_node.walletLoader().context()};
+    std::shared_ptr<CWallet> wallet{std::make_shared<CWallet>(test.m_node.chain.get(), test.m_node.coinjoin_loader.get(),
+                                                              "", test.m_args, CreateMockWalletDatabase())};
+    wallet->LoadWallet();
+    wallet->SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->SetupDescriptorScriptPubKeyMans("", "");
+
+        FlatSigningProvider provider;
+        std::string descriptor_error;
+        std::unique_ptr<Descriptor> descriptor{Parse("combo(" + EncodeSecret(test.coinbaseKey) + ")", provider,
+                                                     descriptor_error, /*require_checksum=*/false)};
+        QVERIFY(descriptor != nullptr);
+        WalletDescriptor wallet_descriptor{std::move(descriptor), 0, 0, 1, 1};
+        QVERIFY(wallet->AddWalletDescriptor(wallet_descriptor, provider, "", /*internal=*/false));
+
+        const CBlockIndex* const tip{
+            WITH_LOCK(Assert(test.m_node.chainman)->GetMutex(), return test.m_node.chainman->ActiveChain().Tip())};
+        wallet->SetLastBlockProcessed(tip->nHeight, tip->GetBlockHash());
+    }
+    {
+        WalletRescanReserver reserver{*wallet};
+        QVERIFY(reserver.reserve());
+        const CWallet::ScanResult result{wallet->ScanForWalletTransactions(Params().GetConsensus().hashGenesisBlock,
+                                                                           /*start_height=*/0, /*max_height=*/{}, reserver,
+                                                                           /*fUpdate=*/false, /*save_progress=*/false)};
+        QCOMPARE(result.status, CWallet::ScanResult::SUCCESS);
+        QVERIFY(result.last_failed_block.IsNull());
+    }
+    QVERIFY(AddWallet(context, wallet));
+    WalletCleanup wallet_cleanup{context, wallet};
+    TransactionTypeSettingRestorer setting_restorer;
+
+    const CScript own_script{GetScriptForRawPubKey(test.coinbaseKey.GetPubKey())};
+    CKey external_key;
+    external_key.MakeNewKey(/*fCompressed=*/true);
+    const CScript external_script{GetScriptForDestination(PKHash(external_key.GetPubKey()))};
+
+    auto make_owned_input = [&test](size_t index) { return COutPoint{test.m_coinbase_txns.at(index)->GetHash(), 0}; };
+    auto input_amount = [&test](size_t index) { return test.m_coinbase_txns.at(index)->vout.at(0).nValue; };
+
+    const CAmount registration_fee{1000};
+    const CAmount service_fee{2000};
+    const CAmount registrar_fee{3000};
+    const CAmount revoke_fee{4000};
+
+    const CTransactionRef registration{MakeSpecialTransaction(TRANSACTION_PROVIDER_REGISTER, make_owned_input(0),
+                                                              input_amount(0) - registration_fee, own_script)};
+    const CTransactionRef update_service{MakeSpecialTransaction(TRANSACTION_PROVIDER_UPDATE_SERVICE, make_owned_input(1),
+                                                                input_amount(1) - service_fee, own_script)};
+    const CTransactionRef update_registrar{MakeSpecialTransaction(TRANSACTION_PROVIDER_UPDATE_REGISTRAR,
+                                                                  make_owned_input(2), input_amount(2) - registrar_fee,
+                                                                  external_script)};
+    const CTransactionRef update_revoke{MakeSpecialTransaction(TRANSACTION_PROVIDER_UPDATE_REVOKE, make_owned_input(3),
+                                                               input_amount(3) - revoke_fee, own_script)};
+    const CTransactionRef other_special_tx{
+        MakeSpecialTransaction(TRANSACTION_ASSET_LOCK, make_owned_input(4), input_amount(4) - 5000, own_script)};
+
+    std::vector<ExpectedRecord> expected{
+        {registration->GetHash(), TransactionRecord::MasternodeRegistration, -registration_fee,
+         QString{"Masternode Registration"}, QString{"Registers a masternode"}},
+        {update_service->GetHash(), TransactionRecord::MasternodeUpdate, -service_fee, QString{"Masternode Update"},
+         QString{"Updates an existing masternode"}},
+        // A provider transaction with an external output reports the complete wallet delta, not
+        // just the fee or an arbitrary output amount.
+        {update_registrar->GetHash(), TransactionRecord::MasternodeUpdate, -input_amount(2),
+         QString{"Masternode Update"}, QString{"Updates an existing masternode"}},
+        {update_revoke->GetHash(), TransactionRecord::MasternodeUpdate, -revoke_fee, QString{"Masternode Update"},
+         QString{"Updates an existing masternode"}},
+    };
+
+    for (const CTransactionRef& tx : {registration, update_service, update_registrar, update_revoke, other_special_tx}) {
+        QVERIFY(wallet->AddToWallet(tx, TxStateInactive{}) != nullptr);
+    }
+
+    OptionsModel options_model{m_node};
+    bilingual_str error;
+    QVERIFY(options_model.Init(error));
+    ClientModel client_model{m_node, &options_model};
+
+    {
+        WalletModel wallet_model{interfaces::MakeWallet(context, wallet), client_model};
+        TransactionTableModel* const model{wallet_model.getTransactionTableModel()};
+
+        // Transactions loaded before the model is constructed exercise the wallet-restart path.
+        CheckProviderRecords(*model, expected);
+        const std::vector<int> registrar_rows{FindTransactionRows(*model, update_registrar->GetHash())};
+        QCOMPARE(registrar_rows.size(), size_t{1});
+        const QString registrar_description{
+            model->index(registrar_rows.front(), 0).data(TransactionTableModel::LongDescriptionRole).toString()};
+        const QString registrar_summary{registrar_description.section("<hr>", 0, 0)};
+        const QString external_address{QString::fromStdString(EncodeDestination(PKHash(external_key.GetPubKey())))};
+        QVERIFY(!registrar_summary.contains(external_address));
+
+        const std::vector<int> other_rows{FindTransactionRows(*model, other_special_tx->GetHash())};
+        QCOMPARE(other_rows.size(), size_t{1});
+        QCOMPARE(model->index(other_rows.front(), 0).data(TransactionTableModel::TypeRole).toInt(),
+                 static_cast<int>(TransactionRecord::SendToSelf));
+        QCOMPARE(model->index(other_rows.front(), TransactionTableModel::Type).data(Qt::DisplayRole).toString(),
+                 QString{"Payment to yourself"});
+
+        // Add an externally funded registration after model construction to exercise live wallet
+        // notification. Its owned output is the wallet's positive net change and still yields one
+        // logical registration record rather than one record per output.
+        const CAmount received_collateral{1000 * COIN};
+        const CTransactionRef received_registration{MakeSpecialTransaction(TRANSACTION_PROVIDER_REGISTER,
+                                                                           COutPoint{uint256::ONE, 7},
+                                                                           received_collateral, own_script)};
+        QVERIFY(wallet->AddToWallet(received_registration, TxStateInactive{}) != nullptr);
+        QTRY_COMPARE_WITH_TIMEOUT(FindTransactionRows(*model, received_registration->GetHash()).size(), size_t{1}, 5000);
+        expected.push_back({received_registration->GetHash(), TransactionRecord::MasternodeRegistration,
+                            received_collateral, QString{"Masternode Registration"}, QString{"Registers a masternode"}});
+        CheckProviderRecords(*model, expected);
+
+        const quint32 masternode_filter{TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
+                                        TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate)};
+        TransactionFilterProxy filter;
+        filter.setSourceModel(model);
+        filter.setTypeFilter(masternode_filter);
+        QCOMPARE(filter.rowCount(), static_cast<int>(expected.size()));
+
+#if defined(Q_OS_MACOS)
+        if (QApplication::platformName() == "minimal") {
+            QWARN("Skipping TransactionView checks on macOS with the minimal platform due to QTBUG-49686");
+        } else
+#endif
+        {
+            CoinJoinOptionsRestorer coinjoin_restorer{m_node.coinJoinOptions()};
+            m_node.coinJoinOptions().setEnabled(false);
+
+            TransactionView transaction_view;
+            transaction_view.setModel(&wallet_model);
+
+            QComboBox* const type_widget{FindTransactionTypeWidget(transaction_view)};
+            QVERIFY(type_widget != nullptr);
+            const int masternode_row{type_widget->findText("Masternode")};
+            QCOMPARE(type_widget->itemData(masternode_row).toUInt(), masternode_filter);
+
+            QListView* const type_list{qobject_cast<QListView*>(type_widget->view())};
+            QVERIFY(type_list != nullptr);
+            for (const quint32 coinjoin_filter :
+                 {TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinSend),
+                  TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMakeCollaterals),
+                  TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCreateDenominations),
+                  TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMixing),
+                  TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCollateralPayment)}) {
+                const int row{type_widget->findData(coinjoin_filter)};
+                QVERIFY(row >= 0);
+                QVERIFY(type_list->isRowHidden(row));
+            }
+            QVERIFY(!type_list->isRowHidden(masternode_row));
+
+            type_widget->setCurrentIndex(masternode_row);
+            transaction_view.chooseType(masternode_row);
+            QTableView* const table{transaction_view.findChild<QTableView*>("transactionView")};
+            QVERIFY(table != nullptr);
+            QCOMPARE(table->model()->rowCount(), static_cast<int>(expected.size()));
+        }
+    }
+
+    // Reconstructing the model must neither lose the classifications nor duplicate their rows.
+    {
+        WalletModel restarted_wallet_model{interfaces::MakeWallet(context, wallet), client_model};
+        CheckProviderRecords(*restarted_wallet_model.getTransactionTableModel(), expected);
+    }
+}

--- a/src/qt/test/providertransactiontests.h
+++ b/src/qt/test/providertransactiontests.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_PROVIDERTRANSACTIONTESTS_H
+#define BITCOIN_QT_TEST_PROVIDERTRANSACTIONTESTS_H
+
+#include <QObject>
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+class ProviderTransactionTests : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ProviderTransactionTests(interfaces::Node& node) :
+        m_node(node)
+    {
+    }
+
+private Q_SLOTS:
+    void transactionTypeSettingCompatibility_data();
+    void transactionTypeSettingCompatibility();
+    void providerTransactionHistory();
+
+private:
+    interfaces::Node& m_node;
+};
+
+#endif // BITCOIN_QT_TEST_PROVIDERTRANSACTIONTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -19,6 +19,7 @@
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
+#include <qt/test/providertransactiontests.h>
 #include <qt/test/wallettests.h>
 #endif // ENABLE_WALLET
 
@@ -105,6 +106,9 @@ int main(int argc, char* argv[])
 
     AddressBookTests test6(app.node());
     num_test_failures += QTest::qExec(&test6);
+
+    ProviderTransactionTests provider_transaction_tests(app.node());
+    num_test_failures += QTest::qExec(&provider_transaction_tests);
 #endif
     TrafficGraphDataTests test7;
     num_test_failures += QTest::qExec(&test7);

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -105,30 +105,36 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     CAmount nCredit = wtx.credit;
     CAmount nDebit = wtx.debit;
     CAmount nNet = nCredit - nDebit;
+    const bool is_masternode_transaction{rec->type == TransactionRecord::MasternodeRegistration ||
+                                         rec->type == TransactionRecord::MasternodeUpdate};
 
     strHTML += "<b>" + tr("Status") + ":</b> " + FormatTxStatus(status, inMempool);
     strHTML += "<br>";
 
     strHTML += "<b>" + tr("Date") + ":</b> " + (nTime ? GUIUtil::dateTimeStr(nTime) : "") + "<br>";
 
+    switch (rec->type) {
+    case TransactionRecord::MasternodeRegistration:
+        strHTML += "<b>" + tr("Type") + ":</b> " + tr("Masternode Registration") + "<br>";
+        break;
+    case TransactionRecord::MasternodeUpdate:
+        strHTML += "<b>" + tr("Type") + ":</b> " + tr("Masternode Update") + "<br>";
+        break;
+    default:
+        break;
+    }
+
     //
     // From
     //
-    if (wtx.is_coinbase)
-    {
+    if (!is_masternode_transaction && wtx.is_coinbase) {
         strHTML += "<b>" + tr("Source") + ":</b> " + tr("Generated") + "<br>";
-    }
-    else if (wtx.is_platform_transfer)
-    {
+    } else if (!is_masternode_transaction && wtx.is_platform_transfer) {
         strHTML += "<b>" + tr("Source") + ":</b> " + tr("Platform Transfer") + "<br>";
-    }
-    else if (wtx.value_map.count("from") && !wtx.value_map["from"].empty())
-    {
+    } else if (!is_masternode_transaction && wtx.value_map.count("from") && !wtx.value_map["from"].empty()) {
         // Online transaction
         strHTML += "<b>" + tr("From") + ":</b> " + GUIUtil::HtmlEscape(wtx.value_map["from"]) + "<br>";
-    }
-    else
-    {
+    } else if (!is_masternode_transaction) {
         // Offline transaction
         if (nNet > 0)
         {
@@ -156,8 +162,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // To
     //
-    if (wtx.value_map.count("to") && !wtx.value_map["to"].empty())
-    {
+    if (!is_masternode_transaction && wtx.value_map.count("to") && !wtx.value_map["to"].empty()) {
         // Online transaction
         std::string strAddress = wtx.value_map["to"];
         strHTML += "<b>" + tr("To") + ":</b> ";
@@ -172,8 +177,7 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     //
     // Amount
     //
-    if (wtx.is_coinbase && nCredit == 0)
-    {
+    if (!is_masternode_transaction && wtx.is_coinbase && nCredit == 0) {
         //
         // Coinbase
         //
@@ -186,16 +190,12 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         else
             strHTML += "(" + tr("not accepted") + ")";
         strHTML += "<br>";
-    }
-    else if (nNet > 0)
-    {
+    } else if (!is_masternode_transaction && nNet > 0) {
         //
         // Credit
         //
         strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, nNet) + "<br>";
-    }
-    else
-    {
+    } else if (!is_masternode_transaction) {
         isminetype fAllFromMe = ISMINE_SPENDABLE;
         for (const isminetype mine : wtx.txin_is_mine)
         {
@@ -293,7 +293,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
         strHTML += "<br><b>" + tr("Comment") + ":</b><br>" + GUIUtil::HtmlEscape(wtx.value_map["comment"], true) + "<br>";
 
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";
-    strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
+    if (!is_masternode_transaction) {
+        strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
+    }
     strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx.tx->GetTotalSize()) + " bytes<br>";
 
     // Show OP_RETURN payload for this specific output

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -24,7 +24,8 @@ class TransactionFilterProxy : public QSortFilterProxyModel
 public:
     explicit TransactionFilterProxy(QObject *parent = nullptr);
 
-    /** Types to exclude from common transaction lists (CoinJoin internal transactions and dust) */
+    /** Types to exclude from common transaction lists (CoinJoin internal transactions and dust).
+     *  Masternode transactions remain visible in the default common-transactions view. */
     static constexpr quint32 EXCLUDED_TYPES =
         TransactionTypeToBit(TransactionRecord::CoinJoinCollateralPayment) |
         TransactionTypeToBit(TransactionRecord::CoinJoinCreateDenominations) |
@@ -36,6 +37,8 @@ public:
     static constexpr quint32 ALL_TYPES = 0xFFFFFFFF;
     /** Type filter bit field (all types except excluded) */
     static constexpr quint32 COMMON_TYPES = ALL_TYPES & ~EXCLUDED_TYPES;
+    static_assert(TransactionRecord::MasternodeUpdate < 32,
+                  "TransactionRecord::Type no longer fits in the quint32 type filter");
 
     static constexpr quint32 TYPE(int type) { return TransactionTypeToBit(type); }
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -6,12 +6,15 @@
 #include <qt/transactionrecord.h>
 
 #include <chain.h>
-#include <interfaces/wallet.h>
 #include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <primitives/transaction.h>
 
 #include <wallet/ismine.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <optional>
 
 using wallet::ISMINE_SPENDABLE;
 using wallet::ISMINE_WATCH_ONLY;
@@ -24,6 +27,22 @@ bool TransactionRecord::showTransaction()
     // There are currently no cases where we hide transactions, but
     // we may want to use this in the future for things like RBF.
     return true;
+}
+
+static std::optional<TransactionRecord::Type> MasternodeRecordType(const CTransaction& tx)
+{
+    if (!tx.IsSpecialTxVersion()) return std::nullopt;
+
+    switch (tx.nType) {
+    case TRANSACTION_PROVIDER_REGISTER:
+        return TransactionRecord::MasternodeRegistration;
+    case TRANSACTION_PROVIDER_UPDATE_SERVICE:
+    case TRANSACTION_PROVIDER_UPDATE_REGISTRAR:
+    case TRANSACTION_PROVIDER_UPDATE_REVOKE:
+        return TransactionRecord::MasternodeUpdate;
+    default:
+        return std::nullopt;
+    }
 }
 
 /*
@@ -39,6 +58,18 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
     CAmount nNet = nCredit - nDebit;
     uint256 hash = wtx.tx->GetHash();
     std::map<std::string, std::string> mapValue = wtx.value_map;
+
+    if (const auto mn_type = MasternodeRecordType(*wtx.tx)) {
+        TransactionRecord record(hash, nTime, *mn_type, /*_strAddress=*/"", std::min<CAmount>(nNet, 0),
+                                 std::max<CAmount>(nNet, 0));
+        record.involvesWatchAddress = std::any_of(wtx.txin_is_mine.begin(), wtx.txin_is_mine.end(),
+                                                  [](const isminetype mine) { return mine & ISMINE_WATCH_ONLY; }) ||
+                                      std::any_of(wtx.txout_is_mine.begin(), wtx.txout_is_mine.end(),
+                                                  [](const isminetype mine) { return mine & ISMINE_WATCH_ONLY; });
+        parts.append(record);
+        return parts;
+    }
+
     auto& coinJoinOptions = node.coinJoinOptions();
 
     // Check if any inputs belong to this wallet (for dust detection)

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -70,7 +70,8 @@ struct TransactionStatus {
 class TransactionRecord
 {
 public:
-    // Update EXCLUDED_TYPES in TransactionFilterProxy when adding a new type
+    // Update EXCLUDED_TYPES in TransactionFilterProxy when adding a new type.
+    // Append new types so existing values remain stable as type-filter bit positions.
     enum Type
     {
         Other,
@@ -89,6 +90,10 @@ public:
         PlatformTransfer,
         DustReceive,
         DataTransaction,
+        /// ProRegTx that registers a regular or Evo masternode
+        MasternodeRegistration,
+        /// ProUpServTx, ProUpRegTx, or ProUpRevTx for an existing masternode
+        MasternodeUpdate,
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -437,6 +437,10 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Data Transaction");
     case TransactionRecord::DustReceive:
         return tr("Dust Receive");
+    case TransactionRecord::MasternodeRegistration:
+        return tr("Masternode Registration");
+    case TransactionRecord::MasternodeUpdate:
+        return tr("Masternode Update");
 
     case TransactionRecord::CoinJoinMixing:
         return tr("%1 Mixing").arg(QString::fromStdString(gCoinJoinName));
@@ -492,6 +496,8 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::CoinJoinMakeCollaterals:
     case TransactionRecord::CoinJoinCreateDenominations:
     case TransactionRecord::DataTransaction:
+    case TransactionRecord::MasternodeRegistration:
+    case TransactionRecord::MasternodeUpdate:
     case TransactionRecord::Other:
         break; // use fail-over here
     } // no default case, so the compiler can warn about missing cases
@@ -521,6 +527,8 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::CoinJoinMakeCollaterals:
     case TransactionRecord::CoinJoinCollateralPayment:
     case TransactionRecord::DataTransaction:
+    case TransactionRecord::MasternodeRegistration:
+    case TransactionRecord::MasternodeUpdate:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BAREADDRESS);
     case TransactionRecord::SendToOther:
     case TransactionRecord::RecvFromOther:
@@ -564,6 +572,8 @@ QVariant TransactionTableModel::amountColor(const TransactionRecord *rec) const
     case TransactionRecord::CoinJoinMakeCollaterals:
     case TransactionRecord::CoinJoinCreateDenominations:
     case TransactionRecord::DustReceive:
+    case TransactionRecord::MasternodeRegistration:
+    case TransactionRecord::MasternodeUpdate:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::ORANGE);
     }
     return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::DEFAULT);
@@ -617,6 +627,18 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
        rec->type==TransactionRecord::SendToAddress || rec->type==TransactionRecord::RecvWithAddress)
     {
         tooltip += QString(" ") + formatTxToAddress(rec, true);
+    }
+    switch (rec->type) {
+    case TransactionRecord::MasternodeRegistration:
+        tooltip += QString("\n") + tr("Registers a masternode. The amount is this wallet's net balance change and is "
+                                      "normally only the network fee when the collateral remains in this wallet.");
+        break;
+    case TransactionRecord::MasternodeUpdate:
+        tooltip += QString("\n") + tr("Updates an existing masternode registration. The amount is this wallet's net "
+                                      "balance change, normally only the network fee.");
+        break;
+    default:
+        break;
     }
     return tooltip;
 }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -99,6 +99,8 @@ TransactionView::TransactionView(QWidget* parent) :
     typeWidget->addItem(tr("Data Transaction"), TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction));
     typeWidget->addItem(tr("Dust Receive"), TransactionFilterProxy::TYPE(TransactionRecord::DustReceive));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
+    typeWidget->addItem(tr("Masternode"), TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
+                                              TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate));
     typeWidget->setCurrentIndex(settings.value("transactionType").toInt());
 
     hlayout->addWidget(typeWidget);
@@ -790,10 +792,14 @@ void TransactionView::updateCoinJoinVisibility()
     int idx = fEnabled ? 0 : 1;
     chooseType(idx);
     typeWidget->setCurrentIndex(idx);
-    // Hide all CoinJoin related filters
+    // Hide all CoinJoin related filters by value so this stays correct when entries are reordered.
     QListView* typeList = qobject_cast<QListView*>(typeWidget->view());
-    std::vector<int> vecRows{4, 5, 6, 7, 8};
-    for (auto nRow : vecRows) {
-        typeList->setRowHidden(nRow, !fEnabled);
+    for (const quint32 type_filter : {TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinSend),
+                                      TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMakeCollaterals),
+                                      TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCreateDenominations),
+                                      TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMixing),
+                                      TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCollateralPayment)}) {
+        const int row = typeWidget->findData(type_filter);
+        if (row >= 0) typeList->setRowHidden(row, !fEnabled);
     }
 }

--- a/test/util/data/non-backported.txt
+++ b/test/util/data/non-backported.txt
@@ -42,6 +42,8 @@ src/qt/masternodelist.*
 src/qt/masternodemodel.*
 src/qt/mnemonicverificationdialog.*
 src/qt/networkwidget.*
+src/qt/test/providertransactiontests.cpp
+src/qt/test/providertransactiontests.h
 src/qt/proposalcreate.*
 src/qt/proposalinfo.*
 src/qt/proposallist.*


### PR DESCRIPTION
## Issue being fixed or feature implemented

Provider registration and maintenance transactions currently decompose into ordinary payment rows in the Qt transaction history. A self-funded registration can consequently look like a payment to yourself, while one logical provider transaction can produce multiple misleading rows.

This change gives regular and Evo provider transactions a single, recognizable history record without depending on the registration or maintenance dialogs.

## What was done?

- Classify `ProRegTx` as **Masternode Registration** and `ProUpServTx`, `ProUpRegTx`, and `ProUpRevTx` as **Masternode Update**.
- Emit exactly one logical record per provider transaction, using the wallet's net balance change. For the common wallet-owned collateral case this is the network fee; external credits/debits retain their real net amount.
- Avoid a misleading address or output index for whole-operation, potentially multi-output records; details retain the transaction ID and explicit operation type.
- Summarize provider details as an operation rather than rendering incidental outputs as recipients, credits, or debits.
- Add actionable tooltips, details text, orange styling, and a combined **Masternode** transaction-type filter.
- Preserve existing saved filter indices and hide CoinJoin filters by stored type value rather than row position.

No shared-masternode/DMS transaction types are included.

## Exact base-to-head visual comparison

Every **Before** image below is from the exact PR base `981a25d0a3c385cd4fe037a8a68f814ca6c4a815`. Every **After** image is from the full PR head `f9e7509493103cc977dcc9e9044c9a4d86e9eaff`. Both builds use matching copies of the same disposable regtest wallet and chain.

[Full-resolution screenshot index and capture record](https://github.com/PastaPastaPasta/dash-ui-artifacts/tree/main/pr-d/comparison)

### 1. Complete transaction history

Before, provider transactions are mixed into ordinary `Payment to yourself` rows with wallet addresses. After, they are recognizable operation-level `Masternode Registration` and `Masternode Update` rows with `(n/a)` for the non-applicable address and the wallet's net balance change.

| Before — exact PR base | After — full PR head |
|---|---|
| [![Before history](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/01-history-overview.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/01-history-overview.png?v=017555b) | [![After history](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/01-history-overview.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/01-history-overview.png?v=017555b) |

### 2. Registration row — same exact transaction

Both views are filtered to transaction ID `8f630584bd5227fe7398178a4c93d36156dd84d5851ded4ca3a116a762cb2b79`.

| Before — `Payment to yourself` | After — `Masternode Registration` |
|---|---|
| [![Before registration row](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/02-registration-records.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/02-registration-records.png?v=017555b) | [![After registration row](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/02-registration-records.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/02-registration-records.png?v=017555b) |

### 3. Registration details — same exact transaction

Before, there is no operation type and the whole special transaction is presented as generic total debit, total credit, fee, and `Output index: 0`. After, the details identify `Masternode Registration` and retain the operation's net wallet effect, transaction ID, and size without pretending the record represents `vout[0]`.

| Before — generic payment decomposition | After — operation summary |
|---|---|
| [![Before registration details](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/03-registration-details.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/03-registration-details.png?v=017555b) | [![After registration details](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/03-registration-details.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/03-registration-details.png?v=017555b) |

### 4. Update row — same exact transaction

Both views are filtered to Update Registrar transaction ID `76084b4b03d97f4da17085b0a3cb928eeb6baadd04651844da8de658ba9c8519`.

| Before — `Payment to yourself` | After — `Masternode Update` |
|---|---|
| [![Before update row](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/04-update-records.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/04-update-records.png?v=017555b) | [![After update row](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/04-update-records.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/04-update-records.png?v=017555b) |

### 5. Update tooltip — same exact transaction

The tooltip changes from a generic self-payment label to the operation type plus an explanation that the amount is the wallet's net balance change.

| Before | After |
|---|---|
| [![Before update tooltip](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/05-update-tooltip.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/05-update-tooltip.png?v=017555b) | [![After update tooltip](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/05-update-tooltip.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/05-update-tooltip.png?v=017555b) |

### 6. Update details — same exact transaction

The status, date, net amount, transaction ID, and serialized size match. The PR replaces the generic debit/credit/fee/output-index decomposition with the explicit operation type.

| Before — generic payment decomposition | After — operation summary |
|---|---|
| [![Before update details](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/06-update-details.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/06-update-details.png?v=017555b) | [![After update details](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/06-update-details.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/06-update-details.png?v=017555b) |

### 7. Transaction type filter

The PR appends a **Masternode** choice. Existing stored filter values retain their meaning; the CoinJoin-disabled configuration shown here still exposes the same non-CoinJoin choices in the same order.

| Before — no Masternode choice | After — Masternode appended |
|---|---|
| [![Before type filter](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/07-type-filter-expanded.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/07-type-filter-expanded.png?v=017555b) | [![After type filter](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/07-type-filter-expanded.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/07-type-filter-expanded.png?v=017555b) |

### 8. Masternode-only result

This view does not exist before the PR. After selecting **Masternode**, the fixture shows exactly seven provider operations: four registrations and three updates, with no ordinary payments or mined transactions.

[![After Masternode-only filter](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/08-masternode-only.png?v=017555b)](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/08-masternode-only.png?v=017555b)

Copied-text comparison for the same update: [before](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/before/update-copied-text.txt?v=017555b) / [after](https://raw.githubusercontent.com/PastaPastaPasta/dash-ui-artifacts/main/pr-d/comparison/after/update-copied-text.txt?v=017555b).

## User stories verified

- **D01 — wallet-funded regular and Evo registration:** one `Masternode Registration` row, `(n/a)` address, net-fee semantics, explicit details type, and accurate copied text.
- **D02 — wallet-owned exact and external collateral:** one registration record, with no duplicate or misleading provider-output rows.
- **D03 — maintenance:** Update Service, Update Registrar, and Revoke each render one `Masternode Update` operation summary.
- **D04 — filtering:** provider records remain in the common view; **Masternode** selects exactly four registrations and three updates.
- **D05 — restart:** all seven historical records reclassify identically after GUI termination and wallet-model reconstruction.
- **D06 — CoinJoin-disabled regression:** all CoinJoin choices disappear by stored value while later filters remain correctly ordered.
- **D07 — saved-filter compatibility:** legacy saved indices still select Data Transaction, Dust Receive, and Other; Masternode is appended.

D05–D07 are compatibility/regression guarantees, so their intended before/after result is unchanged behavior. Focused Qt tests cover restart reconstruction, saved indices, and CoinJoin-enabled/disabled filter visibility.

## How Has This Been Tested?

Focused Qt integration coverage exercises restart and live-notification paths, net fee/debit/credit cases, exactly one record per provider transaction, operation-level descriptions, saved-filter compatibility, CoinJoin visibility, and non-provider special-transaction behavior. The complete native Qt suite also passes; CI carries the platform build and lint matrix.

## Breaking Changes

None. This changes only Qt presentation/classification of existing wallet transactions and adds a filter choice.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious whole-operation and value-indexing invariants
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
