### PR TITLE
fix: revalidate CoinJoin DSA session before admission

### DIFF
--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -67,7 +67,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
 {
     assert(m_mn_metaman.IsValid());
 
-    if (IsSessionReady()) {
+    if (WITH_LOCK(cs_coinjoin, return IsSessionReady())) {
         // too many users in this session already, reject new ones
         LogPrint(BCLog::COINJOIN, "DSACCEPT -- queue is already full!\n");
         PushStatus(peer, STATUS_REJECTED, ERR_QUEUE_FULL);
@@ -86,7 +86,7 @@ void CCoinJoinServer::ProcessDSACCEPT(CNode& peer, CDataStream& vRecv)
         return;
     }
 
-    if (vecSessionCollaterals.empty()) {
+    if (WITH_LOCK(cs_coinjoin, return vecSessionCollaterals.empty())) {
         {
             const auto hasQueue = m_queueman.TryHasQueueFromMasternode(m_mn_activeman.GetOutPoint());
             if (!hasQueue.has_value()) return;
@@ -541,17 +541,23 @@ void CCoinJoinServer::CheckTimeout()
 */
 void CCoinJoinServer::CheckForCompleteQueue()
 {
-    if (nState == POOL_STATE_QUEUE && IsSessionReady()) {
-        SetState(POOL_STATE_ACCEPTING_ENTRIES);
+    int session_denom;
+    size_t participants;
+    {
+        LOCK(cs_coinjoin);
+        if (nState != POOL_STATE_QUEUE || !IsSessionReady()) return;
 
-        CCoinJoinQueue dsq(nSessionDenom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(),
-                           GetAdjustedTime(), true);
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckForCompleteQueue -- queue is ready, signing and relaying (%s) " /* Continued */
-                                     "with %d participants\n", dsq.ToString(), vecSessionCollaterals.size());
-        dsq.vchSig = m_mn_activeman.SignBasic(dsq.GetSignatureHash());
-        m_peer_manager->PeerRelayDSQ(dsq);
-        m_queueman.AddQueue(std::move(dsq));
+        SetState(POOL_STATE_ACCEPTING_ENTRIES);
+        session_denom = nSessionDenom;
+        participants = vecSessionCollaterals.size();
     }
+
+    CCoinJoinQueue dsq(session_denom, m_mn_activeman.GetOutPoint(), m_mn_activeman.GetProTxHash(), GetAdjustedTime(), true);
+    LogPrint(BCLog::COINJOIN, "CCoinJoinServer::CheckForCompleteQueue -- ready queue %s with %d participants\n",
+             dsq.ToString(), participants);
+    dsq.vchSig = m_mn_activeman.SignBasic(dsq.GetSignatureHash());
+    m_peer_manager->PeerRelayDSQ(dsq);
+    m_queueman.AddQueue(std::move(dsq));
 }
 
 // Check to make sure a given input matches an input in the pool and its scriptSig is valid
@@ -807,33 +813,42 @@ bool CCoinJoinServer::CreateNewSession(const CCoinJoinAccept& dsa, PoolMessage& 
 
 bool CCoinJoinServer::AddUserToExistingSession(const CCoinJoinAccept& dsa, PoolMessage& nMessageIDRet)
 {
-    if (nSessionID == 0 || IsSessionReady()) return false;
+    int session_id;
+    int session_denom;
+    {
+        LOCK(cs_coinjoin);
+        if (nSessionID == 0 || nState != POOL_STATE_QUEUE) {
+            nMessageIDRet = ERR_MODE;
+            return false;
+        }
+        if (IsSessionReady()) {
+            nMessageIDRet = ERR_QUEUE_FULL;
+            return false;
+        }
+        session_id = nSessionID;
+        session_denom = nSessionDenom;
+    }
 
     if (!IsAcceptableDSA(dsa, nMessageIDRet)) {
         return false;
     }
 
-    // we only add new users to an existing session when we are in queue mode
-    if (nState != POOL_STATE_QUEUE) {
-        nMessageIDRet = ERR_MODE;
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- incompatible mode: nState=%d\n", nState);
-        return false;
-    }
-
-    if (dsa.nDenom != nSessionDenom) {
-        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- incompatible denom %d (%s) != nSessionDenom %d (%s)\n",
-            dsa.nDenom, CoinJoin::DenominationToString(dsa.nDenom), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+    if (dsa.nDenom != session_denom) {
+        LogPrint(BCLog::COINJOIN, "CCoinJoinServer::AddUserToExistingSession -- incompatible denom %d (%s) != %d (%s)\n",
+                 dsa.nDenom, CoinJoin::DenominationToString(dsa.nDenom), session_denom,
+                 CoinJoin::DenominationToString(session_denom));
         nMessageIDRet = ERR_DENOM;
         return false;
     }
 
     LOCK(cs_coinjoin);
 
-    // A scheduler-thread timeout can reset the session via SetNull() between the checks above
-    // and taking cs_coinjoin, so revalidate: a collateral must never be committed to a session
-    // that no longer exists.
-    if (nSessionID == 0 || nState != POOL_STATE_QUEUE) {
+    if (nSessionID != session_id || nSessionDenom != session_denom || nState != POOL_STATE_QUEUE) {
         nMessageIDRet = ERR_MODE;
+        return false;
+    }
+    if (IsSessionReady()) {
+        nMessageIDRet = ERR_QUEUE_FULL;
         return false;
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

CoinJoin DSA admission validates a request outside the session lock. While that validation runs, the scheduler can reset or advance the session, allowing the request to be committed against state different from the state that was validated. The queue-ready transition also previously raced admission.

## What was done?

- Snapshot the active session identity and denomination under `cs_coinjoin`.
- Perform the expensive collateral validation without holding the session lock.
- Reacquire the lock and require the same queue session, denomination, and available capacity before committing the collateral.
- Make the queue-to-entry transition atomic with DSA admission.
- Protect the remaining DSA reads of the collateral vector and readiness predicate.

## How Has This Been Tested?

- Built `test/test_dash` with depends on macOS arm64 using `--enable-debug --enable-werror`.
- Ran `coinjoin_inouts_tests` (8 cases).
- Ran `coinjoin_tests` (12 cases).
- Ran the whitespace and logging linters.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
