### PR TITLE
fix: make CoinJoin session denomination atomic

### DIFF
--- a/src/coinjoin/client.cpp
+++ b/src/coinjoin/client.cpp
@@ -1229,8 +1229,9 @@ bool CCoinJoinClientSession::JoinExistingQueue(CAmount nBalanceNeedsAnonymized, 
         SetState(POOL_STATE_QUEUE);
         nTimeLastSuccessfulStep = GetTime();
         WalletCJLogPrint(m_wallet, /* Continued */
-                         "CCoinJoinClientSession::JoinExistingQueue -- pending connection, masternode=%s, nSessionDenom=%d (%s)\n",
-                         dmn->proTxHash.ToString(), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+                         "CCoinJoinClientSession::JoinExistingQueue -- pending connection, masternode=%s, "
+                         "nSessionDenom=%d (%s)\n",
+                         dmn->proTxHash.ToString(), nSessionDenom.load(), CoinJoin::DenominationToString(nSessionDenom));
         strAutoDenomResult = _("Trying to connect…");
         return true;
     }
@@ -1310,9 +1311,11 @@ bool CCoinJoinClientSession::StartNewQueue(CAmount nBalanceNeedsAnonymized, CCon
         pendingDsaRequest = CPendingDsaRequest(dmn->proTxHash, CCoinJoinAccept(nSessionDenom, txMyCollateral));
         SetState(POOL_STATE_QUEUE);
         nTimeLastSuccessfulStep = GetTime();
-        WalletCJLogPrint( /* Continued */
-            m_wallet, "CCoinJoinClientSession::StartNewQueue -- pending connection, masternode=%s, nSessionDenom=%d (%s)\n",
-            dmn->proTxHash.ToString(), nSessionDenom, CoinJoin::DenominationToString(nSessionDenom));
+        WalletCJLogPrint(/* Continued */
+                         m_wallet,
+                         "CCoinJoinClientSession::StartNewQueue -- pending connection, masternode=%s, nSessionDenom=%d "
+                         "(%s)\n",
+                         dmn->proTxHash.ToString(), nSessionDenom.load(), CoinJoin::DenominationToString(nSessionDenom));
         strAutoDenomResult = _("Trying to connect…");
         return true;
     }
@@ -1424,7 +1427,7 @@ bool CCoinJoinClientSession::SubmitDenominate(CConnman& connman)
         return a.second > b.second || (a.second == b.second && a.first < b.first);
     });
 
-    WalletCJLogPrint(m_wallet, "vecInputsByRounds for denom %d\n", nSessionDenom);
+    WalletCJLogPrint(m_wallet, "vecInputsByRounds for denom %d\n", nSessionDenom.load());
     for (const auto& pair : vecInputsByRounds) {
         WalletCJLogPrint(m_wallet, "vecInputsByRounds: rounds: %d, inputs: %d\n", pair.first, pair.second);
     }

--- a/src/coinjoin/coinjoin.h
+++ b/src/coinjoin/coinjoin.h
@@ -342,7 +342,9 @@ protected:
                        PoolMessage& nMessageIDRet, bool* fConsumeCollateralRet) const;
 
 public:
-    int nSessionDenom{0}; // Users must submit a denom matching this
+    // Atomic because the message-handling and scheduler threads write it while those threads and
+    // RPC callers also read it without holding cs_coinjoin.
+    std::atomic<int> nSessionDenom{0};
 
     CCoinJoinBaseSession() = default;
     virtual ~CCoinJoinBaseSession() = default;


### PR DESCRIPTION
## Issue being fixed or feature implemented

CoinJoin session denomination is read by RPC, message-handling, and scheduler paths while other threads can update it. A plain integer makes those unsynchronized reads and writes a C++ data race.

## What was done?

- Store the session denomination in an atomic integer.
- Use explicit atomic loads where the value is passed through variadic logging calls.
- Preserve the existing value and behavior; this changes synchronization only.

## How Has This Been Tested?

- Built `test/test_dash` with depends on macOS arm64 using `--enable-debug --enable-werror`.
- Ran `coinjoin_inouts_tests` (8 cases).
- Ran `coinjoin_tests` (12 cases).
- Ran the whitespace and logging linters.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
