### PR TITLE
fix: snapshot CoinJoin collaterals before random fee charging

### DIFF
--- a/src/coinjoin/server.cpp
+++ b/src/coinjoin/server.cpp
@@ -490,7 +490,15 @@ void CCoinJoinServer::ChargeFees() const
 */
 void CCoinJoinServer::ChargeRandomFees() const
 {
-    for (const auto& txCollateral : vecSessionCollaterals) {
+    AssertLockNotHeld(cs_coinjoin);
+
+    std::vector<CTransactionRef> session_collaterals;
+    {
+        LOCK(cs_coinjoin);
+        session_collaterals = vecSessionCollaterals;
+    }
+
+    for (const auto& txCollateral : session_collaterals) {
         if (GetRand<int>(/*nMax=*/100) > 10) return;
         LogPrint(BCLog::COINJOIN, /* Continued */
                  "CCoinJoinServer::ChargeRandomFees -- charging random fees, txCollateral=%s", txCollateral->ToString());

--- a/src/coinjoin/server.h
+++ b/src/coinjoin/server.h
@@ -60,7 +60,7 @@ private:
     /// Charge fees to bad actors (Charge clients a fee if they're abusive)
     void ChargeFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Rarely charge fees to pay miners
-    void ChargeRandomFees() const;
+    void ChargeRandomFees() const EXCLUSIVE_LOCKS_REQUIRED(!cs_coinjoin);
     /// Consume collateral in cases when peer misbehaved
     void ConsumeCollateral(const CTransactionRef& txref) const;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`ChargeRandomFees()` iterates the live CoinJoin session collateral vector without holding the session lock. A concurrent session reset can clear that vector while it is being traversed, invalidating the iterator and transaction reference.

## What was done?

- Copy the shared collateral references while holding `cs_coinjoin`.
- Release the lock before random selection and collateral submission.
- Add a lock annotation and assertion documenting the call contract.

The copied `CTransactionRef` values keep each collateral alive, and the existing fee-selection behavior is unchanged.

## How Has This Been Tested?

- Built `test/test_dash` with depends on macOS arm64 using `--enable-debug --enable-werror`.
- Ran `coinjoin_inouts_tests` (8 cases).
- Ran `coinjoin_tests` (12 cases).
- Ran the whitespace and logging linters.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
