### PR TITLE
fix: skip old budget block value checks while not synced

### DIFF
--- a/src/masternode/payments.cpp
+++ b/src/masternode/payments.cpp
@@ -247,7 +247,7 @@ CAmount GetMasternodePayment(int nHeight, CAmount blockValue, const Consensus::P
     return true;
 }
 
-[[nodiscard]] bool CMNPaymentsProcessor::IsOldBudgetBlockValueValid(const CBlock& block, const int nBlockHeight, const CAmount blockReward, std::string& strErrorRet)
+[[nodiscard]] bool CMNPaymentsProcessor::IsOldBudgetBlockValueValid(const CBlock& block, const int nBlockHeight, const CAmount blockReward, std::string& strErrorRet, SuperBlockCheckType check_superblock)
 {
     bool isBlockRewardValueMet = (block.vtx[0]->GetValueOut() <= blockReward);
 
@@ -267,6 +267,12 @@ CAmount GetMasternodePayment(int nHeight, CAmount blockValue, const Consensus::P
     int nOffset = nBlockHeight % m_consensus_params.nBudgetPaymentsCycleBlocks;
     if (nOffset < m_consensus_params.nBudgetPaymentsWindowBlocks) {
         // NOTE: old budget system is disabled since 12.1
+        if (check_superblock == SuperBlockCheckType::NoCheck) {
+            // historical mainnet blocks in this window do pay old budgets and we have no
+            // data to validate them with, so rely on online nodes (all networks)
+            LogPrint(BCLog::GOBJECT, "CMNPaymentsProcessor::%s -- WARNING! Skipping old budget block value checks, accepting block\n", __func__);
+            return true;
+        }
         // no old budget blocks should be accepted here on mainnet,
         // testnet/devnet/regtest should produce regular blocks only
         if(!isBlockRewardValueMet) {
@@ -308,7 +314,7 @@ bool CMNPaymentsProcessor::IsBlockValueValid(const CChain& active_chain, const C
         return isBlockRewardValueMet;
     } else if (nBlockHeight < m_consensus_params.nSuperblockStartBlock) {
         // superblocks are not enabled yet, check if we can pass old budget rules
-        return IsOldBudgetBlockValueValid(block, nBlockHeight, blockReward, strErrorRet);
+        return IsOldBudgetBlockValueValid(block, nBlockHeight, blockReward, strErrorRet, check_superblock);
     }
 
     LogPrint(BCLog::MNPAYMENTS, "block.vtx[0]->GetValueOut() %lld <= blockReward %lld\n", block.vtx[0]->GetValueOut(), blockReward);

--- a/src/masternode/payments.h
+++ b/src/masternode/payments.h
@@ -85,7 +85,7 @@ private:
                                       MnRewardEra era, std::vector<CTxOut>& voutMasternodePaymentsRet);
     [[nodiscard]] bool IsTransactionValid(const CTransaction& txNew, const CBlockIndex* pindexPrev, const CAmount blockSubsidy,
                                           const CAmount feeReward, MnRewardEra era, bool strict_multiplicity);
-    [[nodiscard]] bool IsOldBudgetBlockValueValid(const CBlock& block, const int nBlockHeight, const CAmount blockReward, std::string& strErrorRet);
+    [[nodiscard]] bool IsOldBudgetBlockValueValid(const CBlock& block, const int nBlockHeight, const CAmount blockReward, std::string& strErrorRet, SuperBlockCheckType check_superblock);
 
 public:
     explicit CMNPaymentsProcessor(CDeterministicMNManager& dmnman, governance::SuperblockManager& superblocks,

--- a/src/test/masternode_payments_tests.cpp
+++ b/src/test/masternode_payments_tests.cpp
@@ -4,8 +4,15 @@
 
 #include <masternode/payments.h>
 
+#include <chain.h>
+#include <chainparams.h>
+#include <evo/chainhelper.h>
+#include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
+#include <validation.h>
+
+#include <test/util/setup_common.h>
 
 #include <vector>
 
@@ -83,6 +90,46 @@ BOOST_AUTO_TEST_CASE(strict_amount_must_match_exactly)
     const std::vector<CTxOut> actual{MakeOut(99, 0x01)};
     BOOST_CHECK_EQUAL(FindUnmatchedMasternodePayment(expected, actual, /*strict_multiplicity=*/true), 0);
     BOOST_CHECK_EQUAL(FindUnmatchedMasternodePayment(expected, actual, /*strict_multiplicity=*/false), 0);
+}
+
+// Regression: mainnet block 332320 sits inside an old-budget cycle window and pays
+// out a budget on top of the block reward. The old budget data is long gone, so a
+// node that is not synced yet (SuperBlockCheckType::NoCheck) has no way to validate
+// such a block and must accept it, otherwise it can never sync past that height.
+BOOST_FIXTURE_TEST_CASE(old_budget_window_accepted_while_unsynced, TestingSetup)
+{
+    const Consensus::Params& consensus{Params().GetConsensus()};
+    constexpr int nBlockHeight{332320};
+    BOOST_REQUIRE(nBlockHeight >= consensus.nBudgetPaymentsStartBlock);
+    BOOST_REQUIRE(nBlockHeight < consensus.nSuperblockStartBlock);
+    BOOST_REQUIRE(nBlockHeight % consensus.nBudgetPaymentsCycleBlocks < consensus.nBudgetPaymentsWindowBlocks);
+
+    CBlockIndex pindexPrev;
+    pindexPrev.nHeight = nBlockHeight - 1;
+
+    constexpr CAmount blockReward{508031847};
+    CMutableTransaction coinbase;
+    coinbase.vin.resize(1);
+    coinbase.vin[0].prevout.SetNull();
+    coinbase.vout = {MakeOut(blockReward, 0x01), MakeOut(117600000000, 0x02)};
+
+    CBlock block;
+    block.vtx.push_back(MakeTransactionRef(coinbase));
+
+    auto& mn_payments{*Assert(m_node.chain_helper)->mn_payments};
+    LOCK(cs_main);
+    const CChain& active_chain{m_node.chainman->ActiveChain()};
+
+    std::string strError;
+    BOOST_CHECK(mn_payments.IsBlockValueValid(active_chain, block, &pindexPrev, blockReward, strError,
+                                              SuperBlockCheckType::NoCheck));
+    BOOST_CHECK(strError.empty());
+
+    // The enforcing branch is only reached by a node that is synced and has no
+    // chainlock at that height, and it still rejects the over-reward block.
+    BOOST_CHECK(!mn_payments.IsBlockValueValid(active_chain, block, &pindexPrev, blockReward, strError,
+                                               SuperBlockCheckType::AllowDuplicates));
+    BOOST_CHECK(!strError.empty());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Syncing `develop` from scratch on mainnet stops at height 332320:

```
ERROR: ConnectBlock(DASH): coinbase pays too much at height 332320 (actual=118108031847 vs limit=508031847), exceeded block reward, old budgets are disabled
ERROR: ConnectTip: ConnectBlock 000000000014702a849cddf3145c495086ef5235b8e1a08fbea8e9c17c7d149b failed, bad-cb-amount
```

Blocks between `nBudgetPaymentsStartBlock` (328008) and `nSuperblockStartBlock` (614820) that fall into an old budget cycle window pay out a budget on top of the block reward. 332320 is `16616 * 20`, i.e. offset 0 inside the 100-block window. The old budget system was removed in 12.1 and no data is left to validate those payments, so the only way past those heights is to rely on the network having followed the correct chain.

95d5dcc2c2 ("refactor: extract SuperblockManager from CGovernanceManager") dropped the `m_govman.IsValidAndSynced()` guard that used to accept such blocks while the node is not synced yet, leaving the block reward limit enforced unconditionally. The equivalent guard was reintroduced for the superblock paths via `CChainstateHelper::IsSuperblockValidationRequired()`, but nothing was threaded into the old budget path.

## What was done?

`IsOldBudgetBlockValueValid()` now takes `check_superblock` and returns early when it is `SuperBlockCheckType::NoCheck`, which already carries the "chainlocked or not synced yet" state. The block reward limit is still enforced for a node that is synced and has no chainlock at that height.

Two deliberate differences from the removed `IsValidAndSynced()` guard:

* `NoCheck` also covers chainlocked blocks. Since `GetBestChainLockHeight()` is the height of the best chainlock, a synced mainnet node skips these checks for the whole 328008-614820 range, which is what the superblock paths in the same function already do.
* The `is_valid` (governance cache loaded) half of the old guard is not carried over. A synced node with an unloaded governance cache now enforces the limit instead of skipping it, matching what every governance-enabled synced node does.

## How Has This Been Tested?

New unit test `masternode_payments_tests/old_budget_window_accepted_while_unsynced` reproduces mainnet block 332320 with the amounts from the log above: it fails without the fix, and asserts both that an unsynced node accepts the block and that a synced node still rejects it.

`src/test/test_dash` (873 cases) passes; `lint-whitespace`, `lint-logs` and `lint-includes` pass.

## Breaking Changes

None. Blocks below `nSuperblockStartBlock` are accepted again as they were before 95d5dcc2c2, see the two noted differences above.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
