### PR TITLE
fix(net): reject response errors in QGETDATA requests

### DIFF
--- a/src/llmq/net_quorum.cpp
+++ b/src/llmq/net_quorum.cpp
@@ -77,6 +77,14 @@ void NetQuorum::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataS
         }
 
         CQuorumDataRequest request;
+        // An honest QGETDATA is exactly the fixed-size request encoding; nError is
+        // response-only (QDATA). A smuggled value used to select the *_MISSING branches
+        // that skip the rate-limit ban, so reject any longer payload by length — this
+        // also catches an explicitly serialized UNDEFINED byte and trailing garbage.
+        if (vRecv.size() > GetSerializeSize(request, vRecv.GetVersion())) {
+            m_peer_manager->PeerMisbehaving(pfrom.GetId(), 100, "oversized qgetdata");
+            return;
+        }
         vRecv >> request;
 
         auto sendQDATA = [&](CQuorumDataRequest::Errors nError,

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -379,15 +379,15 @@ class QuorumDataMessagesTest(DashTestFramework):
         # Requester-supplied nError on QGETDATA is rejected (+100) and disconnects.
         # Independent of cleanup / rate-limit state — one poisoned message is enough.
         def test_qgetdata_rejects_requester_error():
-            self.log.info("Test QGETDATA with requester-supplied nError is disconnected")
-            p2p_mn = p2p_connection(mn2.get_node(self))
-            id_p2p_mn = get_p2p_id(mn2.get_node(self))
-            mnauth(mn2.get_node(self), id_p2p_mn, fake_mnauth_2[0], fake_mnauth_2[1])
-            wait_for_banscore(mn2.get_node(self), id_p2p_mn, 0)
-            poisoned = msg_qgetdata(quorum_hash_int, 100, 0x01, error=ENCRYPTED_CONTRIBUTIONS_MISSING)
-            p2p_mn.send_message(poisoned)
-            self.wait_until(lambda: not p2p_mn.is_connected, timeout=10)
-            mn2.get_node(self).disconnect_p2ps()
+            for error in (ENCRYPTED_CONTRIBUTIONS_MISSING, 0, 0xFF):
+                self.log.info(f"Test QGETDATA with requester-supplied nError {error:#x} is disconnected")
+                p2p_mn = p2p_connection(mn2.get_node(self))
+                id_p2p_mn = get_p2p_id(mn2.get_node(self))
+                mnauth(mn2.get_node(self), id_p2p_mn, fake_mnauth_2[0], fake_mnauth_2[1])
+                wait_for_banscore(mn2.get_node(self), id_p2p_mn, 0)
+                p2p_mn.send_message(msg_qgetdata(quorum_hash_int, 100, 0x01, error=error))
+                self.wait_until(lambda: not p2p_mn.is_connected, timeout=10)
+                mn2.get_node(self).disconnect_p2ps()
 
         # Test request limiting / banscore increase
         def test_request_limit():

--- a/test/functional/p2p_quorum_data.py
+++ b/test/functional/p2p_quorum_data.py
@@ -376,6 +376,19 @@ class QuorumDataMessagesTest(DashTestFramework):
             self.restart_mn(mn1)
             self.wait_for_quorum_data([mn1], 100, quorum_hash, recover=False)
 
+        # Requester-supplied nError on QGETDATA is rejected (+100) and disconnects.
+        # Independent of cleanup / rate-limit state — one poisoned message is enough.
+        def test_qgetdata_rejects_requester_error():
+            self.log.info("Test QGETDATA with requester-supplied nError is disconnected")
+            p2p_mn = p2p_connection(mn2.get_node(self))
+            id_p2p_mn = get_p2p_id(mn2.get_node(self))
+            mnauth(mn2.get_node(self), id_p2p_mn, fake_mnauth_2[0], fake_mnauth_2[1])
+            wait_for_banscore(mn2.get_node(self), id_p2p_mn, 0)
+            poisoned = msg_qgetdata(quorum_hash_int, 100, 0x01, error=ENCRYPTED_CONTRIBUTIONS_MISSING)
+            p2p_mn.send_message(poisoned)
+            self.wait_until(lambda: not p2p_mn.is_connected, timeout=10)
+            mn2.get_node(self).disconnect_p2ps()
+
         # Test request limiting / banscore increase
         def test_request_limit():
 
@@ -531,6 +544,8 @@ class QuorumDataMessagesTest(DashTestFramework):
             test_watchquorums()
             test_rpc_quorum_getdata_protx_hash()
 
+        # Once: nError rejection does not depend on request-expiry cleanup.
+        test_qgetdata_rejects_requester_error()
         test_qsigshares_inv_oom()
 
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -2565,20 +2565,27 @@ class msg_qwatch:
 
 
 class msg_qgetdata:
-    __slots__ = ("quorum_hash", "quorum_type", "data_mask", "protx_hash")
+    __slots__ = ("quorum_hash", "quorum_type", "data_mask", "protx_hash", "error")
     msgtype = b"qgetdata"
 
-    def __init__(self, quorum_hash=0, quorum_type=-1, data_mask=0, protx_hash=0):
+    def __init__(self, quorum_hash=0, quorum_type=-1, data_mask=0, protx_hash=0, error=None):
         self.quorum_hash = quorum_hash
         self.quorum_type = quorum_type
         self.data_mask = data_mask
         self.protx_hash = protx_hash
+        # error is response-only on the wire. Honest requesters leave it None so
+        # it is not serialized. Attackers can set it to smuggle a QDATA error
+        # code into a request (see CQuorumDataRequest SERIALIZE_METHODS).
+        self.error = error
 
     def deserialize(self, f):
         self.quorum_type = struct.unpack("<B", f.read(1))[0]
         self.quorum_hash = deser_uint256(f)
         self.data_mask = struct.unpack("<H", f.read(2))[0]
         self.protx_hash = deser_uint256(f)
+        # Optional trailing byte (present on QDATA responses; may be smuggled on requests).
+        extra = f.read(1)
+        self.error = struct.unpack("<B", extra)[0] if extra else None
 
     def serialize(self):
         r = b""
@@ -2586,14 +2593,17 @@ class msg_qgetdata:
         r += ser_uint256(self.quorum_hash)
         r += struct.pack("<H", self.data_mask)
         r += ser_uint256(self.protx_hash)
+        if self.error is not None:
+            r += struct.pack("<B", self.error)
         return r
 
     def __repr__(self):
-        return "msg_qgetdata(quorum_hash=%064x, quorum_type=%d, data_mask=%d, protx_hash=%064x)" % (
+        return "msg_qgetdata(quorum_hash=%064x, quorum_type=%d, data_mask=%d, protx_hash=%064x, error=%s)" % (
                                                                                 self.quorum_hash,
                                                                                 self.quorum_type,
                                                                                 self.data_mask,
-                                                                                self.protx_hash)
+                                                                                self.protx_hash,
+                                                                                self.error)
 
 
 class msg_qdata:


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CQuorumDataRequest` reads an optional trailing `nError` byte for QDATA responses, but the QGETDATA request handler also accepted that response-only field. A requester could select one of the missing-data errors that intentionally suppress repeated-request scoring while still forcing response work.

This is the protocol-validation half split out of #7519 so it can be reviewed and merged independently from request-tracking bounds.

## What was done?

- Reject QGETDATA payloads longer than the fixed request encoding with a score of 100.
- Detect the field by presence rather than decoded value, so explicit `NONE`, `UNDEFINED`, and trailing bytes are rejected too.
- Extend the functional-test message helper to construct the malformed request and verify that the peer is disconnected.

## How Has This Been Tested?

- Full local `make -j13` build on macOS arm64 using the prebuilt depends tree.
- `/opt/homebrew/bin/python3.9 test/functional/test_runner.py p2p_quorum_data.py`
- `git diff --check`

`test/lint/lint-python.py` was invoked but skipped because `flake8` is not installed in the local environment.

## Breaking Changes

None. `nError` on an inbound QGETDATA request was never meaningful.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
