### PR TITLE
fix: cleanse generated BLS secret candidate

### DIFF
--- a/src/bls/bls.cpp
+++ b/src/bls/bls.cpp
@@ -8,6 +8,7 @@
 
 #ifndef BUILD_BITCOIN_INTERNAL
 #include <support/allocators/mt_pooled_secure.h>
+#include <support/cleanse.h>
 #endif
 
 #include <cassert>
@@ -73,6 +74,7 @@ void CBLSSecretKey::MakeNewKey()
         } catch (...) {
         }
     }
+    memory_cleanse(buf, sizeof(buf));
     fValid = true;
     cachedHash.SetNull();
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CBLSSecretKey::MakeNewKey()` retains the accepted 32-byte random candidate in
its stack buffer after constructing the secret key. The candidate is private
key material and should not remain recoverable from the stack longer than
necessary.

This is an existing issue in random BLS generation, including the `bls
generate` RPC. It is intentionally split from dashpay/dash#7594 because the
wallet-derived operator-key path does not call `MakeNewKey()`.

## What was done?

Cleanse the candidate buffer immediately after the key-generation retry loop,
before publishing the resulting key as valid.

## How Has This Been Tested?

- `make -C src -j6 test/test_dash`
- `src/test/test_dash --run_test=bls_tests` (20 cases passed)
- `test/lint/lint-includes.py`
- `test/lint/lint-whitespace.py`
- `git clang-format --diff upstream/develop -- src/bls/bls.cpp`
- `git diff --check`

Tested on macOS 15/Apple Silicon using the repository depends toolchain.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone

This pull request was created by Codex.
