### PR TITLE
fix(wallet): serialize mixing-only lock state

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3910,9 +3910,8 @@ bool CWallet::IsLocked(bool fForMixing) const
     if (!IsCrypted())
         return false;
 
-    if(!fForMixing && fOnlyMixingAllowed) return true;
-
     LOCK(cs_wallet);
+    if (!fForMixing && fOnlyMixingAllowed) return true;
     return vMasterKey.empty();
 }
 
@@ -3921,15 +3920,17 @@ bool CWallet::Lock(bool fAllowMixing)
     if (!IsCrypted())
         return false;
 
-    if(!fAllowMixing) {
+    {
         LOCK(cs_wallet);
-        if (!vMasterKey.empty()) {
-            memory_cleanse(vMasterKey.data(), vMasterKey.size() * sizeof(decltype(vMasterKey)::value_type));
-            vMasterKey.clear();
+        if (!fAllowMixing) {
+            if (!vMasterKey.empty()) {
+                memory_cleanse(vMasterKey.data(), vMasterKey.size() * sizeof(decltype(vMasterKey)::value_type));
+                vMasterKey.clear();
+            }
         }
+        fOnlyMixingAllowed = fAllowMixing;
     }
 
-    fOnlyMixingAllowed = fAllowMixing;
     NotifyStatusChanged(this);
     return true;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -290,7 +290,7 @@ private:
     CKeyingMaterial vMasterKey GUARDED_BY(cs_wallet);
 
     //! if fOnlyMixingAllowed is true, only mixing should be allowed in unlocked wallet
-    bool fOnlyMixingAllowed{false};
+    bool fOnlyMixingAllowed GUARDED_BY(cs_wallet){false};
 
     bool Unlock(const CKeyingMaterial& vMasterKeyIn, bool fForMixingOnly = false);
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`CWallet::Lock(true)` updated the mixing-only lock flag without holding `cs_wallet`, while `Unlock()` updated the same flag under the mutex. `IsLocked()` could also read the flag before acquiring the mutex. Concurrent wallet lock transitions could therefore race and expose an inconsistent lock state.

## What was done?

- Guard `fOnlyMixingAllowed` with `cs_wallet` and annotate that invariant.
- Serialize both reads and all lock transitions through the wallet mutex.

No release note is included because this is an internal synchronization fix with no interface or workflow change.

## How Has This Been Tested?

Built on Apple Silicon with the depends toolchain using `--without-gui --disable-bench`, then ran:

- `make -j13`
- `./src/test/test_dash --run_test=wallet_tests --log_level=message`
- `test/lint/all-lint.py`
- `git clang-format --diff upstream/develop -- src/wallet/wallet.cpp src/wallet/wallet.h`

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests (not applicable; guarded by Clang thread-safety analysis)
- [ ] I have made corresponding changes to the documentation (not applicable)
- [ ] I have assigned this pull request to a milestone (for repository code-owners and collaborators only)

This pull request was created by Codex.

