### PR TITLE
test: wait for MN disconnect after in-place ProUpServ migration

### DIFF
--- a/test/functional/feature_protx_version.py
+++ b/test/functional/feature_protx_version.py
@@ -258,7 +258,11 @@ class ProTxVersionTest(DashTestFramework):
         upserv_hash = surviving_legacy_mn.update_service(node, submit=True,
                                                          addrs_core_p2p=[f'127.0.0.1:{surviving_legacy_mn.nodePort}'])
         self.bump_mocktime(10 * 60 + 1)
-        tip = self.generate(node, 1)[0]
+        # Same CMNAuth disconnect as a key rotation: SetStateVersion re-encodes pubKeyOperator, so
+        # skip sync_all until the old peers are gone and this node is reconnected.
+        assert surviving_legacy_mn.nodeIdx is not None
+        old_peer_ids = self.get_peer_ids(surviving_legacy_mn.nodeIdx)
+        tip = self.generate(node, 1, sync_fun=self.no_op)[0]
         assert_equal(node.getrawtransaction(upserv_hash, 1, tip)['proUpServTx']['version'], 3)
         state = node.protx('info', surviving_legacy_mn.proTxHash)['state']
         assert_equal(state['version'], 3)  # migrated in place
@@ -266,10 +270,7 @@ class ProTxVersionTest(DashTestFramework):
         # masternode is not PoSe-banned).
         assert state['pubKeyOperator'] != key_before
         assert_equal(state['PoSeBanHeight'], -1)
-        # The key re-encoding churns the migrated node's masternode connections, so reconnect it (as
-        # the rotation path does) before syncing, then confirm the list still reloads from disk
-        # identically after the in-place migration.
-        assert surviving_legacy_mn.nodeIdx is not None
+        self.wait_for_peers_disconnected(surviving_legacy_mn.nodeIdx, old_peer_ids)
         self.connect_nodes(surviving_legacy_mn.nodeIdx, 0)
         self.sync_all()
         list_before = self.nodes[1].masternodelist()


### PR DESCRIPTION
## Issue being fixed or feature implemented
- `feature_protx_version.py` flakes on the ASAN job because a post-v24 in-place `update_service` migration re-encodes `pubKeyOperator`. CMNAuth then drops verified connections, and the default `generate()` → `sync_all()` path asserts that every node still has at least one peer.
- Same race this test already handles for revoke and registrar key rotation; this path was missing `sync_fun=self.no_op`.

## What was done?
- Mine the ProUpServTx with `sync_fun=self.no_op`.
- Wait for the migrated masternode's old peers to disconnect, reconnect it to node 0, then `sync_all()`.
- Keep the `protx` / `getrawtransaction` checks on the mining node, which already has the block.

## How Has This Been Tested?
- Compared against the existing revoke and `update_registrar` disconnect handling in the same file.
- Root-caused from https://github.com/PastaPastaPasta/dash/actions/runs/31740186678/job/94598843934 (`feature_protx_version.py` failed 3/3 on `sync_blocks` peer-count assert; no AddressSanitizer report).
- Did not re-run the full functional test locally; it is a long masternode test and the failure is a timing race that shows up under ASAN slowdown.

## Breaking Changes
- None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

This pull request was created by Codex.
