### PR TITLE
test(qt): cover transaction type filter persistence and fallback

### DIFF
--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -173,6 +173,10 @@ void ProviderTransactionTests::transactionTypeSettingPersistence_data()
                                 << QString{"Masternode"};
     QTest::newRow("data") << TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction)
                           << QString{"Data Transaction"};
+    QTest::newRow("dust") << TransactionFilterProxy::TYPE(TransactionRecord::DustReceive)
+                          << QString{"Dust Receive"};
+    QTest::newRow("other") << TransactionFilterProxy::TYPE(TransactionRecord::Other)
+                           << QString{"Other"};
     // An unknown stored filter selects nothing instead of an arbitrary entry.
     QTest::newRow("unknown") << quint32{0} << QString{};
 }
@@ -350,6 +354,53 @@ void ProviderTransactionTests::providerTransactionHistory()
             QTableView* const table{transaction_view.findChild<QTableView*>("transactionView")};
             QVERIFY(table != nullptr);
             QCOMPARE(table->model()->rowCount(), static_cast<int>(expected.size()));
+
+            struct RestoreCase {
+                quint32 saved_filter;
+                quint32 expected_filter;
+                QString expected_text;
+            };
+            const std::vector<RestoreCase> restore_cases{
+                {TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction),
+                 TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction),
+                 QString{"Data Transaction"}},
+                {TransactionFilterProxy::TYPE(TransactionRecord::DustReceive),
+                 TransactionFilterProxy::TYPE(TransactionRecord::DustReceive),
+                 QString{"Dust Receive"}},
+                {TransactionFilterProxy::TYPE(TransactionRecord::Other),
+                 TransactionFilterProxy::TYPE(TransactionRecord::Other),
+                 QString{"Other"}},
+                // Hidden CoinJoin filter falls back to "Most Common" when CoinJoin is disabled.
+                {TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinSend),
+                 TransactionFilterProxy::COMMON_TYPES,
+                 QString{"Most Common"}},
+                // Unknown stored filter falls back to "Most Common" when CoinJoin is disabled.
+                {0, TransactionFilterProxy::COMMON_TYPES, QString{"Most Common"}},
+            };
+
+            TransactionTypeSettingRestorer setting_restorer;
+            for (const RestoreCase& restore_case : restore_cases) {
+                QSettings{}.setValue("transactionTypeFilter", restore_case.saved_filter);
+                TransactionView restored_view;
+                restored_view.setModel(&wallet_model);
+                QComboBox* const restored_widget{FindTransactionTypeWidget(restored_view)};
+                QVERIFY(restored_widget != nullptr);
+                QCOMPARE(restored_widget->currentText(), restore_case.expected_text);
+                QCOMPARE(restored_widget->currentData().toUInt(), restore_case.expected_filter);
+                QCOMPARE(QSettings{}.value("transactionTypeFilter").toUInt(), restore_case.expected_filter);
+            }
+
+            {
+                // When no setting exists, setModel() defaults to "Most Common" (when CoinJoin is disabled).
+                QSettings{}.remove("transactionTypeFilter");
+                TransactionView default_view;
+                default_view.setModel(&wallet_model);
+                QComboBox* const default_widget{FindTransactionTypeWidget(default_view)};
+                QVERIFY(default_widget != nullptr);
+                QCOMPARE(default_widget->currentText(), QString{"Most Common"});
+                QCOMPARE(default_widget->currentData().toUInt(), TransactionFilterProxy::COMMON_TYPES);
+                QCOMPARE(QSettings{}.value("transactionTypeFilter").toUInt(), TransactionFilterProxy::COMMON_TYPES);
+            }
         }
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Following up on #7595 where the transaction type filter persistence fix was merged, this adds regression test coverage in `ProviderTransactionTests` without duplicating test fixtures.

## What was done?

- Move transaction type filter persistence and fallback test cases into `src/qt/test/providertransactiontests.cpp`.
- Add test coverage for `Dust Receive` and `Other` filter restoration.
- Add test coverage for fallback to "Most Common" when restoring hidden CoinJoin filters (with CoinJoin disabled) or unknown filters upon wallet model attach.
- Add test coverage for default selection when no filter setting is stored.

## How Has This Been Tested?

- Ran `src/qt/test/test_dash-qt` (both minimal and cocoa platform).
- Ran static linters (`test/lint/all-lint.py`).
- Ran core unit tests (`src/test/test_dash`).

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone