### PR TITLE
fix: re-ordering list of filters to put Masternode between "Mined" and "Platform transfer"

### DIFF
--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -162,18 +162,6 @@ void CheckProviderRecords(const TransactionTableModel& model, const std::vector<
         const QString plain_text{base.data(TransactionTableModel::TxPlainTextRole).toString()};
         QVERIFY(plain_text.contains(record.label));
         QVERIFY(!plain_text.contains("Payment to yourself"));
-
-        const QString description{base.data(TransactionTableModel::LongDescriptionRole).toString()};
-        QVERIFY(description.contains(record.label));
-        QVERIFY(description.contains(QString::fromStdString(record.txid.ToString())));
-        QVERIFY(description.contains("Net amount"));
-        QVERIFY(description.contains("Transaction total size"));
-        const QString summary{description.section("<hr>", 0, 0)};
-        QVERIFY(!summary.contains("From:"));
-        QVERIFY(!summary.contains("To:"));
-        QVERIFY(!summary.contains("<b>Debit:</b>"));
-        QVERIFY(!summary.contains("<b>Credit:</b>"));
-        QVERIFY(!summary.contains("Output index"));
     }
 }
 
@@ -300,13 +288,6 @@ void ProviderTransactionTests::providerTransactionHistory()
 
         // Transactions loaded before the model is constructed exercise the wallet-restart path.
         CheckProviderRecords(*model, expected);
-        const std::vector<int> registrar_rows{FindTransactionRows(*model, update_registrar->GetHash())};
-        QCOMPARE(registrar_rows.size(), size_t{1});
-        const QString registrar_description{
-            model->index(registrar_rows.front(), 0).data(TransactionTableModel::LongDescriptionRole).toString()};
-        const QString registrar_summary{registrar_description.section("<hr>", 0, 0)};
-        const QString external_address{QString::fromStdString(EncodeDestination(PKHash(external_key.GetPubKey())))};
-        QVERIFY(!registrar_summary.contains(external_address));
 
         const std::vector<int> other_rows{FindTransactionRows(*model, other_special_tx->GetHash())};
         QCOMPARE(other_rows.size(), size_t{1});

--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -158,10 +158,6 @@ void CheckProviderRecords(const TransactionTableModel& model, const std::vector<
         QVERIFY(tooltip.contains(record.label));
         QVERIFY(tooltip.contains(record.tooltip_text));
         QVERIFY(!tooltip.contains("Payment to yourself"));
-
-        const QString plain_text{base.data(TransactionTableModel::TxPlainTextRole).toString()};
-        QVERIFY(plain_text.contains(record.label));
-        QVERIFY(!plain_text.contains("Payment to yourself"));
     }
 }
 

--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -331,16 +331,17 @@ void ProviderTransactionTests::providerTransactionHistory()
 
             QListView* const type_list{qobject_cast<QListView*>(type_widget->view())};
             QVERIFY(type_list != nullptr);
-            for (const quint32 coinjoin_filter :
-                 {TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinSend),
-                  TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMakeCollaterals),
-                  TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCreateDenominations),
-                  TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMixing),
-                  TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCollateralPayment)}) {
-                const int row{type_widget->findData(coinjoin_filter)};
-                QVERIFY(row >= 0);
-                QVERIFY(type_list->isRowHidden(row));
+            // Match CoinJoin entries by title so filters added later are covered without
+            // duplicating the implementation's filter list.
+            int hidden_coinjoin_rows{0};
+            for (int row{0}; row < type_widget->count(); ++row) {
+                const QString title{type_widget->itemText(row)};
+                if (title.contains("coinjoin", Qt::CaseInsensitive) || title.contains("coin join", Qt::CaseInsensitive)) {
+                    QVERIFY(type_list->isRowHidden(row));
+                    ++hidden_coinjoin_rows;
+                }
             }
+            QVERIFY(hidden_coinjoin_rows > 0);
             QVERIFY(!type_list->isRowHidden(masternode_row));
 
             type_widget->setCurrentIndex(masternode_row);

--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -118,16 +118,16 @@ class TransactionTypeSettingRestorer
 {
 public:
     TransactionTypeSettingRestorer() :
-        m_had_value(m_settings.contains("transactionType")),
-        m_value(m_settings.value("transactionType"))
+        m_had_value(m_settings.contains("transactionTypeFilter")),
+        m_value(m_settings.value("transactionTypeFilter"))
     {
     }
     ~TransactionTypeSettingRestorer()
     {
         if (m_had_value) {
-            m_settings.setValue("transactionType", m_value);
+            m_settings.setValue("transactionTypeFilter", m_value);
         } else {
-            m_settings.remove("transactionType");
+            m_settings.remove("transactionTypeFilter");
         }
     }
 
@@ -178,6 +178,35 @@ void CheckProviderRecords(const TransactionTableModel& model, const std::vector<
 }
 
 } // namespace
+
+void ProviderTransactionTests::transactionTypeSettingPersistence_data()
+{
+    QTest::addColumn<quint32>("saved_filter");
+    QTest::addColumn<QString>("expected_text");
+
+    QTest::newRow("masternode") << (TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
+                                    TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate))
+                                << QString{"Masternode"};
+    QTest::newRow("data") << TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction)
+                          << QString{"Data Transaction"};
+    // An unknown stored filter selects nothing instead of an arbitrary entry.
+    QTest::newRow("unknown") << quint32{0} << QString{};
+}
+
+void ProviderTransactionTests::transactionTypeSettingPersistence()
+{
+    QFETCH(quint32, saved_filter);
+    QFETCH(QString, expected_text);
+
+    TransactionTypeSettingRestorer setting_restorer;
+    QSettings{}.setValue("transactionTypeFilter", saved_filter);
+
+    TransactionView transaction_view;
+    QComboBox* const type_widget{FindTransactionTypeWidget(transaction_view)};
+    QVERIFY(type_widget != nullptr);
+    QCOMPARE(type_widget->currentText(), expected_text);
+    QCOMPARE(type_widget->currentData().toUInt(), saved_filter);
+}
 
 void ProviderTransactionTests::providerTransactionHistory()
 {
@@ -339,6 +368,7 @@ void ProviderTransactionTests::providerTransactionHistory()
 
             type_widget->setCurrentIndex(masternode_row);
             transaction_view.chooseType(masternode_row);
+            QCOMPARE(QSettings{}.value("transactionTypeFilter").toUInt(), masternode_filter);
             QTableView* const table{transaction_view.findChild<QTableView*>("transactionView")};
             QVERIFY(table != nullptr);
             QCOMPARE(table->model()->rowCount(), static_cast<int>(expected.size()));

--- a/src/qt/test/providertransactiontests.cpp
+++ b/src/qt/test/providertransactiontests.cpp
@@ -179,36 +179,6 @@ void CheckProviderRecords(const TransactionTableModel& model, const std::vector<
 
 } // namespace
 
-void ProviderTransactionTests::transactionTypeSettingCompatibility_data()
-{
-    QTest::addColumn<int>("saved_index");
-    QTest::addColumn<QString>("expected_text");
-    QTest::addColumn<quint32>("expected_filter");
-
-    QTest::newRow("data") << 12 << QString{"Data Transaction"}
-                          << TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction);
-    QTest::newRow("dust") << 13 << QString{"Dust Receive"} << TransactionFilterProxy::TYPE(TransactionRecord::DustReceive);
-    QTest::newRow("other") << 14 << QString{"Other"} << TransactionFilterProxy::TYPE(TransactionRecord::Other);
-}
-
-void ProviderTransactionTests::transactionTypeSettingCompatibility()
-{
-    QFETCH(int, saved_index);
-    QFETCH(QString, expected_text);
-    QFETCH(quint32, expected_filter);
-
-    TransactionTypeSettingRestorer setting_restorer;
-    QSettings{}.setValue("transactionType", saved_index);
-
-    TransactionView transaction_view;
-    QComboBox* const type_widget{FindTransactionTypeWidget(transaction_view)};
-    QVERIFY(type_widget != nullptr);
-    QCOMPARE(type_widget->currentIndex(), saved_index);
-    QCOMPARE(type_widget->currentText(), expected_text);
-    QCOMPARE(type_widget->currentData().toUInt(), expected_filter);
-    QCOMPARE(type_widget->findText("Masternode"), 15);
-}
-
 void ProviderTransactionTests::providerTransactionHistory()
 {
     TestChain100Setup test;

--- a/src/qt/test/providertransactiontests.h
+++ b/src/qt/test/providertransactiontests.h
@@ -22,8 +22,6 @@ public:
     }
 
 private Q_SLOTS:
-    void transactionTypeSettingCompatibility_data();
-    void transactionTypeSettingCompatibility();
     void providerTransactionHistory();
 
 private:

--- a/src/qt/test/providertransactiontests.h
+++ b/src/qt/test/providertransactiontests.h
@@ -22,6 +22,8 @@ public:
     }
 
 private Q_SLOTS:
+    void transactionTypeSettingPersistence_data();
+    void transactionTypeSettingPersistence();
     void providerTransactionHistory();
 
 private:

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -95,12 +95,12 @@ TransactionView::TransactionView(QWidget* parent) :
     typeWidget->addItem(tr("%1 Collateral Payment").arg(strCoinJoinName), TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCollateralPayment));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
+    typeWidget->addItem(tr("Masternode"), TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
+                                              TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate));
     typeWidget->addItem(tr("Platform Transfer"), TransactionFilterProxy::TYPE(TransactionRecord::PlatformTransfer));
     typeWidget->addItem(tr("Data Transaction"), TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction));
     typeWidget->addItem(tr("Dust Receive"), TransactionFilterProxy::TYPE(TransactionRecord::DustReceive));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
-    typeWidget->addItem(tr("Masternode"), TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
-                                              TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate));
     typeWidget->setCurrentIndex(typeWidget->findData(settings.value("transactionTypeFilter").toUInt()));
 
     hlayout->addWidget(typeWidget);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -101,7 +101,7 @@ TransactionView::TransactionView(QWidget* parent) :
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
     typeWidget->addItem(tr("Masternode"), TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
                                               TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate));
-    typeWidget->setCurrentIndex(settings.value("transactionType").toInt());
+    typeWidget->setCurrentIndex(typeWidget->findData(settings.value("transactionTypeFilter").toUInt()));
 
     hlayout->addWidget(typeWidget);
 
@@ -261,7 +261,6 @@ void TransactionView::setModel(WalletModel *_model)
         connect(_model, &WalletModel::notifyWatchonlyChanged, this, &TransactionView::updateWatchOnlyColumn);
 
         // Update transaction list with persisted settings
-        chooseType(settings.value("transactionType").toInt());
         chooseDate(settings.value("transactionDate").toInt());
 
         updateCoinJoinVisibility();
@@ -331,7 +330,7 @@ void TransactionView::chooseType(int idx)
         typeWidget->itemData(idx).toUInt());
     // Persist settings
     QSettings settings;
-    settings.setValue("transactionType", idx);
+    settings.setValue("transactionTypeFilter", typeWidget->itemData(idx).toUInt());
 }
 
 void TransactionView::chooseWatchonly(int idx)
@@ -788,10 +787,6 @@ void TransactionView::updateCoinJoinVisibility()
         return;
     }
     bool fEnabled = model->node().coinJoinOptions().isEnabled();
-    // If CoinJoin gets enabled use "All" else "Most common"
-    int idx = fEnabled ? 0 : 1;
-    chooseType(idx);
-    typeWidget->setCurrentIndex(idx);
     // Hide all CoinJoin related filters by value so this stays correct when entries are reordered.
     QListView* typeList = qobject_cast<QListView*>(typeWidget->view());
     for (const quint32 type_filter : {TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinSend),
@@ -802,4 +797,11 @@ void TransactionView::updateCoinJoinVisibility()
         const int row = typeWidget->findData(type_filter);
         if (row >= 0) typeList->setRowHidden(row, !fEnabled);
     }
+
+    int idx = typeWidget->currentIndex();
+    if (idx < 0 || typeList->isRowHidden(idx)) {
+        idx = typeWidget->findData(fEnabled ? TransactionFilterProxy::ALL_TYPES : TransactionFilterProxy::COMMON_TYPES);
+        typeWidget->setCurrentIndex(idx);
+    }
+    chooseType(idx);
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Order of filters for transaction is important for showing user and the item "Masternode" should not be after "Other".

Anywhere after "Mining" and before "Dust received" seems fine for me.

## What was done?
Put Masternode between "Mined" and "Platform transfer".
Apparently, persistent settings are using "index" instead value for this combo-box. It is fixed by saving value instead.
Also removed irrelevant useless regressions tests that are testing implementation instead testing functionality or just a copy-paste of implementation.


## How Has This Been Tested?
Run qt app and change filter ; test that saved option is preserved.

Extra build has been done to be sure that it is _not_ index this time, but saved properly. it works as expected after restart:
    
    diff --git a/src/qt/transactionview.cpp b/src/qt/transactionview.cpp
    index a9421e3793..090bd462ab 100644
    --- a/src/qt/transactionview.cpp
    +++ b/src/qt/transactionview.cpp
    @@ -83,7 +83,6 @@ TransactionView::TransactionView(QWidget* parent) :
         typeWidget = new QComboBox(this);
         typeWidget->setFixedWidth(TYPE_COLUMN_WIDTH - 1);
         typeWidget->addItem(tr("All"), TransactionFilterProxy::ALL_TYPES);
    -    typeWidget->addItem(tr("Most Common"), TransactionFilterProxy::COMMON_TYPES);
         typeWidget->addItem(tr("Received with"), TransactionFilterProxy::TYPE(TransactionRecord::RecvWithAddress) |
                                             TransactionFilterProxy::TYPE(TransactionRecord::RecvFromOther));
         typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |

## Breaking Changes
N/A

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_

