### PR TITLE
docs: clarify when to use assert vs Assert vs Assume vs CHECK_NONFATAL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,37 @@ changes, update the other in the same commit.
   code; reserve them for things that genuinely need explaining (non-obvious
   invariants, workaround rationale, non-local side effects).
 
+## Assertions and Checks
+
+Full guidance lives in `doc/developer-notes.md` under "Assertions and Checks".
+Short version, in order of preference:
+
+- `Assume(cond)` is the default. Use it for "this is how things are supposed to
+  be": a violation means someone has a bug worth investigating, but execution
+  stays well-defined. A negative rate-limit counter is the archetype - somebody
+  decremented twice, we may be more DoS-exposed than intended, but nothing is
+  corrupt. It aborts in `--enable-debug` and `--enable-fuzz` builds (CI's
+  `linux64_multiprocess` and fuzz jobs) while a failure is silent in release,
+  so it must never take down a production node. The expression is always
+  evaluated.
+- `assert(cond)` / `Assert(cond)` is the "we must crash now" case. Use it only
+  when continuing would be undefined behavior, memory corruption, or corrupt
+  persisted/consensus state - aborting has to be the safer outcome. It should
+  be rare and obviously justified, but do use it where it is genuinely needed
+  to document and enforce a precondition that keeps the code below it safe.
+  `Assert` returns its argument: `assert(ptr != nullptr); obj = *ptr;` becomes
+  `obj = *Assert(ptr);`
+- `CHECK_NONFATAL(cond)` / `NONFATAL_UNREACHABLE()` for internal logic bugs on
+  a path with a caller to report to. Required in RPC code, enforced
+  (best-effort) by `test/lint/lint-assertions.py` for `src/rpc/` and
+  `src/wallet/rpc*`.
+
+None of these validate input. Data from peers, RPC arguments, wallet files, or
+on-disk state must be checked and rejected through normal error handling -
+asserting on it turns a peer-triggered inconsistency into a remote crash.
+Environment failures (disk full, corrupt block on disk, failed DB write) are
+not checks at all: return an error, `AbortNode()`, or `InitError()`.
+
 ## Repository Map
 
 - `src/` - C++ implementation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,37 @@ changes, update the other in the same commit.
   code; reserve them for things that genuinely need explaining (non-obvious
   invariants, workaround rationale, non-local side effects).
 
+## Assertions and Checks
+
+Full guidance lives in `doc/developer-notes.md` under "Assertions and Checks".
+Short version, in order of preference:
+
+- `Assume(cond)` is the default. Use it for "this is how things are supposed to
+  be": a violation means someone has a bug worth investigating, but execution
+  stays well-defined. A negative rate-limit counter is the archetype - somebody
+  decremented twice, we may be more DoS-exposed than intended, but nothing is
+  corrupt. It aborts in `--enable-debug` and `--enable-fuzz` builds (CI's
+  `linux64_multiprocess` and fuzz jobs) while a failure is silent in release,
+  so it must never take down a production node. The expression is always
+  evaluated.
+- `assert(cond)` / `Assert(cond)` is the "we must crash now" case. Use it only
+  when continuing would be undefined behavior, memory corruption, or corrupt
+  persisted/consensus state - aborting has to be the safer outcome. It should
+  be rare and obviously justified, but do use it where it is genuinely needed
+  to document and enforce a precondition that keeps the code below it safe.
+  `Assert` returns its argument: `assert(ptr != nullptr); obj = *ptr;` becomes
+  `obj = *Assert(ptr);`
+- `CHECK_NONFATAL(cond)` / `NONFATAL_UNREACHABLE()` for internal logic bugs on
+  a path with a caller to report to. Required in RPC code, enforced
+  (best-effort) by `test/lint/lint-assertions.py` for `src/rpc/` and
+  `src/wallet/rpc*`.
+
+None of these validate input. Data from peers, RPC arguments, wallet files, or
+on-disk state must be checked and rejected through normal error handling -
+asserting on it turns a peer-triggered inconsistency into a remote crash.
+Environment failures (disk full, corrupt block on disk, failed DB write) are
+not checks at all: return an error, `AbortNode()`, or `InitError()`.
+
 ## Repository Map
 
 - `src/` - C++ implementation.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -17,6 +17,7 @@ Developer Notes
         - [Devnet, testnet, and regtest modes](#devnet-testnet-and-regtest-modes)
         - [DEBUG_LOCKORDER](#debug_lockorder)
         - [DEBUG_LOCKCONTENTION](#debug_lockcontention)
+        - [Assertions and Checks](#assertions-and-checks)
         - [Valgrind suppressions file](#valgrind-suppressions-file)
         - [Compiling for test coverage](#compiling-for-test-coverage)
         - [Performance profiling with perf](#performance-profiling-with-perf)
@@ -108,6 +109,7 @@ code.
   - `++i` is preferred over `i++`.
   - `nullptr` is preferred over `NULL` or `(void*)0`.
   - `static_assert` is preferred over `assert` where possible. Generally; compile-time checking is preferred over run-time checking.
+    For run-time checks, see [Assertions and Checks](#assertions-and-checks) on choosing between `assert`/`Assert`, `Assume` and `CHECK_NONFATAL`.
   - Align pointers and references to the left i.e. use `type& var` and not `type &var`.
   - Use a named cast or functional cast, not a C-Style cast. When casting
     between integer types, use functional casts such as `int(x)` or `int{x}`
@@ -432,30 +434,73 @@ It can be toggled off again with `dash-cli logging [] '["lock"]'`.
 
 ### Assertions and Checks
 
-The util file `src/util/check.h` offers helpers to protect against coding and
-internal logic bugs. They must never be used to validate user, network or any
-other input.
+The util file [`src/util/check.h`](../src/util/check.h) offers helpers to
+protect against coding and internal logic bugs. They document invariants the
+code itself is responsible for maintaining, and must never be used to validate
+user, network, RPC, disk or any other input: untrusted data that does not
+match expectations is an ordinary error to be handled, not a bug to be
+reported.
 
-* `assert` or `Assert` should be used to document assumptions when any
-  violation would mean that it is not safe to continue program execution. The
-  code is always compiled with assertions enabled.
-   - For example, a nullptr dereference or any other logic bug in validation
-     code means the program code is faulty and must terminate immediately.
-* `CHECK_NONFATAL` should be used for recoverable internal logic bugs. On
-  failure, it will throw an exception, which can be caught to recover from the
-  error.
-   - For example, a nullptr dereference or any other logic bug in RPC code
-     means that the RPC code is faulty and cannot be executed. However, the
-     logic bug can be shown to the user and the program can continue to run.
-* `Assume` should be used to document assumptions when program execution can
-  safely continue even if the assumption is violated. In debug builds it
-  behaves like `Assert`/`assert` to notify developers and testers about
-  nonfatal errors. In production it doesn't warn or log anything, though the
-  expression is always evaluated.
-   - For example it can be assumed that a variable is only initialized once,
-     but a failed assumption does not result in a fatal bug. A failed
-     assumption may or may not result in a slightly degraded user experience,
-     but it is safe to continue program execution.
+Pick the helper by the cost of continuing with the invariant violated:
+
+| Cost of continuing | Use |
+| --- | --- |
+| Undefined behavior, memory corruption, or corrupt persisted/consensus state | `assert` / `Assert` |
+| A bug worth investigating, but execution stays well-defined | `Assume` |
+| Same, but there is a caller who can be told (RPC/CLI) | `CHECK_NONFATAL` / `NONFATAL_UNREACHABLE` |
+| Nothing is broken in-process; the environment failed (disk full, failed DB write) | Not a check: return an error, `AbortNode()`, or `InitError()` |
+
+**`Assume` is the default.** Reach for `Assert`/`assert` only when you can name
+the undefined behavior or corruption that continuing would cause.
+
+* `Assume` documents "this is how things are supposed to be": a violation means
+  someone has a bug to chase, but execution stays well-defined. The archetype:
+
+  ```cpp
+  // Somebody decremented twice if this trips. Nothing is corrupt, but the
+  // rate limiter is not limiting anything, so it is worth finding out about.
+  Assume(m_request_count >= 0);
+  ```
+
+  A bugged rate limiter may expose us to extra DoS pressure; aborting would
+  turn that into a guaranteed outage for every user running the release. Never
+  let an `Assume` be the thing that kills a production node. The expression is
+  always evaluated, in every build; failures abort only where
+  `-DABORT_ON_FAILED_ASSUME` is defined — `--enable-debug` and `--enable-fuzz`
+  builds, i.e. CI's `linux64_multiprocess` and fuzz jobs — and are silent in
+  release. That coverage is partial: an invariant you actually care about also
+  needs a test, and code downstream must still cope with the violated case.
+
+* `assert` / `Assert` is for "continuing is unsafe": a nullptr dereference,
+  out-of-bounds access, or an invariant whose violation would corrupt data on
+  disk or consensus state. Aborting must be the safer outcome; such cases
+  should be rare and obvious to a reader. It is still the right tool where a
+  precondition genuinely keeps the code below it safe:
+  `Chainstate::ConnectBlock()` dereferences `pindex` unconditionally, so its
+  `assert(pindex);` just makes a guaranteed crash diagnosable. Plain `assert()`
+  is always active — the build never defines `NDEBUG` (`check.h` refuses to
+  compile with it). `Assert` returns its argument, so a check followed by a
+  use of the checked value collapses into one expression:
+  `assert(ptr != nullptr); obj = *ptr;` becomes `obj = *Assert(ptr);`
+  (`Assume` is an identity function too). Prefer `static_assert` when the
+  condition is known at compile time.
+
+* `CHECK_NONFATAL` / `NONFATAL_UNREACHABLE` report internal logic bugs to a
+  caller: they throw `NonFatalCheckError`, which RPC code catches and turns
+  into an error message asking the user to file a bug report, and the node
+  keeps running. Mandatory in RPC code, enforced (best-effort) by
+  `test/lint/lint-assertions.py` for `src/rpc/` and `src/wallet/rpc*`; use
+  `NONFATAL_UNREACHABLE()` instead of `assert(false)` there.
+
+An assertion reachable from P2P messages, RPC arguments, wallet files, or
+on-disk data is a remote crash. This cuts especially deep in Dash-specific
+code: masternode, LLMQ, InstantSend, ChainLocks, governance and CoinJoin paths
+process peer-chosen message contents and read state (EvoDB, quorum caches, DKG
+sessions) possibly written by an older or buggy version. There, validate and
+reject (misbehaving peer, `state.Invalid(...)`, early return) rather than
+assert; use `Assume` for our *own* bookkeeping while still handling the
+violated case; and reserve `assert` for the narrow spot where continuing would
+corrupt EvoDB, the block index, or the wallet.
 
 ### Valgrind suppressions file
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The "Assertions and Checks" section in `doc/developer-notes.md` lists the
helpers in `src/util/check.h` as three equally-weighted options without saying
which to reach for by default. In practice `assert()` gets used for invariants
that are merely suspicious, turning a violated bookkeeping assumption into a
node crash. It also omits which builds abort on a failed `Assume` and that
assertions must never be derived from peer/RPC/on-disk input.

## What was done?

Rewrote the section around one question — what does it cost to continue with
the invariant violated?

- **`Assume` is the default**: a violation is a real bug to investigate, but
  execution stays well-defined (archetype: a rate-limit counter going
  negative). Documented that `--enable-debug`/`--enable-fuzz` define
  `-DABORT_ON_FAILED_ASSUME` (CI's `linux64_multiprocess` and fuzz jobs), and
  that this coverage is partial.
- **`assert`/`Assert`** is reserved for cases where continuing means UB or
  corrupt persisted/consensus state — rare, but still correct where a
  precondition genuinely keeps the code below it safe.
- **`CHECK_NONFATAL`/`NONFATAL_UNREACHABLE`** for logic bugs with a caller to
  report to; mandatory under `src/rpc/` and `src/wallet/rpc*` per
  `test/lint/lint-assertions.py`.
- None of these validate input; environment failures (disk full, failed DB
  write) are `AbortNode()`/`InitError()`/error returns, not checks. Added a
  Dash-specific note: asserting on peer-chosen messages or EvoDB/quorum state
  converts a peer-triggered inconsistency into a network-wide remote crash.
- Added the missing TOC entry, a cross-reference from the `static_assert`
  bullet, and a condensed version in `CLAUDE.md`/`AGENTS.md` (kept identical,
  as those files require).

No code changes.

## How Has This Been Tested?

Documentation only. Claims were verified against the tree: the
`ABORT_ON_FAILED_ASSUME` blocks in `configure.ac`, the CI job configs, the
lint regex, and the `assert(pindex)` example (`Chainstate::ConnectBlock()`).
`lint-whitespace.py` and `lint-spelling.py` are clean for the touched files.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
