### PR TITLE
docs: add instruction to PR template to prevent manual line wrapping

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 _Provide a general summary of your changes in the Title above_
 
+_Do not manually line wrap text; allow the GitHub UI to dynamically wrap lines._
+
 _Pull requests without a rationale and clear improvement may be closed
 immediately._
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Adds an explicit instruction in `.github/PULL_REQUEST_TEMPLATE.md` directing contributors and automated models not to manually line wrap text in PR descriptions, allowing the GitHub UI to handle dynamic wrapping.

## What was done?
Added `_Do not manually line wrap text; allow the GitHub UI to dynamically wrap lines._` to the italicized help prompts in `.github/PULL_REQUEST_TEMPLATE.md`.

## How Has This Been Tested?
Ran lint checks (`test/lint/lint-whitespace.py`, `test/lint/all-lint.py`) to confirm formatting and static analysis rules pass cleanly.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_