### PR TITLE
fix: repair coinjoin_inouts_tests build after isman moved out of LLMQContext

### DIFF
--- a/src/test/coinjoin_inouts_tests.cpp
+++ b/src/test/coinjoin_inouts_tests.cpp
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(server_addentry_binds_entries_to_accepted_collaterals)
     TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
                                   *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
                                   *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
-                                  *Assert(m_node.llmq_ctx->isman));
+                                  *Assert(m_node.isman));
 
     auto make_collateral = [](uint8_t tag) {
         CMutableTransaction tx;
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(server_addentry_rejects_entries_once_the_session_finalized)
     TestableCoinJoinServer server(m_node.peerman.get(), *Assert(m_node.chainman), *Assert(m_node.connman),
                                   *Assert(m_node.dmnman), *Assert(m_node.dstxman), *Assert(m_node.mn_metaman),
                                   *Assert(m_node.mempool), mn_activeman, *Assert(m_node.mn_sync),
-                                  *Assert(m_node.llmq_ctx->isman));
+                                  *Assert(m_node.isman));
 
     CMutableTransaction txCollateral;
     txCollateral.vin.emplace_back(COutPoint(uint256::ONE, 1));


### PR DESCRIPTION
## Issue being fixed or feature implemented

`develop` does not compile since #7603 merged:

```
test/coinjoin_inouts_tests.cpp:354:60: error: no member named 'isman' in 'LLMQContext'
  354 |                                   *Assert(m_node.llmq_ctx->isman));
test/coinjoin_inouts_tests.cpp:406:60: error: no member named 'isman' in 'LLMQContext'
  406 |                                   *Assert(m_node.llmq_ctx->isman));
2 errors generated.
```

This is a semantic merge conflict, not a mistake in either branch. #7603 moved `CInstantSendManager` out of `LLMQContext` into `NodeContext` (`refactor: move CInstantSendManager out of LLMQContext`, then `refactor: drop the isman reference member from LLMQContext`) and updated every call site that existed when that branch was cut. Two CoinJoin server test cases — `server_addentry_binds_entries_to_accepted_collaterals` and `server_addentry_rejects_entries_once_the_session_finalized` — landed on `develop` afterwards, spelled `m_node.llmq_ctx->isman` like the five call sites around them.

The two sides never touch the same lines, so git had nothing to flag. I confirmed the same two references also survive a conflict-free rebase of #7603 onto `develop`, so neither merge strategy would have caught this; only a build does.

## What was done?

Rewrote the two surviving references to `m_node.isman`, matching the five sites in the same file that #7603 already converted.

## How Has This Been Tested?

macOS (arm64), depends build, autotools:

* `make -j` — clean build of the full tree, no errors.
* `./src/test/test_dash --run_test=coinjoin_inouts_tests` — 49 test cases, no errors detected.
* `grep -rn 'llmq_ctx->isman\|llmq_ctx\.isman' src/` — no remaining references anywhere in the tree.

## Breaking Changes

None. Test-only change; no behavior change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone _(for repository code-owners and collaborators only)_
